### PR TITLE
Step 57: S3 DELETE Operation

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -193,3 +193,11 @@ Will implement per-tenant rate limiting using golang.org/x/time/rate
 - Tests: 2/2 passing ✅
 
 **Progress: 56/510 (11.0%) - Core storage functional!**
+
+### Step 57: S3 DELETE Operation ✅
+- DELETE operation implemented ✅
+- Tenant isolation maintained ✅
+- Test verifies deletion ✅
+- CRUD operations complete (PUT/GET/DELETE) ✅
+
+**Progress: 57/510 (11.2%) - Basic CRUD complete!**

--- a/internal/api/s3_delete_test.go
+++ b/internal/api/s3_delete_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+    "bytes"
+    "net/http/httptest"
+    "os"
+    "testing"
+    
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "github.com/gorilla/mux"
+    "go.uber.org/zap"
+    "github.com/FairForge/vaultaire/internal/engine"
+    "github.com/FairForge/vaultaire/internal/tenant"
+    "github.com/FairForge/vaultaire/internal/drivers"
+)
+
+func TestS3_DeleteObject(t *testing.T) {
+    logger := zap.NewNop()
+    eng := engine.NewEngine(logger)
+    
+    // Setup storage
+    tempDir, err := os.MkdirTemp("", "vaultaire-test-*")
+    require.NoError(t, err)
+    defer func() { _ = os.RemoveAll(tempDir) }()
+    
+    driver := drivers.NewLocalDriver(tempDir, logger)
+    eng.AddDriver("local", driver)
+    eng.SetPrimary("local")
+    
+    server := &Server{
+        logger: logger,
+        router: mux.NewRouter(),
+        engine: eng,
+    }
+    server.router.PathPrefix("/").HandlerFunc(server.handleS3Request)
+    
+    testTenant := &tenant.Tenant{
+        ID:        "test-tenant",
+        Namespace: "tenant/test-tenant/",
+    }
+    
+    // First PUT an object
+    putReq := httptest.NewRequest("PUT", "/test-bucket/test-key.txt", 
+        bytes.NewReader([]byte("test content")))
+    ctx := tenant.WithTenant(putReq.Context(), testTenant)
+    putReq = putReq.WithContext(ctx)
+    putW := httptest.NewRecorder()
+    server.handleS3Request(putW, putReq)
+    assert.Equal(t, 200, putW.Code, "PUT should succeed")
+    
+    // Then DELETE it
+    deleteReq := httptest.NewRequest("DELETE", "/test-bucket/test-key.txt", nil)
+    ctx = tenant.WithTenant(deleteReq.Context(), testTenant)
+    deleteReq = deleteReq.WithContext(ctx)
+    deleteW := httptest.NewRecorder()
+    
+    server.handleS3Request(deleteW, deleteReq)
+    assert.Equal(t, 204, deleteW.Code, "DELETE should return 204 No Content")
+    
+    // Verify it's gone with GET
+    getReq := httptest.NewRequest("GET", "/test-bucket/test-key.txt", nil)
+    ctx = tenant.WithTenant(getReq.Context(), testTenant)
+    getReq = getReq.WithContext(ctx)
+    getW := httptest.NewRecorder()
+    
+    server.handleS3Request(getW, getReq)
+    assert.Equal(t, 404, getW.Code, "GET after DELETE should return 404")
+}


### PR DESCRIPTION
## What This PR Does
Implements S3 DELETE operation to complete basic CRUD functionality.

## Changes
- DELETE operation with tenant isolation
- Uses adapter pattern for consistency
- Test verifies deletion and 404 on subsequent GET

## Tests
- `TestS3_DeleteObject` - passing (1/1)
- All existing tests still passing

## Next Steps
Step 58: LIST operation to enumerate objects