### PR TITLE
fix: migrate AWS SDK from v1 to v2 endpoint configuration

### DIFF
--- a/internal/drivers/lyve.go
+++ b/internal/drivers/lyve.go
@@ -34,21 +34,13 @@ func NewLyveDriver(accessKey, secretKey, tenantID, region string, logger *zap.Lo
 			credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
 		),
 		config.WithRegion(region),
-		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
-			func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-				return aws.Endpoint{
-					URL:           endpoint,
-					SigningRegion: region,
-				}, nil
-			},
-		)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 
 	return &LyveDriver{
-		client:   s3.NewFromConfig(cfg),
+		client:   s3.NewFromConfig(cfg, func(o *s3.Options) { o.BaseEndpoint = aws.String(endpoint); o.UsePathStyle = true }),
 		tenantID: tenantID,
 		region:   region,
 		logger:   logger,


### PR DESCRIPTION
- Replaced deprecated WithEndpointResolverWithOptions
- Using modern BaseEndpoint option for custom S3 endpoints
- Added UsePathStyle for Lyve Cloud compatibility
- Resolves all SA1019 staticcheck warnings

## Description
<!-- Brief description of changes -->

## Step Number
<!-- If applicable: Step XX of master plan -->

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Coverage remains above 80%

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings from golangci-lint
- [ ] Error handling follows project standards (wrapped with context)
