### PR TITLE
fix(tests): resolve flaky tests and data races

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -448,7 +448,7 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\"") // Mock ETag for now
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(time.RFC1123))
+	w.Header().Set("Last-Modified", time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT"))
 	w.Header().Set("x-amz-storage-class", "STANDARD")
 
 	// HEAD requests don't have a body, just headers

--- a/internal/drivers/geyser.go
+++ b/internal/drivers/geyser.go
@@ -1,0 +1,145 @@
+// internal/drivers/geyser.go
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/FairForge/vaultaire/internal/common"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.uber.org/zap"
+)
+
+type GeyserDriver struct {
+	client   *s3.Client
+	bucket   string
+	tenantID string
+	logger   *zap.Logger
+}
+
+func NewGeyserDriver(accessKey, secretKey, bucket, tenantID string, logger *zap.Logger) (*GeyserDriver, error) {
+	endpoint := "https://la1.geyserdata.com"
+
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+		),
+		config.WithRegion("us-west-2"), // Geyser uses us-west-2
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	return &GeyserDriver{
+		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+			o.UsePathStyle = true // Geyser requires path-style
+		}),
+		bucket:   bucket,
+		tenantID: tenantID,
+		logger:   logger,
+	}, nil
+}
+
+func (d *GeyserDriver) getTenantID(ctx context.Context) string {
+	if tid := ctx.Value(common.TenantIDKey); tid != nil {
+		if s, ok := tid.(string); ok && s != "" {
+			return s
+		}
+	}
+	return d.tenantID
+}
+
+func (d *GeyserDriver) buildKey(tenantID, container, artifact string) string {
+	return fmt.Sprintf("t-%s/%s/%s", tenantID, container, artifact)
+}
+
+func (d *GeyserDriver) Get(ctx context.Context, container, artifact string) (io.ReadCloser, error) {
+	tenantID := d.getTenantID(ctx)
+	key := d.buildKey(tenantID, container, artifact)
+
+	resp, err := d.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("geyser get %s: %w", key, err)
+	}
+	return resp.Body, nil
+}
+
+func (d *GeyserDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error {
+	tenantID := d.getTenantID(ctx)
+	key := d.buildKey(tenantID, container, artifact)
+
+	d.logger.Debug("geyser put",
+		zap.String("tenant_id", tenantID),
+		zap.String("bucket", d.bucket),
+		zap.String("key", key),
+	)
+
+	_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+		Body:   data,
+	})
+	if err != nil {
+		return fmt.Errorf("geyser put %s: %w", key, err)
+	}
+	return nil
+}
+
+func (d *GeyserDriver) Delete(ctx context.Context, container, artifact string) error {
+	tenantID := d.getTenantID(ctx)
+	key := d.buildKey(tenantID, container, artifact)
+
+	_, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("geyser delete %s: %w", key, err)
+	}
+	return nil
+}
+
+func (d *GeyserDriver) List(ctx context.Context, container string, prefix string) ([]string, error) {
+	tenantID := d.getTenantID(ctx)
+	fullPrefix := d.buildKey(tenantID, container, prefix)
+
+	resp, err := d.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(d.bucket),
+		Prefix: aws.String(fullPrefix),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("geyser list: %w", err)
+	}
+
+	var artifacts []string
+	basePrefix := d.buildKey(tenantID, container, "")
+	for _, obj := range resp.Contents {
+		name := strings.TrimPrefix(*obj.Key, basePrefix)
+		artifacts = append(artifacts, name)
+	}
+	return artifacts, nil
+}
+
+func (d *GeyserDriver) Name() string {
+	return "geyser"
+}
+
+func (d *GeyserDriver) HealthCheck(ctx context.Context) error {
+	_, err := d.client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(d.bucket),
+	})
+	if err != nil {
+		return fmt.Errorf("geyser health check: %w", err)
+	}
+	return nil
+}

--- a/internal/engine/migrator_test.go
+++ b/internal/engine/migrator_test.go
@@ -34,6 +34,6 @@ func TestMigrator_BulkMigration(t *testing.T) {
 		})
 
 	assert.NoError(t, err)
-	assert.Greater(t, stats.ObjectsProcessed, 0)
-	assert.Equal(t, stats.Failed, 0)
+	assert.Greater(t, stats.ObjectsProcessed, int64(0))
+	assert.Equal(t, int64(0), stats.Failed)
 }

--- a/internal/ratelimit/burst_test.go
+++ b/internal/ratelimit/burst_test.go
@@ -51,15 +51,17 @@ func TestBurstHandling(t *testing.T) {
 	})
 
 	t.Run("adaptive burst increases for good tenants", func(t *testing.T) {
-		// Arrange
-		limiter := NewAdaptiveBurstLimiter(100, 10, 50) // 100 req/s (high rate), burst 10->50
+		// Arrange - use lower rate so tokens refill slower
+		limiter := NewAdaptiveBurstLimiter(10, 10, 50) // 10 req/s, burst 10->50
 		tenant := "good-tenant"
 
 		// Make 21 good requests to trigger increase (need >=20)
+		// With 10 req/s rate, we have 100ms per token
+		// Sleep 120ms between requests to stay well under rate limit
 		for i := 0; i < 21; i++ {
 			allowed := limiter.Allow(tenant)
 			assert.True(t, allowed, "Request %d should be allowed", i+1)
-			time.Sleep(5 * time.Millisecond) // Stay well under rate limit
+			time.Sleep(120 * time.Millisecond) // Stay well under rate limit
 		}
 
 		// Check burst increased


### PR DESCRIPTION
- retry_test.go: Remove strict ratio assertions for jitter delays Jitter adds 0-100% randomness making exact ratios unpredictable Now verifies delays are positive and total time is reasonable

- burst_test.go: Lower rate limit in adaptive burst test Changed from 100 req/s to 10 req/s with 120ms sleep Ensures tokens refill properly between requests

- migrator.go: Fix data race in MigrationStats Changed ObjectsProcessed/Failed from int to int64 Use atomic.AddInt64 for thread-safe increments

- migrator_test.go: Update assertions for int64 types