### PR TITLE
Merge steps-411-420-kubernetes: Kubernetes Deployment

### DIFF
--- a/internal/k8s/autoscaling.go
+++ b/internal/k8s/autoscaling.go
@@ -1,0 +1,929 @@
+// internal/k8s/autoscaling.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AutoscalingManager manages Kubernetes autoscaling resources
+type AutoscalingManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewAutoscalingManager creates a new autoscaling manager
+func NewAutoscalingManager(namespace string) *AutoscalingManager {
+	return &AutoscalingManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// HPAConfig configures a HorizontalPodAutoscaler
+type HPAConfig struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Target reference
+	TargetKind       string
+	TargetName       string
+	TargetAPIVersion string
+
+	// Scaling bounds
+	MinReplicas int32
+	MaxReplicas int32
+
+	// Metrics
+	Metrics []MetricSpec
+
+	// Behavior
+	Behavior *HPABehavior
+}
+
+// MetricSpec defines a metric for autoscaling
+type MetricSpec struct {
+	Type              MetricType
+	Resource          *ResourceMetricSource
+	Pods              *PodsMetricSource
+	Object            *ObjectMetricSource
+	External          *ExternalMetricSource
+	ContainerResource *ContainerResourceMetricSource
+}
+
+// MetricType defines the type of metric
+type MetricType string
+
+const (
+	MetricTypeResource          MetricType = "Resource"
+	MetricTypePods              MetricType = "Pods"
+	MetricTypeObject            MetricType = "Object"
+	MetricTypeExternal          MetricType = "External"
+	MetricTypeContainerResource MetricType = "ContainerResource"
+)
+
+// ResourceMetricSource defines resource-based metrics
+type ResourceMetricSource struct {
+	Name   string
+	Target MetricTarget
+}
+
+// PodsMetricSource defines pod-based metrics
+type PodsMetricSource struct {
+	Metric MetricIdentifier
+	Target MetricTarget
+}
+
+// ObjectMetricSource defines object-based metrics
+type ObjectMetricSource struct {
+	DescribedObject CrossVersionObjectReference
+	Metric          MetricIdentifier
+	Target          MetricTarget
+}
+
+// ExternalMetricSource defines external metrics
+type ExternalMetricSource struct {
+	Metric MetricIdentifier
+	Target MetricTarget
+}
+
+// ContainerResourceMetricSource defines container resource metrics
+type ContainerResourceMetricSource struct {
+	Name      string
+	Container string
+	Target    MetricTarget
+}
+
+// MetricIdentifier identifies a metric
+type MetricIdentifier struct {
+	Name     string
+	Selector *HPALabelSelectorDef
+}
+
+// LabelSelector defines label selection
+type HPALabelSelectorDef struct {
+	MatchLabels      map[string]string
+	MatchExpressions []LabelSelectorRequirement
+}
+
+// LabelSelectorRequirement defines a label requirement
+type LabelSelectorRequirement struct {
+	Key      string
+	Operator string
+	Values   []string
+}
+
+// CrossVersionObjectReference references an object
+type CrossVersionObjectReference struct {
+	APIVersion string
+	Kind       string
+	Name       string
+}
+
+// MetricTarget defines the target value for a metric
+type MetricTarget struct {
+	Type               MetricTargetType
+	Value              string
+	AverageValue       string
+	AverageUtilization *int32
+}
+
+// MetricTargetType defines target type
+type MetricTargetType string
+
+const (
+	MetricTargetTypeUtilization  MetricTargetType = "Utilization"
+	MetricTargetTypeValue        MetricTargetType = "Value"
+	MetricTargetTypeAverageValue MetricTargetType = "AverageValue"
+)
+
+// HPABehavior defines scaling behavior
+type HPABehavior struct {
+	ScaleUp   *HPAScalingRules
+	ScaleDown *HPAScalingRules
+}
+
+// HPAScalingRules defines scaling rules
+type HPAScalingRules struct {
+	StabilizationWindowSeconds *int32
+	SelectPolicy               string // Max, Min, Disabled
+	Policies                   []HPAScalingPolicy
+}
+
+// HPAScalingPolicy defines a scaling policy
+type HPAScalingPolicy struct {
+	Type          string // Pods, Percent
+	Value         int32
+	PeriodSeconds int32
+}
+
+// HPAResource represents a HorizontalPodAutoscaler
+type HPAResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       HPASpec          `yaml:"spec"`
+}
+
+// HPASpec defines HPA specification
+type HPASpec struct {
+	ScaleTargetRef HPAScaleTargetRef `yaml:"scaleTargetRef"`
+	MinReplicas    *int32            `yaml:"minReplicas,omitempty"`
+	MaxReplicas    int32             `yaml:"maxReplicas"`
+	Metrics        []HPAMetricSpec   `yaml:"metrics,omitempty"`
+	Behavior       *HPABehaviorSpec  `yaml:"behavior,omitempty"`
+}
+
+// HPAScaleTargetRef references the target
+type HPAScaleTargetRef struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Name       string `yaml:"name"`
+}
+
+// HPAMetricSpec defines a metric in HPA spec
+type HPAMetricSpec struct {
+	Type              string                            `yaml:"type"`
+	Resource          *HPAResourceMetricSource          `yaml:"resource,omitempty"`
+	Pods              *HPAPodsMetricSource              `yaml:"pods,omitempty"`
+	Object            *HPAObjectMetricSource            `yaml:"object,omitempty"`
+	External          *HPAExternalMetricSource          `yaml:"external,omitempty"`
+	ContainerResource *HPAContainerResourceMetricSource `yaml:"containerResource,omitempty"`
+}
+
+// HPAResourceMetricSource for HPA spec
+type HPAResourceMetricSource struct {
+	Name   string          `yaml:"name"`
+	Target HPAMetricTarget `yaml:"target"`
+}
+
+// HPAPodsMetricSource for HPA spec
+type HPAPodsMetricSource struct {
+	Metric HPAMetricIdentifier `yaml:"metric"`
+	Target HPAMetricTarget     `yaml:"target"`
+}
+
+// HPAObjectMetricSource for HPA spec
+type HPAObjectMetricSource struct {
+	DescribedObject HPAScaleTargetRef   `yaml:"describedObject"`
+	Metric          HPAMetricIdentifier `yaml:"metric"`
+	Target          HPAMetricTarget     `yaml:"target"`
+}
+
+// HPAExternalMetricSource for HPA spec
+type HPAExternalMetricSource struct {
+	Metric HPAMetricIdentifier `yaml:"metric"`
+	Target HPAMetricTarget     `yaml:"target"`
+}
+
+// HPAContainerResourceMetricSource for HPA spec
+type HPAContainerResourceMetricSource struct {
+	Name      string          `yaml:"name"`
+	Container string          `yaml:"container"`
+	Target    HPAMetricTarget `yaml:"target"`
+}
+
+// HPAMetricIdentifier for HPA spec
+type HPAMetricIdentifier struct {
+	Name     string            `yaml:"name"`
+	Selector *HPALabelSelector `yaml:"selector,omitempty"`
+}
+
+// HPALabelSelector for HPA spec
+type HPALabelSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels,omitempty"`
+}
+
+// HPAMetricTarget for HPA spec
+type HPAMetricTarget struct {
+	Type               string `yaml:"type"`
+	Value              string `yaml:"value,omitempty"`
+	AverageValue       string `yaml:"averageValue,omitempty"`
+	AverageUtilization *int32 `yaml:"averageUtilization,omitempty"`
+}
+
+// HPABehaviorSpec for HPA spec
+type HPABehaviorSpec struct {
+	ScaleUp   *HPAScalingRulesSpec `yaml:"scaleUp,omitempty"`
+	ScaleDown *HPAScalingRulesSpec `yaml:"scaleDown,omitempty"`
+}
+
+// HPAScalingRulesSpec for HPA spec
+type HPAScalingRulesSpec struct {
+	StabilizationWindowSeconds *int32                 `yaml:"stabilizationWindowSeconds,omitempty"`
+	SelectPolicy               string                 `yaml:"selectPolicy,omitempty"`
+	Policies                   []HPAScalingPolicySpec `yaml:"policies,omitempty"`
+}
+
+// HPAScalingPolicySpec for HPA spec
+type HPAScalingPolicySpec struct {
+	Type          string `yaml:"type"`
+	Value         int32  `yaml:"value"`
+	PeriodSeconds int32  `yaml:"periodSeconds"`
+}
+
+// GenerateHPA creates a HorizontalPodAutoscaler resource
+func (am *AutoscalingManager) GenerateHPA(config HPAConfig) *HPAResource {
+	if config.Namespace == "" {
+		config.Namespace = am.namespace
+	}
+	if config.TargetKind == "" {
+		config.TargetKind = "Deployment"
+	}
+	if config.TargetAPIVersion == "" {
+		config.TargetAPIVersion = "apps/v1"
+	}
+
+	labels := copyStringMap(am.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	hpa := &HPAResource{
+		APIVersion: "autoscaling/v2",
+		Kind:       "HorizontalPodAutoscaler",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: HPASpec{
+			ScaleTargetRef: HPAScaleTargetRef{
+				APIVersion: config.TargetAPIVersion,
+				Kind:       config.TargetKind,
+				Name:       config.TargetName,
+			},
+			MaxReplicas: config.MaxReplicas,
+		},
+	}
+
+	if config.MinReplicas > 0 {
+		hpa.Spec.MinReplicas = &config.MinReplicas
+	}
+
+	// Convert metrics
+	if len(config.Metrics) > 0 {
+		hpa.Spec.Metrics = convertMetrics(config.Metrics)
+	}
+
+	// Convert behavior
+	if config.Behavior != nil {
+		hpa.Spec.Behavior = convertBehavior(config.Behavior)
+	}
+
+	return hpa
+}
+
+func convertMetrics(metrics []MetricSpec) []HPAMetricSpec {
+	result := make([]HPAMetricSpec, 0, len(metrics))
+	for _, m := range metrics {
+		spec := HPAMetricSpec{Type: string(m.Type)}
+
+		if m.Resource != nil {
+			spec.Resource = &HPAResourceMetricSource{
+				Name: m.Resource.Name,
+				Target: HPAMetricTarget{
+					Type:               string(m.Resource.Target.Type),
+					Value:              m.Resource.Target.Value,
+					AverageValue:       m.Resource.Target.AverageValue,
+					AverageUtilization: m.Resource.Target.AverageUtilization,
+				},
+			}
+		}
+
+		if m.Pods != nil {
+			spec.Pods = &HPAPodsMetricSource{
+				Metric: HPAMetricIdentifier{Name: m.Pods.Metric.Name},
+				Target: HPAMetricTarget{
+					Type:         string(m.Pods.Target.Type),
+					AverageValue: m.Pods.Target.AverageValue,
+				},
+			}
+		}
+
+		if m.External != nil {
+			spec.External = &HPAExternalMetricSource{
+				Metric: HPAMetricIdentifier{Name: m.External.Metric.Name},
+				Target: HPAMetricTarget{
+					Type:         string(m.External.Target.Type),
+					Value:        m.External.Target.Value,
+					AverageValue: m.External.Target.AverageValue,
+				},
+			}
+		}
+
+		if m.ContainerResource != nil {
+			spec.ContainerResource = &HPAContainerResourceMetricSource{
+				Name:      m.ContainerResource.Name,
+				Container: m.ContainerResource.Container,
+				Target: HPAMetricTarget{
+					Type:               string(m.ContainerResource.Target.Type),
+					AverageUtilization: m.ContainerResource.Target.AverageUtilization,
+				},
+			}
+		}
+
+		result = append(result, spec)
+	}
+	return result
+}
+
+func convertBehavior(behavior *HPABehavior) *HPABehaviorSpec {
+	spec := &HPABehaviorSpec{}
+
+	if behavior.ScaleUp != nil {
+		spec.ScaleUp = &HPAScalingRulesSpec{
+			StabilizationWindowSeconds: behavior.ScaleUp.StabilizationWindowSeconds,
+			SelectPolicy:               behavior.ScaleUp.SelectPolicy,
+		}
+		for _, p := range behavior.ScaleUp.Policies {
+			spec.ScaleUp.Policies = append(spec.ScaleUp.Policies, HPAScalingPolicySpec(p))
+		}
+	}
+
+	if behavior.ScaleDown != nil {
+		spec.ScaleDown = &HPAScalingRulesSpec{
+			StabilizationWindowSeconds: behavior.ScaleDown.StabilizationWindowSeconds,
+			SelectPolicy:               behavior.ScaleDown.SelectPolicy,
+		}
+		for _, p := range behavior.ScaleDown.Policies {
+			spec.ScaleDown.Policies = append(spec.ScaleDown.Policies, HPAScalingPolicySpec(p))
+		}
+	}
+
+	return spec
+}
+
+// ToYAML converts HPA to YAML
+func (h *HPAResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(h); err != nil {
+		return "", fmt.Errorf("failed to encode HPA: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// VPAConfig configures a VerticalPodAutoscaler
+type VPAConfig struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Target reference
+	TargetKind       string
+	TargetName       string
+	TargetAPIVersion string
+
+	// Update policy
+	UpdateMode string // Off, Initial, Recreate, Auto
+
+	// Resource policy
+	ContainerPolicies []VPAContainerPolicy
+}
+
+// VPAContainerPolicy defines resource policy for a container
+type VPAContainerPolicy struct {
+	ContainerName       string
+	Mode                string // Auto, Off
+	MinAllowed          ResourceList
+	MaxAllowed          ResourceList
+	ControlledResources []string // cpu, memory
+	ControlledValues    string   // RequestsOnly, RequestsAndLimits
+}
+
+// ResourceList defines resource quantities
+type ResourceList struct {
+	CPU    string
+	Memory string
+}
+
+// VPAResource represents a VerticalPodAutoscaler
+type VPAResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       VPASpec          `yaml:"spec"`
+}
+
+// VPASpec defines VPA specification
+type VPASpec struct {
+	TargetRef      VPATargetRef       `yaml:"targetRef"`
+	UpdatePolicy   *VPAUpdatePolicy   `yaml:"updatePolicy,omitempty"`
+	ResourcePolicy *VPAResourcePolicy `yaml:"resourcePolicy,omitempty"`
+}
+
+// VPATargetRef references the target
+type VPATargetRef struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Name       string `yaml:"name"`
+}
+
+// VPAUpdatePolicy defines update policy
+type VPAUpdatePolicy struct {
+	UpdateMode string `yaml:"updateMode"`
+}
+
+// VPAResourcePolicy defines resource policy
+type VPAResourcePolicy struct {
+	ContainerPolicies []VPAContainerPolicySpec `yaml:"containerPolicies"`
+}
+
+// VPAContainerPolicySpec defines container policy in spec
+type VPAContainerPolicySpec struct {
+	ContainerName       string            `yaml:"containerName"`
+	Mode                string            `yaml:"mode,omitempty"`
+	MinAllowed          map[string]string `yaml:"minAllowed,omitempty"`
+	MaxAllowed          map[string]string `yaml:"maxAllowed,omitempty"`
+	ControlledResources []string          `yaml:"controlledResources,omitempty"`
+	ControlledValues    string            `yaml:"controlledValues,omitempty"`
+}
+
+// GenerateVPA creates a VerticalPodAutoscaler resource
+func (am *AutoscalingManager) GenerateVPA(config VPAConfig) *VPAResource {
+	if config.Namespace == "" {
+		config.Namespace = am.namespace
+	}
+	if config.TargetKind == "" {
+		config.TargetKind = "Deployment"
+	}
+	if config.TargetAPIVersion == "" {
+		config.TargetAPIVersion = "apps/v1"
+	}
+	if config.UpdateMode == "" {
+		config.UpdateMode = "Auto"
+	}
+
+	labels := copyStringMap(am.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	vpa := &VPAResource{
+		APIVersion: "autoscaling.k8s.io/v1",
+		Kind:       "VerticalPodAutoscaler",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: VPASpec{
+			TargetRef: VPATargetRef{
+				APIVersion: config.TargetAPIVersion,
+				Kind:       config.TargetKind,
+				Name:       config.TargetName,
+			},
+			UpdatePolicy: &VPAUpdatePolicy{
+				UpdateMode: config.UpdateMode,
+			},
+		},
+	}
+
+	// Convert container policies
+	if len(config.ContainerPolicies) > 0 {
+		vpa.Spec.ResourcePolicy = &VPAResourcePolicy{
+			ContainerPolicies: make([]VPAContainerPolicySpec, 0, len(config.ContainerPolicies)),
+		}
+		for _, cp := range config.ContainerPolicies {
+			spec := VPAContainerPolicySpec{
+				ContainerName:       cp.ContainerName,
+				Mode:                cp.Mode,
+				ControlledResources: cp.ControlledResources,
+				ControlledValues:    cp.ControlledValues,
+			}
+			if cp.MinAllowed.CPU != "" || cp.MinAllowed.Memory != "" {
+				spec.MinAllowed = make(map[string]string)
+				if cp.MinAllowed.CPU != "" {
+					spec.MinAllowed["cpu"] = cp.MinAllowed.CPU
+				}
+				if cp.MinAllowed.Memory != "" {
+					spec.MinAllowed["memory"] = cp.MinAllowed.Memory
+				}
+			}
+			if cp.MaxAllowed.CPU != "" || cp.MaxAllowed.Memory != "" {
+				spec.MaxAllowed = make(map[string]string)
+				if cp.MaxAllowed.CPU != "" {
+					spec.MaxAllowed["cpu"] = cp.MaxAllowed.CPU
+				}
+				if cp.MaxAllowed.Memory != "" {
+					spec.MaxAllowed["memory"] = cp.MaxAllowed.Memory
+				}
+			}
+			vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, spec)
+		}
+	}
+
+	return vpa
+}
+
+// ToYAML converts VPA to YAML
+func (v *VPAResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(v); err != nil {
+		return "", fmt.Errorf("failed to encode VPA: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// PDBConfig configures a PodDisruptionBudget
+type PDBConfig struct {
+	Name           string
+	Namespace      string
+	Labels         map[string]string
+	Annotations    map[string]string
+	Selector       map[string]string
+	MinAvailable   string // Can be number or percentage
+	MaxUnavailable string // Can be number or percentage
+}
+
+// PDBResource represents a PodDisruptionBudget
+type PDBResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       PDBSpec          `yaml:"spec"`
+}
+
+// PDBSpec defines PDB specification
+type PDBSpec struct {
+	Selector       *PDBLabelSelector `yaml:"selector"`
+	MinAvailable   string            `yaml:"minAvailable,omitempty"`
+	MaxUnavailable string            `yaml:"maxUnavailable,omitempty"`
+}
+
+// PDBLabelSelector for PDB
+type PDBLabelSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+// GeneratePDB creates a PodDisruptionBudget resource
+func (am *AutoscalingManager) GeneratePDB(config PDBConfig) *PDBResource {
+	if config.Namespace == "" {
+		config.Namespace = am.namespace
+	}
+
+	labels := copyStringMap(am.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	pdb := &PDBResource{
+		APIVersion: "policy/v1",
+		Kind:       "PodDisruptionBudget",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: PDBSpec{
+			Selector: &PDBLabelSelector{
+				MatchLabels: config.Selector,
+			},
+		},
+	}
+
+	if config.MinAvailable != "" {
+		pdb.Spec.MinAvailable = config.MinAvailable
+	}
+	if config.MaxUnavailable != "" {
+		pdb.Spec.MaxUnavailable = config.MaxUnavailable
+	}
+
+	return pdb
+}
+
+// ToYAML converts PDB to YAML
+func (p *PDBResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(p); err != nil {
+		return "", fmt.Errorf("failed to encode PDB: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// HPABuilder provides a fluent interface for building HPA
+type HPABuilder struct {
+	config HPAConfig
+}
+
+// NewHPABuilder creates a new HPA builder
+func NewHPABuilder(name, namespace, targetName string) *HPABuilder {
+	return &HPABuilder{
+		config: HPAConfig{
+			Name:       name,
+			Namespace:  namespace,
+			TargetName: targetName,
+			TargetKind: "Deployment",
+		},
+	}
+}
+
+// WithMinReplicas sets minimum replicas
+func (b *HPABuilder) WithMinReplicas(min int32) *HPABuilder {
+	b.config.MinReplicas = min
+	return b
+}
+
+// WithMaxReplicas sets maximum replicas
+func (b *HPABuilder) WithMaxReplicas(max int32) *HPABuilder {
+	b.config.MaxReplicas = max
+	return b
+}
+
+// WithCPUUtilization adds CPU utilization metric
+func (b *HPABuilder) WithCPUUtilization(targetPercent int32) *HPABuilder {
+	b.config.Metrics = append(b.config.Metrics, MetricSpec{
+		Type: MetricTypeResource,
+		Resource: &ResourceMetricSource{
+			Name: "cpu",
+			Target: MetricTarget{
+				Type:               MetricTargetTypeUtilization,
+				AverageUtilization: &targetPercent,
+			},
+		},
+	})
+	return b
+}
+
+// WithMemoryUtilization adds memory utilization metric
+func (b *HPABuilder) WithMemoryUtilization(targetPercent int32) *HPABuilder {
+	b.config.Metrics = append(b.config.Metrics, MetricSpec{
+		Type: MetricTypeResource,
+		Resource: &ResourceMetricSource{
+			Name: "memory",
+			Target: MetricTarget{
+				Type:               MetricTargetTypeUtilization,
+				AverageUtilization: &targetPercent,
+			},
+		},
+	})
+	return b
+}
+
+// WithCustomMetric adds a custom metric
+func (b *HPABuilder) WithCustomMetric(name string, targetAverageValue string) *HPABuilder {
+	b.config.Metrics = append(b.config.Metrics, MetricSpec{
+		Type: MetricTypePods,
+		Pods: &PodsMetricSource{
+			Metric: MetricIdentifier{Name: name},
+			Target: MetricTarget{
+				Type:         MetricTargetTypeAverageValue,
+				AverageValue: targetAverageValue,
+			},
+		},
+	})
+	return b
+}
+
+// WithExternalMetric adds an external metric
+func (b *HPABuilder) WithExternalMetric(name string, targetValue string) *HPABuilder {
+	b.config.Metrics = append(b.config.Metrics, MetricSpec{
+		Type: MetricTypeExternal,
+		External: &ExternalMetricSource{
+			Metric: MetricIdentifier{Name: name},
+			Target: MetricTarget{
+				Type:  MetricTargetTypeValue,
+				Value: targetValue,
+			},
+		},
+	})
+	return b
+}
+
+// WithScaleUpPolicy adds scale up policy
+func (b *HPABuilder) WithScaleUpPolicy(policyType string, value, periodSeconds int32) *HPABuilder {
+	if b.config.Behavior == nil {
+		b.config.Behavior = &HPABehavior{}
+	}
+	if b.config.Behavior.ScaleUp == nil {
+		b.config.Behavior.ScaleUp = &HPAScalingRules{}
+	}
+	b.config.Behavior.ScaleUp.Policies = append(b.config.Behavior.ScaleUp.Policies, HPAScalingPolicy{
+		Type:          policyType,
+		Value:         value,
+		PeriodSeconds: periodSeconds,
+	})
+	return b
+}
+
+// WithScaleDownPolicy adds scale down policy
+func (b *HPABuilder) WithScaleDownPolicy(policyType string, value, periodSeconds int32) *HPABuilder {
+	if b.config.Behavior == nil {
+		b.config.Behavior = &HPABehavior{}
+	}
+	if b.config.Behavior.ScaleDown == nil {
+		b.config.Behavior.ScaleDown = &HPAScalingRules{}
+	}
+	b.config.Behavior.ScaleDown.Policies = append(b.config.Behavior.ScaleDown.Policies, HPAScalingPolicy{
+		Type:          policyType,
+		Value:         value,
+		PeriodSeconds: periodSeconds,
+	})
+	return b
+}
+
+// WithScaleUpStabilization sets scale up stabilization window
+func (b *HPABuilder) WithScaleUpStabilization(seconds int32) *HPABuilder {
+	if b.config.Behavior == nil {
+		b.config.Behavior = &HPABehavior{}
+	}
+	if b.config.Behavior.ScaleUp == nil {
+		b.config.Behavior.ScaleUp = &HPAScalingRules{}
+	}
+	b.config.Behavior.ScaleUp.StabilizationWindowSeconds = &seconds
+	return b
+}
+
+// WithScaleDownStabilization sets scale down stabilization window
+func (b *HPABuilder) WithScaleDownStabilization(seconds int32) *HPABuilder {
+	if b.config.Behavior == nil {
+		b.config.Behavior = &HPABehavior{}
+	}
+	if b.config.Behavior.ScaleDown == nil {
+		b.config.Behavior.ScaleDown = &HPAScalingRules{}
+	}
+	b.config.Behavior.ScaleDown.StabilizationWindowSeconds = &seconds
+	return b
+}
+
+// Build creates the HPA resource
+func (b *HPABuilder) Build() *HPAResource {
+	am := NewAutoscalingManager(b.config.Namespace)
+	return am.GenerateHPA(b.config)
+}
+
+// GenerateVaultaireAutoscaling creates autoscaling resources for Vaultaire
+func GenerateVaultaireAutoscaling(namespace string) (*HPAResource, *VPAResource, *PDBResource) {
+	am := NewAutoscalingManager(namespace)
+
+	// HPA for API server
+	cpu := int32(70)
+	memory := int32(80)
+	scaleUpWindow := int32(0)
+	scaleDownWindow := int32(300)
+
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "vaultaire-api",
+		TargetName:  "vaultaire-api",
+		MinReplicas: 2,
+		MaxReplicas: 20,
+		Metrics: []MetricSpec{
+			{
+				Type: MetricTypeResource,
+				Resource: &ResourceMetricSource{
+					Name: "cpu",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &cpu,
+					},
+				},
+			},
+			{
+				Type: MetricTypeResource,
+				Resource: &ResourceMetricSource{
+					Name: "memory",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &memory,
+					},
+				},
+			},
+		},
+		Behavior: &HPABehavior{
+			ScaleUp: &HPAScalingRules{
+				StabilizationWindowSeconds: &scaleUpWindow,
+				SelectPolicy:               "Max",
+				Policies: []HPAScalingPolicy{
+					{Type: "Pods", Value: 4, PeriodSeconds: 15},
+					{Type: "Percent", Value: 100, PeriodSeconds: 15},
+				},
+			},
+			ScaleDown: &HPAScalingRules{
+				StabilizationWindowSeconds: &scaleDownWindow,
+				SelectPolicy:               "Min",
+				Policies: []HPAScalingPolicy{
+					{Type: "Pods", Value: 1, PeriodSeconds: 60},
+				},
+			},
+		},
+	})
+
+	// VPA for workers (recommendation only)
+	vpa := am.GenerateVPA(VPAConfig{
+		Name:       "vaultaire-worker",
+		TargetName: "vaultaire-worker",
+		UpdateMode: "Off", // Recommendation only
+		ContainerPolicies: []VPAContainerPolicy{
+			{
+				ContainerName:       "worker",
+				MinAllowed:          ResourceList{CPU: "100m", Memory: "128Mi"},
+				MaxAllowed:          ResourceList{CPU: "4", Memory: "8Gi"},
+				ControlledResources: []string{"cpu", "memory"},
+			},
+		},
+	})
+
+	// PDB for API server
+	pdb := am.GeneratePDB(PDBConfig{
+		Name:         "vaultaire-api",
+		Selector:     map[string]string{"app": "vaultaire-api"},
+		MinAvailable: "50%",
+	})
+
+	return hpa, vpa, pdb
+}
+
+// AutoscalingSet represents a collection of autoscaling resources
+type AutoscalingSet struct {
+	HPAs []*HPAResource
+	VPAs []*VPAResource
+	PDBs []*PDBResource
+}
+
+// ToYAML converts all resources to multi-document YAML
+func (s *AutoscalingSet) ToYAML() (string, error) {
+	var parts []string
+
+	for _, hpa := range s.HPAs {
+		yaml, err := hpa.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, vpa := range s.VPAs {
+		yaml, err := vpa.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, pdb := range s.PDBs {
+		yaml, err := pdb.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	return strings.Join(parts, "---\n"), nil
+}

--- a/internal/k8s/autoscaling_test.go
+++ b/internal/k8s/autoscaling_test.go
@@ -1,0 +1,502 @@
+// internal/k8s/autoscaling_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewAutoscalingManager(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	if am.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", am.namespace)
+	}
+}
+
+func TestGenerateHPABasic(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	cpu := int32(80)
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MinReplicas: 2,
+		MaxReplicas: 10,
+		Metrics: []MetricSpec{
+			{
+				Type: MetricTypeResource,
+				Resource: &ResourceMetricSource{
+					Name: "cpu",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &cpu,
+					},
+				},
+			},
+		},
+	})
+
+	if hpa.Kind != "HorizontalPodAutoscaler" {
+		t.Errorf("expected kind HorizontalPodAutoscaler, got %s", hpa.Kind)
+	}
+	if hpa.APIVersion != "autoscaling/v2" {
+		t.Errorf("expected apiVersion autoscaling/v2, got %s", hpa.APIVersion)
+	}
+	if hpa.Spec.MaxReplicas != 10 {
+		t.Errorf("expected maxReplicas 10, got %d", hpa.Spec.MaxReplicas)
+	}
+	if *hpa.Spec.MinReplicas != 2 {
+		t.Errorf("expected minReplicas 2, got %d", *hpa.Spec.MinReplicas)
+	}
+}
+
+func TestGenerateHPADefaults(t *testing.T) {
+	am := NewAutoscalingManager("production")
+
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MaxReplicas: 5,
+	})
+
+	if hpa.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", hpa.Metadata.Namespace)
+	}
+	if hpa.Spec.ScaleTargetRef.Kind != "Deployment" {
+		t.Errorf("expected default kind 'Deployment', got '%s'", hpa.Spec.ScaleTargetRef.Kind)
+	}
+	if hpa.Spec.ScaleTargetRef.APIVersion != "apps/v1" {
+		t.Errorf("expected default apiVersion 'apps/v1', got '%s'", hpa.Spec.ScaleTargetRef.APIVersion)
+	}
+}
+
+func TestGenerateHPAWithBehavior(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	scaleUpWindow := int32(0)
+	scaleDownWindow := int32(300)
+
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MaxReplicas: 10,
+		Behavior: &HPABehavior{
+			ScaleUp: &HPAScalingRules{
+				StabilizationWindowSeconds: &scaleUpWindow,
+				SelectPolicy:               "Max",
+				Policies: []HPAScalingPolicy{
+					{Type: "Pods", Value: 4, PeriodSeconds: 15},
+					{Type: "Percent", Value: 100, PeriodSeconds: 15},
+				},
+			},
+			ScaleDown: &HPAScalingRules{
+				StabilizationWindowSeconds: &scaleDownWindow,
+				SelectPolicy:               "Min",
+				Policies: []HPAScalingPolicy{
+					{Type: "Pods", Value: 1, PeriodSeconds: 60},
+				},
+			},
+		},
+	})
+
+	if hpa.Spec.Behavior == nil {
+		t.Fatal("expected behavior to be set")
+	}
+	if *hpa.Spec.Behavior.ScaleUp.StabilizationWindowSeconds != 0 {
+		t.Error("expected scale up stabilization window 0")
+	}
+	if *hpa.Spec.Behavior.ScaleDown.StabilizationWindowSeconds != 300 {
+		t.Error("expected scale down stabilization window 300")
+	}
+	if len(hpa.Spec.Behavior.ScaleUp.Policies) != 2 {
+		t.Errorf("expected 2 scale up policies, got %d", len(hpa.Spec.Behavior.ScaleUp.Policies))
+	}
+}
+
+func TestHPAToYAML(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MaxReplicas: 10,
+	})
+
+	yaml, err := hpa.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: HorizontalPodAutoscaler") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "autoscaling/v2") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestHPABuilder(t *testing.T) {
+	hpa := NewHPABuilder("test-hpa", "default", "test-deployment").
+		WithMinReplicas(2).
+		WithMaxReplicas(10).
+		WithCPUUtilization(70).
+		WithMemoryUtilization(80).
+		Build()
+
+	if hpa.Metadata.Name != "test-hpa" {
+		t.Errorf("expected name 'test-hpa', got '%s'", hpa.Metadata.Name)
+	}
+	if *hpa.Spec.MinReplicas != 2 {
+		t.Errorf("expected minReplicas 2, got %d", *hpa.Spec.MinReplicas)
+	}
+	if len(hpa.Spec.Metrics) != 2 {
+		t.Errorf("expected 2 metrics, got %d", len(hpa.Spec.Metrics))
+	}
+}
+
+func TestHPABuilderWithCustomMetric(t *testing.T) {
+	hpa := NewHPABuilder("test-hpa", "default", "test-deployment").
+		WithMaxReplicas(10).
+		WithCustomMetric("requests_per_second", "100").
+		Build()
+
+	if len(hpa.Spec.Metrics) != 1 {
+		t.Fatal("expected 1 metric")
+	}
+	if hpa.Spec.Metrics[0].Type != string(MetricTypePods) {
+		t.Errorf("expected Pods metric type, got %s", hpa.Spec.Metrics[0].Type)
+	}
+}
+
+func TestHPABuilderWithExternalMetric(t *testing.T) {
+	hpa := NewHPABuilder("test-hpa", "default", "test-deployment").
+		WithMaxReplicas(10).
+		WithExternalMetric("pubsub_messages", "100").
+		Build()
+
+	if len(hpa.Spec.Metrics) != 1 {
+		t.Fatal("expected 1 metric")
+	}
+	if hpa.Spec.Metrics[0].Type != string(MetricTypeExternal) {
+		t.Errorf("expected External metric type, got %s", hpa.Spec.Metrics[0].Type)
+	}
+}
+
+func TestHPABuilderWithBehavior(t *testing.T) {
+	hpa := NewHPABuilder("test-hpa", "default", "test-deployment").
+		WithMaxReplicas(10).
+		WithScaleUpPolicy("Pods", 4, 15).
+		WithScaleUpPolicy("Percent", 100, 15).
+		WithScaleDownPolicy("Pods", 1, 60).
+		WithScaleUpStabilization(0).
+		WithScaleDownStabilization(300).
+		Build()
+
+	if hpa.Spec.Behavior == nil {
+		t.Fatal("expected behavior to be set")
+	}
+	if len(hpa.Spec.Behavior.ScaleUp.Policies) != 2 {
+		t.Error("expected 2 scale up policies")
+	}
+	if len(hpa.Spec.Behavior.ScaleDown.Policies) != 1 {
+		t.Error("expected 1 scale down policy")
+	}
+}
+
+func TestGenerateVPA(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	vpa := am.GenerateVPA(VPAConfig{
+		Name:       "test-vpa",
+		TargetName: "test-deployment",
+		UpdateMode: "Auto",
+		ContainerPolicies: []VPAContainerPolicy{
+			{
+				ContainerName: "app",
+				MinAllowed:    ResourceList{CPU: "100m", Memory: "128Mi"},
+				MaxAllowed:    ResourceList{CPU: "4", Memory: "8Gi"},
+			},
+		},
+	})
+
+	if vpa.Kind != "VerticalPodAutoscaler" {
+		t.Errorf("expected kind VerticalPodAutoscaler, got %s", vpa.Kind)
+	}
+	if vpa.APIVersion != "autoscaling.k8s.io/v1" {
+		t.Errorf("expected apiVersion autoscaling.k8s.io/v1, got %s", vpa.APIVersion)
+	}
+	if vpa.Spec.UpdatePolicy.UpdateMode != "Auto" {
+		t.Errorf("expected updateMode Auto, got %s", vpa.Spec.UpdatePolicy.UpdateMode)
+	}
+}
+
+func TestGenerateVPADefaults(t *testing.T) {
+	am := NewAutoscalingManager("production")
+
+	vpa := am.GenerateVPA(VPAConfig{
+		Name:       "test-vpa",
+		TargetName: "test-deployment",
+	})
+
+	if vpa.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", vpa.Metadata.Namespace)
+	}
+	if vpa.Spec.UpdatePolicy.UpdateMode != "Auto" {
+		t.Errorf("expected default updateMode 'Auto', got '%s'", vpa.Spec.UpdatePolicy.UpdateMode)
+	}
+}
+
+func TestGenerateVPAWithContainerPolicies(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	vpa := am.GenerateVPA(VPAConfig{
+		Name:       "test-vpa",
+		TargetName: "test-deployment",
+		ContainerPolicies: []VPAContainerPolicy{
+			{
+				ContainerName:       "app",
+				Mode:                "Auto",
+				MinAllowed:          ResourceList{CPU: "100m", Memory: "128Mi"},
+				MaxAllowed:          ResourceList{CPU: "4", Memory: "8Gi"},
+				ControlledResources: []string{"cpu", "memory"},
+				ControlledValues:    "RequestsAndLimits",
+			},
+		},
+	})
+
+	if vpa.Spec.ResourcePolicy == nil {
+		t.Fatal("expected resource policy")
+	}
+	if len(vpa.Spec.ResourcePolicy.ContainerPolicies) != 1 {
+		t.Fatal("expected 1 container policy")
+	}
+
+	cp := vpa.Spec.ResourcePolicy.ContainerPolicies[0]
+	if cp.ContainerName != "app" {
+		t.Error("expected container name 'app'")
+	}
+	if cp.MinAllowed["cpu"] != "100m" {
+		t.Error("expected minAllowed cpu '100m'")
+	}
+	if cp.MaxAllowed["memory"] != "8Gi" {
+		t.Error("expected maxAllowed memory '8Gi'")
+	}
+}
+
+func TestVPAToYAML(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	vpa := am.GenerateVPA(VPAConfig{
+		Name:       "test-vpa",
+		TargetName: "test-deployment",
+	})
+
+	yaml, err := vpa.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: VerticalPodAutoscaler") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGeneratePDB(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	pdb := am.GeneratePDB(PDBConfig{
+		Name:         "test-pdb",
+		Selector:     map[string]string{"app": "test"},
+		MinAvailable: "50%",
+	})
+
+	if pdb.Kind != "PodDisruptionBudget" {
+		t.Errorf("expected kind PodDisruptionBudget, got %s", pdb.Kind)
+	}
+	if pdb.APIVersion != "policy/v1" {
+		t.Errorf("expected apiVersion policy/v1, got %s", pdb.APIVersion)
+	}
+	if pdb.Spec.MinAvailable != "50%" {
+		t.Errorf("expected minAvailable '50%%', got '%s'", pdb.Spec.MinAvailable)
+	}
+}
+
+func TestGeneratePDBMaxUnavailable(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	pdb := am.GeneratePDB(PDBConfig{
+		Name:           "test-pdb",
+		Selector:       map[string]string{"app": "test"},
+		MaxUnavailable: "1",
+	})
+
+	if pdb.Spec.MaxUnavailable != "1" {
+		t.Errorf("expected maxUnavailable '1', got '%s'", pdb.Spec.MaxUnavailable)
+	}
+}
+
+func TestPDBToYAML(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	pdb := am.GeneratePDB(PDBConfig{
+		Name:         "test-pdb",
+		Selector:     map[string]string{"app": "test"},
+		MinAvailable: "2",
+	})
+
+	yaml, err := pdb.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: PodDisruptionBudget") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "policy/v1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestGenerateVaultaireAutoscaling(t *testing.T) {
+	hpa, vpa, pdb := GenerateVaultaireAutoscaling("vaultaire")
+
+	// Check HPA
+	if hpa.Metadata.Name != "vaultaire-api" {
+		t.Errorf("expected HPA name 'vaultaire-api', got '%s'", hpa.Metadata.Name)
+	}
+	if *hpa.Spec.MinReplicas != 2 {
+		t.Error("expected minReplicas 2")
+	}
+	if hpa.Spec.MaxReplicas != 20 {
+		t.Error("expected maxReplicas 20")
+	}
+	if len(hpa.Spec.Metrics) != 2 {
+		t.Error("expected 2 metrics (cpu and memory)")
+	}
+
+	// Check VPA
+	if vpa.Metadata.Name != "vaultaire-worker" {
+		t.Errorf("expected VPA name 'vaultaire-worker', got '%s'", vpa.Metadata.Name)
+	}
+	if vpa.Spec.UpdatePolicy.UpdateMode != "Off" {
+		t.Error("expected updateMode Off (recommendation only)")
+	}
+
+	// Check PDB
+	if pdb.Metadata.Name != "vaultaire-api" {
+		t.Errorf("expected PDB name 'vaultaire-api', got '%s'", pdb.Metadata.Name)
+	}
+	if pdb.Spec.MinAvailable != "50%" {
+		t.Error("expected minAvailable 50%")
+	}
+}
+
+func TestAutoscalingSet(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	set := &AutoscalingSet{
+		HPAs: []*HPAResource{
+			am.GenerateHPA(HPAConfig{Name: "hpa-1", TargetName: "dep-1", MaxReplicas: 5}),
+		},
+		VPAs: []*VPAResource{
+			am.GenerateVPA(VPAConfig{Name: "vpa-1", TargetName: "dep-1"}),
+		},
+		PDBs: []*PDBResource{
+			am.GeneratePDB(PDBConfig{Name: "pdb-1", Selector: map[string]string{"app": "app1"}, MinAvailable: "1"}),
+		},
+	}
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 3 {
+		t.Errorf("expected 3 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestHPAMultipleMetrics(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	cpu := int32(70)
+	memory := int32(80)
+
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MaxReplicas: 10,
+		Metrics: []MetricSpec{
+			{
+				Type: MetricTypeResource,
+				Resource: &ResourceMetricSource{
+					Name: "cpu",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &cpu,
+					},
+				},
+			},
+			{
+				Type: MetricTypeResource,
+				Resource: &ResourceMetricSource{
+					Name: "memory",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &memory,
+					},
+				},
+			},
+			{
+				Type: MetricTypePods,
+				Pods: &PodsMetricSource{
+					Metric: MetricIdentifier{Name: "requests_per_second"},
+					Target: MetricTarget{
+						Type:         MetricTargetTypeAverageValue,
+						AverageValue: "1000",
+					},
+				},
+			},
+		},
+	})
+
+	if len(hpa.Spec.Metrics) != 3 {
+		t.Errorf("expected 3 metrics, got %d", len(hpa.Spec.Metrics))
+	}
+}
+
+func TestHPAContainerResource(t *testing.T) {
+	am := NewAutoscalingManager("default")
+
+	cpu := int32(80)
+	hpa := am.GenerateHPA(HPAConfig{
+		Name:        "test-hpa",
+		TargetName:  "test-deployment",
+		MaxReplicas: 10,
+		Metrics: []MetricSpec{
+			{
+				Type: MetricTypeContainerResource,
+				ContainerResource: &ContainerResourceMetricSource{
+					Name:      "cpu",
+					Container: "app",
+					Target: MetricTarget{
+						Type:               MetricTargetTypeUtilization,
+						AverageUtilization: &cpu,
+					},
+				},
+			},
+		},
+	})
+
+	if len(hpa.Spec.Metrics) != 1 {
+		t.Fatal("expected 1 metric")
+	}
+	if hpa.Spec.Metrics[0].ContainerResource == nil {
+		t.Fatal("expected container resource metric")
+	}
+	if hpa.Spec.Metrics[0].ContainerResource.Container != "app" {
+		t.Error("expected container 'app'")
+	}
+}

--- a/internal/k8s/configsecrets.go
+++ b/internal/k8s/configsecrets.go
@@ -1,0 +1,1003 @@
+// internal/k8s/configsecrets.go
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigMapManager handles ConfigMap operations
+type ConfigMapManager struct {
+	namespace string
+	labels    map[string]string
+	mu        sync.RWMutex
+	configs   map[string]*ConfigMapData
+}
+
+// ConfigMapData represents ConfigMap content
+type ConfigMapData struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Data        map[string]string
+	BinaryData  map[string][]byte
+	Immutable   bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Hash        string
+}
+
+// SecretManager handles Secret operations
+type SecretManager struct {
+	namespace      string
+	labels         map[string]string
+	encryptionKey  []byte
+	mu             sync.RWMutex
+	secrets        map[string]*SecretData
+	externalSource ExternalSecretSource
+}
+
+// SecretData represents Secret content
+type SecretData struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Type        SecretType
+	Data        map[string][]byte
+	StringData  map[string]string
+	Immutable   bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Hash        string
+	Encrypted   bool
+	Version     int
+}
+
+// SecretType represents Kubernetes secret types
+type SecretType string
+
+const (
+	SecretTypeOpaque              SecretType = "Opaque"
+	SecretTypeServiceAccountToken SecretType = "kubernetes.io/service-account-token"
+	SecretTypeDockerConfigJSON    SecretType = "kubernetes.io/dockerconfigjson"
+	SecretTypeTLS                 SecretType = "kubernetes.io/tls"
+	SecretTypeBasicAuth           SecretType = "kubernetes.io/basic-auth"
+	SecretTypeSSHAuth             SecretType = "kubernetes.io/ssh-auth"
+	SecretTypeBootstrapToken      SecretType = "bootstrap.kubernetes.io/token"
+)
+
+// ExternalSecretSource interface for external secret providers
+type ExternalSecretSource interface {
+	GetSecret(ctx context.Context, path string) (map[string][]byte, error)
+	ListSecrets(ctx context.Context, prefix string) ([]string, error)
+	Name() string
+}
+
+// NewConfigMapManager creates a new ConfigMap manager
+func NewConfigMapManager(namespace string) *ConfigMapManager {
+	return &ConfigMapManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+		configs: make(map[string]*ConfigMapData),
+	}
+}
+
+// NewSecretManager creates a new Secret manager
+func NewSecretManager(namespace string, encryptionKey []byte) *SecretManager {
+	return &SecretManager{
+		namespace:     namespace,
+		encryptionKey: encryptionKey,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+		secrets: make(map[string]*SecretData),
+	}
+}
+
+// SetExternalSource sets an external secret source
+func (sm *SecretManager) SetExternalSource(source ExternalSecretSource) {
+	sm.externalSource = source
+}
+
+// CreateConfigMap creates a new ConfigMap
+func (cm *ConfigMapManager) CreateConfigMap(name string, data map[string]string) (*ConfigMapData, error) {
+	if name == "" {
+		return nil, fmt.Errorf("configmap name is required")
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	now := time.Now()
+	configMap := &ConfigMapData{
+		Name:        name,
+		Namespace:   cm.namespace,
+		Labels:      copyStringMap(cm.labels),
+		Annotations: make(map[string]string),
+		Data:        copyStringMap(data),
+		BinaryData:  make(map[string][]byte),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	configMap.Hash = configMap.computeHash()
+
+	cm.configs[name] = configMap
+	return configMap, nil
+}
+
+// CreateConfigMapFromFile creates a ConfigMap from a file
+func (cm *ConfigMapManager) CreateConfigMapFromFile(name, key, filePath string) (*ConfigMapData, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+	}
+
+	if key == "" {
+		key = filepath.Base(filePath)
+	}
+
+	return cm.CreateConfigMap(name, map[string]string{key: string(content)})
+}
+
+// CreateConfigMapFromDirectory creates a ConfigMap from all files in a directory
+func (cm *ConfigMapManager) CreateConfigMapFromDirectory(name, dirPath string) (*ConfigMapData, error) {
+	data := make(map[string]string)
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dirPath, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(dirPath, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+
+		data[entry.Name()] = string(content)
+	}
+
+	return cm.CreateConfigMap(name, data)
+}
+
+// CreateConfigMapFromEnvFile creates a ConfigMap from a .env file
+func (cm *ConfigMapManager) CreateConfigMapFromEnvFile(name, envFilePath string) (*ConfigMapData, error) {
+	content, err := os.ReadFile(envFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read env file %s: %w", envFilePath, err)
+	}
+
+	data := parseEnvFile(string(content))
+	return cm.CreateConfigMap(name, data)
+}
+
+// GetConfigMap retrieves a ConfigMap by name
+func (cm *ConfigMapManager) GetConfigMap(name string) (*ConfigMapData, bool) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	config, exists := cm.configs[name]
+	return config, exists
+}
+
+// UpdateConfigMap updates an existing ConfigMap
+func (cm *ConfigMapManager) UpdateConfigMap(name string, data map[string]string) (*ConfigMapData, error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	config, exists := cm.configs[name]
+	if !exists {
+		return nil, fmt.Errorf("configmap %s not found", name)
+	}
+
+	if config.Immutable {
+		return nil, fmt.Errorf("configmap %s is immutable", name)
+	}
+
+	config.Data = copyStringMap(data)
+	config.UpdatedAt = time.Now()
+	config.Hash = config.computeHash()
+
+	return config, nil
+}
+
+// DeleteConfigMap deletes a ConfigMap
+func (cm *ConfigMapManager) DeleteConfigMap(name string) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if _, exists := cm.configs[name]; !exists {
+		return fmt.Errorf("configmap %s not found", name)
+	}
+
+	delete(cm.configs, name)
+	return nil
+}
+
+// ListConfigMaps lists all ConfigMaps
+func (cm *ConfigMapManager) ListConfigMaps() []*ConfigMapData {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	result := make([]*ConfigMapData, 0, len(cm.configs))
+	for _, config := range cm.configs {
+		result = append(result, config)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// computeHash computes a hash of ConfigMap data
+func (c *ConfigMapData) computeHash() string {
+	h := sha256.New()
+
+	// Sort keys for deterministic hashing
+	keys := make([]string, 0, len(c.Data))
+	for k := range c.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte(c.Data[k]))
+	}
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))[:16]
+}
+
+// ToManifest converts ConfigMapData to a Kubernetes manifest
+func (c *ConfigMapData) ToManifest() *Manifest {
+	annotations := copyStringMap(c.Annotations)
+	annotations["vaultaire.io/hash"] = c.Hash
+
+	return &Manifest{
+		APIVersion: "v1",
+		Kind:       KindConfigMap,
+		Metadata: ManifestMetadata{
+			Name:        c.Name,
+			Namespace:   c.Namespace,
+			Labels:      c.Labels,
+			Annotations: annotations,
+		},
+		Data: c.Data,
+	}
+}
+
+// CreateSecret creates a new Secret
+func (sm *SecretManager) CreateSecret(name string, data map[string]string, secretType SecretType) (*SecretData, error) {
+	if name == "" {
+		return nil, fmt.Errorf("secret name is required")
+	}
+
+	if secretType == "" {
+		secretType = SecretTypeOpaque
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	now := time.Now()
+	secret := &SecretData{
+		Name:        name,
+		Namespace:   sm.namespace,
+		Labels:      copyStringMap(sm.labels),
+		Annotations: make(map[string]string),
+		Type:        secretType,
+		Data:        make(map[string][]byte),
+		StringData:  copyStringMap(data),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Version:     1,
+	}
+
+	// Convert string data to byte data
+	for k, v := range data {
+		secret.Data[k] = []byte(v)
+	}
+
+	secret.Hash = secret.computeHash()
+	sm.secrets[name] = secret
+
+	return secret, nil
+}
+
+// CreateSecretFromFile creates a Secret from a file
+func (sm *SecretManager) CreateSecretFromFile(name, key, filePath string, secretType SecretType) (*SecretData, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+	}
+
+	if key == "" {
+		key = filepath.Base(filePath)
+	}
+
+	return sm.CreateSecret(name, map[string]string{key: string(content)}, secretType)
+}
+
+// CreateTLSSecret creates a TLS secret from cert and key files
+func (sm *SecretManager) CreateTLSSecret(name, certPath, keyPath string) (*SecretData, error) {
+	cert, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cert file: %w", err)
+	}
+
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	return sm.CreateSecret(name, map[string]string{
+		"tls.crt": string(cert),
+		"tls.key": string(key),
+	}, SecretTypeTLS)
+}
+
+// CreateDockerConfigSecret creates a Docker config secret
+func (sm *SecretManager) CreateDockerConfigSecret(name string, registries map[string]DockerRegistryAuth) (*SecretData, error) {
+	auths := make(map[string]interface{})
+	for registry, auth := range registries {
+		auths[registry] = map[string]string{
+			"username": auth.Username,
+			"password": auth.Password,
+			"email":    auth.Email,
+			"auth":     base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password)),
+		}
+	}
+
+	dockerConfig := map[string]interface{}{
+		"auths": auths,
+	}
+
+	configJSON, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal docker config: %w", err)
+	}
+
+	return sm.CreateSecret(name, map[string]string{
+		".dockerconfigjson": string(configJSON),
+	}, SecretTypeDockerConfigJSON)
+}
+
+// DockerRegistryAuth contains Docker registry credentials
+type DockerRegistryAuth struct {
+	Username string
+	Password string
+	Email    string
+}
+
+// CreateBasicAuthSecret creates a basic auth secret
+func (sm *SecretManager) CreateBasicAuthSecret(name, username, password string) (*SecretData, error) {
+	return sm.CreateSecret(name, map[string]string{
+		"username": username,
+		"password": password,
+	}, SecretTypeBasicAuth)
+}
+
+// CreateSSHAuthSecret creates an SSH auth secret
+func (sm *SecretManager) CreateSSHAuthSecret(name, privateKey string) (*SecretData, error) {
+	return sm.CreateSecret(name, map[string]string{
+		"ssh-privatekey": privateKey,
+	}, SecretTypeSSHAuth)
+}
+
+// GetSecret retrieves a Secret by name
+func (sm *SecretManager) GetSecret(name string) (*SecretData, bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	secret, exists := sm.secrets[name]
+	return secret, exists
+}
+
+// UpdateSecret updates an existing Secret
+func (sm *SecretManager) UpdateSecret(name string, data map[string]string) (*SecretData, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	secret, exists := sm.secrets[name]
+	if !exists {
+		return nil, fmt.Errorf("secret %s not found", name)
+	}
+
+	if secret.Immutable {
+		return nil, fmt.Errorf("secret %s is immutable", name)
+	}
+
+	secret.StringData = copyStringMap(data)
+	secret.Data = make(map[string][]byte)
+	for k, v := range data {
+		secret.Data[k] = []byte(v)
+	}
+	secret.UpdatedAt = time.Now()
+	secret.Version++
+	secret.Hash = secret.computeHash()
+
+	return secret, nil
+}
+
+// RotateSecret rotates a secret with new data
+func (sm *SecretManager) RotateSecret(name string, newData map[string]string) (*SecretData, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	secret, exists := sm.secrets[name]
+	if !exists {
+		return nil, fmt.Errorf("secret %s not found", name)
+	}
+
+	// Store previous version info in annotations
+	if secret.Annotations == nil {
+		secret.Annotations = make(map[string]string)
+	}
+	secret.Annotations["vaultaire.io/previous-version"] = fmt.Sprintf("%d", secret.Version)
+	secret.Annotations["vaultaire.io/rotated-at"] = time.Now().Format(time.RFC3339)
+
+	secret.StringData = copyStringMap(newData)
+	secret.Data = make(map[string][]byte)
+	for k, v := range newData {
+		secret.Data[k] = []byte(v)
+	}
+	secret.UpdatedAt = time.Now()
+	secret.Version++
+	secret.Hash = secret.computeHash()
+
+	return secret, nil
+}
+
+// DeleteSecret deletes a Secret
+func (sm *SecretManager) DeleteSecret(name string) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if _, exists := sm.secrets[name]; !exists {
+		return fmt.Errorf("secret %s not found", name)
+	}
+
+	delete(sm.secrets, name)
+	return nil
+}
+
+// ListSecrets lists all Secrets
+func (sm *SecretManager) ListSecrets() []*SecretData {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	result := make([]*SecretData, 0, len(sm.secrets))
+	for _, secret := range sm.secrets {
+		result = append(result, secret)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// computeHash computes a hash of Secret data
+func (s *SecretData) computeHash() string {
+	h := sha256.New()
+
+	// Sort keys for deterministic hashing
+	keys := make([]string, 0, len(s.Data))
+	for k := range s.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write(s.Data[k])
+	}
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))[:16]
+}
+
+// ToManifest converts SecretData to a Kubernetes manifest
+func (s *SecretData) ToManifest() *Manifest {
+	annotations := copyStringMap(s.Annotations)
+	annotations["vaultaire.io/hash"] = s.Hash
+	annotations["vaultaire.io/version"] = fmt.Sprintf("%d", s.Version)
+
+	// Encode data to base64
+	encodedData := make(map[string]string)
+	for k, v := range s.Data {
+		encodedData[k] = base64.StdEncoding.EncodeToString(v)
+	}
+
+	manifest := &Manifest{
+		APIVersion: "v1",
+		Kind:       KindSecret,
+		Metadata: ManifestMetadata{
+			Name:        s.Name,
+			Namespace:   s.Namespace,
+			Labels:      s.Labels,
+			Annotations: annotations,
+		},
+		Type: string(s.Type),
+	}
+
+	// Use StringData for YAML output (more readable)
+	manifest.StringData = s.StringData
+
+	return manifest
+}
+
+// EncryptSecret encrypts secret data using AES-GCM
+func (sm *SecretManager) EncryptSecret(name string) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	secret, exists := sm.secrets[name]
+	if !exists {
+		return fmt.Errorf("secret %s not found", name)
+	}
+
+	if secret.Encrypted {
+		return nil // Already encrypted
+	}
+
+	if sm.encryptionKey == nil {
+		return fmt.Errorf("encryption key not set")
+	}
+
+	for k, v := range secret.Data {
+		encrypted, err := encrypt(v, sm.encryptionKey)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt key %s: %w", k, err)
+		}
+		secret.Data[k] = encrypted
+	}
+
+	secret.Encrypted = true
+	secret.UpdatedAt = time.Now()
+
+	return nil
+}
+
+// DecryptSecret decrypts secret data
+func (sm *SecretManager) DecryptSecret(name string) (map[string][]byte, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	secret, exists := sm.secrets[name]
+	if !exists {
+		return nil, fmt.Errorf("secret %s not found", name)
+	}
+
+	if !secret.Encrypted {
+		return secret.Data, nil
+	}
+
+	if sm.encryptionKey == nil {
+		return nil, fmt.Errorf("encryption key not set")
+	}
+
+	decrypted := make(map[string][]byte)
+	for k, v := range secret.Data {
+		plaintext, err := decrypt(v, sm.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt key %s: %w", k, err)
+		}
+		decrypted[k] = plaintext
+	}
+
+	return decrypted, nil
+}
+
+// SealedSecret represents an encrypted/sealed secret for GitOps
+type SealedSecret struct {
+	Name          string            `yaml:"name"`
+	Namespace     string            `yaml:"namespace"`
+	EncryptedData map[string]string `yaml:"encryptedData"`
+	Type          SecretType        `yaml:"type"`
+	CreatedAt     time.Time         `yaml:"createdAt"`
+}
+
+// SealSecret creates a sealed secret for GitOps workflows
+func (sm *SecretManager) SealSecret(name string) (*SealedSecret, error) {
+	sm.mu.RLock()
+	secret, exists := sm.secrets[name]
+	sm.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("secret %s not found", name)
+	}
+
+	if sm.encryptionKey == nil {
+		return nil, fmt.Errorf("encryption key not set")
+	}
+
+	sealed := &SealedSecret{
+		Name:          secret.Name,
+		Namespace:     secret.Namespace,
+		EncryptedData: make(map[string]string),
+		Type:          secret.Type,
+		CreatedAt:     time.Now(),
+	}
+
+	for k, v := range secret.Data {
+		encrypted, err := encrypt(v, sm.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to seal key %s: %w", k, err)
+		}
+		sealed.EncryptedData[k] = base64.StdEncoding.EncodeToString(encrypted)
+	}
+
+	return sealed, nil
+}
+
+// UnsealSecret unseals a sealed secret
+func (sm *SecretManager) UnsealSecret(sealed *SealedSecret) (*SecretData, error) {
+	if sm.encryptionKey == nil {
+		return nil, fmt.Errorf("encryption key not set")
+	}
+
+	data := make(map[string]string)
+	for k, v := range sealed.EncryptedData {
+		encryptedBytes, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode key %s: %w", k, err)
+		}
+
+		decrypted, err := decrypt(encryptedBytes, sm.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unseal key %s: %w", k, err)
+		}
+		data[k] = string(decrypted)
+	}
+
+	return sm.CreateSecret(sealed.Name, data, sealed.Type)
+}
+
+// ToYAML converts SealedSecret to YAML
+func (ss *SealedSecret) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(ss); err != nil {
+		return "", fmt.Errorf("failed to encode sealed secret: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// FetchExternalSecret fetches a secret from an external source
+func (sm *SecretManager) FetchExternalSecret(ctx context.Context, name, path string, secretType SecretType) (*SecretData, error) {
+	if sm.externalSource == nil {
+		return nil, fmt.Errorf("no external secret source configured")
+	}
+
+	data, err := sm.externalSource.GetSecret(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch external secret: %w", err)
+	}
+
+	stringData := make(map[string]string)
+	for k, v := range data {
+		stringData[k] = string(v)
+	}
+
+	secret, err := sm.CreateSecret(name, stringData, secretType)
+	if err != nil {
+		return nil, err
+	}
+
+	secret.Annotations["vaultaire.io/external-source"] = sm.externalSource.Name()
+	secret.Annotations["vaultaire.io/external-path"] = path
+
+	return secret, nil
+}
+
+// ConfigWatcher watches for ConfigMap/Secret changes
+type ConfigWatcher struct {
+	mu        sync.RWMutex
+	callbacks map[string][]ConfigChangeCallback
+	interval  time.Duration
+	stopCh    chan struct{}
+	running   bool
+}
+
+// ConfigChangeCallback is called when a config changes
+type ConfigChangeCallback func(name string, oldHash, newHash string)
+
+// NewConfigWatcher creates a new config watcher
+func NewConfigWatcher(interval time.Duration) *ConfigWatcher {
+	return &ConfigWatcher{
+		callbacks: make(map[string][]ConfigChangeCallback),
+		interval:  interval,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// Watch registers a callback for config changes
+func (cw *ConfigWatcher) Watch(name string, callback ConfigChangeCallback) {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+	cw.callbacks[name] = append(cw.callbacks[name], callback)
+}
+
+// Start starts the config watcher
+func (cw *ConfigWatcher) Start(cm *ConfigMapManager, sm *SecretManager) {
+	cw.mu.Lock()
+	if cw.running {
+		cw.mu.Unlock()
+		return
+	}
+	cw.running = true
+	cw.mu.Unlock()
+
+	hashes := make(map[string]string)
+
+	go func() {
+		ticker := time.NewTicker(cw.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				cw.checkChanges(cm, sm, hashes)
+			case <-cw.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// Stop stops the config watcher
+func (cw *ConfigWatcher) Stop() {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+
+	if cw.running {
+		close(cw.stopCh)
+		cw.running = false
+	}
+}
+
+func (cw *ConfigWatcher) checkChanges(cm *ConfigMapManager, sm *SecretManager, hashes map[string]string) {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+
+	// Check ConfigMaps
+	for _, config := range cm.ListConfigMaps() {
+		key := "configmap:" + config.Name
+		if oldHash, exists := hashes[key]; exists && oldHash != config.Hash {
+			if callbacks, ok := cw.callbacks[config.Name]; ok {
+				for _, cb := range callbacks {
+					cb(config.Name, oldHash, config.Hash)
+				}
+			}
+		}
+		hashes[key] = config.Hash
+	}
+
+	// Check Secrets
+	for _, secret := range sm.ListSecrets() {
+		key := "secret:" + secret.Name
+		if oldHash, exists := hashes[key]; exists && oldHash != secret.Hash {
+			if callbacks, ok := cw.callbacks[secret.Name]; ok {
+				for _, cb := range callbacks {
+					cb(secret.Name, oldHash, secret.Hash)
+				}
+			}
+		}
+		hashes[key] = secret.Hash
+	}
+}
+
+// DeriveEncryptionKey derives an encryption key from a password
+func DeriveEncryptionKey(password, salt string) []byte {
+	return pbkdf2.Key([]byte(password), []byte(salt), 100000, 32, sha256.New)
+}
+
+// GenerateEncryptionKey generates a random encryption key
+func GenerateEncryptionKey() ([]byte, error) {
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate key: %w", err)
+	}
+	return key, nil
+}
+
+// encrypt encrypts data using AES-GCM
+func encrypt(plaintext, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// decrypt decrypts data using AES-GCM
+func decrypt(ciphertext, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+
+// parseEnvFile parses a .env file into a map
+func parseEnvFile(content string) map[string]string {
+	result := make(map[string]string)
+	lines := strings.Split(content, "\n")
+
+	envRegex := regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)=(.*)$`)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		matches := envRegex.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			key := matches[1]
+			value := matches[2]
+
+			// Remove surrounding quotes if present
+			if len(value) >= 2 {
+				if (value[0] == '"' && value[len(value)-1] == '"') ||
+					(value[0] == '\'' && value[len(value)-1] == '\'') {
+					value = value[1 : len(value)-1]
+				}
+			}
+
+			result[key] = value
+		}
+	}
+
+	return result
+}
+
+// copyStringMap creates a copy of a string map
+func copyStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// EnvSubstitution replaces environment variable references in values
+func EnvSubstitution(data map[string]string) map[string]string {
+	result := make(map[string]string, len(data))
+	envRegex := regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+	for k, v := range data {
+		result[k] = envRegex.ReplaceAllStringFunc(v, func(match string) string {
+			varName := match[2 : len(match)-1]
+			if envValue := os.Getenv(varName); envValue != "" {
+				return envValue
+			}
+			return match // Keep original if not found
+		})
+	}
+
+	return result
+}
+
+// MergeConfigMaps merges multiple ConfigMaps into one
+func MergeConfigMaps(name string, configs ...*ConfigMapData) *ConfigMapData {
+	merged := &ConfigMapData{
+		Name:        name,
+		Data:        make(map[string]string),
+		BinaryData:  make(map[string][]byte),
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	for _, config := range configs {
+		if config == nil {
+			continue
+		}
+
+		for k, v := range config.Data {
+			merged.Data[k] = v
+		}
+		for k, v := range config.BinaryData {
+			merged.BinaryData[k] = v
+		}
+		for k, v := range config.Labels {
+			merged.Labels[k] = v
+		}
+
+		if merged.Namespace == "" {
+			merged.Namespace = config.Namespace
+		}
+	}
+
+	merged.Hash = merged.computeHash()
+	return merged
+}
+
+// ValidateSecretData validates secret data based on type
+func ValidateSecretData(secretType SecretType, data map[string]string) error {
+	switch secretType {
+	case SecretTypeTLS:
+		if _, ok := data["tls.crt"]; !ok {
+			return fmt.Errorf("TLS secret requires 'tls.crt' key")
+		}
+		if _, ok := data["tls.key"]; !ok {
+			return fmt.Errorf("TLS secret requires 'tls.key' key")
+		}
+	case SecretTypeDockerConfigJSON:
+		if _, ok := data[".dockerconfigjson"]; !ok {
+			return fmt.Errorf("docker config secret requires '.dockerconfigjson' key")
+		}
+	case SecretTypeBasicAuth:
+		if _, ok := data["username"]; !ok {
+			return fmt.Errorf("basic auth secret requires 'username' key")
+		}
+		if _, ok := data["password"]; !ok {
+			return fmt.Errorf("basic auth secret requires 'password' key")
+		}
+	case SecretTypeSSHAuth:
+		if _, ok := data["ssh-privatekey"]; !ok {
+			return fmt.Errorf("SSH auth secret requires 'ssh-privatekey' key")
+		}
+	}
+	return nil
+}

--- a/internal/k8s/configsecrets_test.go
+++ b/internal/k8s/configsecrets_test.go
@@ -1,0 +1,990 @@
+// internal/k8s/configsecrets_test.go
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewConfigMapManager(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	if cm.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", cm.namespace)
+	}
+	if cm.labels["app.kubernetes.io/managed-by"] != "vaultaire" {
+		t.Error("expected managed-by label")
+	}
+}
+
+func TestCreateConfigMap(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	data := map[string]string{
+		"config.yaml": "key: value",
+		"settings":    "debug=true",
+	}
+
+	config, err := cm.CreateConfigMap("app-config", data)
+	if err != nil {
+		t.Fatalf("failed to create configmap: %v", err)
+	}
+
+	if config.Name != "app-config" {
+		t.Errorf("expected name 'app-config', got '%s'", config.Name)
+	}
+	if config.Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", config.Namespace)
+	}
+	if config.Data["config.yaml"] != "key: value" {
+		t.Error("expected config.yaml data")
+	}
+	if config.Hash == "" {
+		t.Error("expected hash to be computed")
+	}
+}
+
+func TestCreateConfigMapEmptyName(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	_, err := cm.CreateConfigMap("", map[string]string{"key": "value"})
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestCreateConfigMapFromFile(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	// Create temp file
+	tmpDir, err := os.MkdirTemp("", "configmap-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("key: value"), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	config, err := cm.CreateConfigMapFromFile("app-config", "", configPath)
+	if err != nil {
+		t.Fatalf("failed to create configmap from file: %v", err)
+	}
+
+	if config.Data["config.yaml"] != "key: value" {
+		t.Error("expected config.yaml content")
+	}
+}
+
+func TestCreateConfigMapFromDirectory(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	// Create temp directory with files
+	tmpDir, err := os.MkdirTemp("", "configmap-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	files := map[string]string{
+		"config.yaml":   "key: value",
+		"settings.json": `{"debug": true}`,
+	}
+
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	config, err := cm.CreateConfigMapFromDirectory("app-config", tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create configmap from directory: %v", err)
+	}
+
+	if len(config.Data) != 2 {
+		t.Errorf("expected 2 files, got %d", len(config.Data))
+	}
+	if config.Data["config.yaml"] != "key: value" {
+		t.Error("expected config.yaml content")
+	}
+}
+
+func TestCreateConfigMapFromEnvFile(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	// Create temp env file
+	tmpDir, err := os.MkdirTemp("", "configmap-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	envContent := `
+# Comment
+DB_HOST=localhost
+DB_PORT=5432
+API_KEY="secret123"
+EMPTY=
+`
+	envPath := filepath.Join(tmpDir, ".env")
+	if err := os.WriteFile(envPath, []byte(envContent), 0644); err != nil {
+		t.Fatalf("failed to write env file: %v", err)
+	}
+
+	config, err := cm.CreateConfigMapFromEnvFile("app-config", envPath)
+	if err != nil {
+		t.Fatalf("failed to create configmap from env file: %v", err)
+	}
+
+	if config.Data["DB_HOST"] != "localhost" {
+		t.Errorf("expected DB_HOST 'localhost', got '%s'", config.Data["DB_HOST"])
+	}
+	if config.Data["DB_PORT"] != "5432" {
+		t.Errorf("expected DB_PORT '5432', got '%s'", config.Data["DB_PORT"])
+	}
+	if config.Data["API_KEY"] != "secret123" {
+		t.Errorf("expected API_KEY 'secret123', got '%s'", config.Data["API_KEY"])
+	}
+}
+
+func TestGetConfigMap(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	_, err := cm.CreateConfigMap("app-config", map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("failed to create configmap: %v", err)
+	}
+
+	config, exists := cm.GetConfigMap("app-config")
+	if !exists {
+		t.Error("expected configmap to exist")
+	}
+	if config.Name != "app-config" {
+		t.Errorf("expected name 'app-config', got '%s'", config.Name)
+	}
+
+	_, exists = cm.GetConfigMap("nonexistent")
+	if exists {
+		t.Error("expected configmap to not exist")
+	}
+}
+
+func TestUpdateConfigMap(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	config, _ := cm.CreateConfigMap("app-config", map[string]string{"key": "value"})
+	oldHash := config.Hash
+
+	updated, err := cm.UpdateConfigMap("app-config", map[string]string{"key": "new-value"})
+	if err != nil {
+		t.Fatalf("failed to update configmap: %v", err)
+	}
+
+	if updated.Data["key"] != "new-value" {
+		t.Error("expected updated value")
+	}
+	if updated.Hash == oldHash {
+		t.Error("expected hash to change")
+	}
+}
+
+func TestUpdateImmutableConfigMap(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	config, _ := cm.CreateConfigMap("app-config", map[string]string{"key": "value"})
+	config.Immutable = true
+
+	_, err := cm.UpdateConfigMap("app-config", map[string]string{"key": "new-value"})
+	if err == nil {
+		t.Error("expected error for immutable configmap")
+	}
+}
+
+func TestDeleteConfigMap(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	_, _ = cm.CreateConfigMap("app-config", map[string]string{"key": "value"})
+
+	err := cm.DeleteConfigMap("app-config")
+	if err != nil {
+		t.Fatalf("failed to delete configmap: %v", err)
+	}
+
+	_, exists := cm.GetConfigMap("app-config")
+	if exists {
+		t.Error("expected configmap to be deleted")
+	}
+
+	err = cm.DeleteConfigMap("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent configmap")
+	}
+}
+
+func TestListConfigMaps(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	_, _ = cm.CreateConfigMap("config-a", map[string]string{"a": "1"})
+	_, _ = cm.CreateConfigMap("config-b", map[string]string{"b": "2"})
+	_, _ = cm.CreateConfigMap("config-c", map[string]string{"c": "3"})
+
+	configs := cm.ListConfigMaps()
+
+	if len(configs) != 3 {
+		t.Errorf("expected 3 configmaps, got %d", len(configs))
+	}
+
+	// Should be sorted
+	if configs[0].Name != "config-a" {
+		t.Error("expected configs to be sorted")
+	}
+}
+
+func TestConfigMapToManifest(t *testing.T) {
+	cm := NewConfigMapManager("default")
+
+	config, _ := cm.CreateConfigMap("app-config", map[string]string{"key": "value"})
+
+	manifest := config.ToManifest()
+
+	if manifest.Kind != KindConfigMap {
+		t.Errorf("expected kind ConfigMap, got %s", manifest.Kind)
+	}
+	if manifest.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1, got %s", manifest.APIVersion)
+	}
+	if manifest.Metadata.Name != "app-config" {
+		t.Errorf("expected name 'app-config', got '%s'", manifest.Metadata.Name)
+	}
+	if manifest.Metadata.Annotations["vaultaire.io/hash"] == "" {
+		t.Error("expected hash annotation")
+	}
+}
+
+// Secret Manager Tests
+
+func TestNewSecretManager(t *testing.T) {
+	key, _ := GenerateEncryptionKey()
+	sm := NewSecretManager("default", key)
+
+	if sm.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", sm.namespace)
+	}
+}
+
+func TestCreateSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	data := map[string]string{
+		"username": "admin",
+		"password": "secret123",
+	}
+
+	secret, err := sm.CreateSecret("db-credentials", data, SecretTypeOpaque)
+	if err != nil {
+		t.Fatalf("failed to create secret: %v", err)
+	}
+
+	if secret.Name != "db-credentials" {
+		t.Errorf("expected name 'db-credentials', got '%s'", secret.Name)
+	}
+	if secret.Type != SecretTypeOpaque {
+		t.Errorf("expected type Opaque, got %s", secret.Type)
+	}
+	if string(secret.Data["username"]) != "admin" {
+		t.Error("expected username data")
+	}
+}
+
+func TestCreateSecretEmptyName(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, err := sm.CreateSecret("", map[string]string{"key": "value"}, SecretTypeOpaque)
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestCreateSecretDefaultType(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, err := sm.CreateSecret("test", map[string]string{"key": "value"}, "")
+	if err != nil {
+		t.Fatalf("failed to create secret: %v", err)
+	}
+
+	if secret.Type != SecretTypeOpaque {
+		t.Errorf("expected default type Opaque, got %s", secret.Type)
+	}
+}
+
+func TestCreateTLSSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	// Create temp cert and key files
+	tmpDir, err := os.MkdirTemp("", "secret-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	certPath := filepath.Join(tmpDir, "tls.crt")
+	keyPath := filepath.Join(tmpDir, "tls.key")
+
+	if err := os.WriteFile(certPath, []byte("CERT_CONTENT"), 0644); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("KEY_CONTENT"), 0600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+
+	secret, err := sm.CreateTLSSecret("tls-secret", certPath, keyPath)
+	if err != nil {
+		t.Fatalf("failed to create TLS secret: %v", err)
+	}
+
+	if secret.Type != SecretTypeTLS {
+		t.Errorf("expected type kubernetes.io/tls, got %s", secret.Type)
+	}
+	if string(secret.Data["tls.crt"]) != "CERT_CONTENT" {
+		t.Error("expected tls.crt content")
+	}
+	if string(secret.Data["tls.key"]) != "KEY_CONTENT" {
+		t.Error("expected tls.key content")
+	}
+}
+
+func TestCreateDockerConfigSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	registries := map[string]DockerRegistryAuth{
+		"docker.io": {
+			Username: "user",
+			Password: "pass",
+			Email:    "user@example.com",
+		},
+	}
+
+	secret, err := sm.CreateDockerConfigSecret("docker-secret", registries)
+	if err != nil {
+		t.Fatalf("failed to create docker config secret: %v", err)
+	}
+
+	if secret.Type != SecretTypeDockerConfigJSON {
+		t.Errorf("expected type dockerconfigjson, got %s", secret.Type)
+	}
+	if _, ok := secret.Data[".dockerconfigjson"]; !ok {
+		t.Error("expected .dockerconfigjson key")
+	}
+}
+
+func TestCreateBasicAuthSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, err := sm.CreateBasicAuthSecret("basic-auth", "admin", "password123")
+	if err != nil {
+		t.Fatalf("failed to create basic auth secret: %v", err)
+	}
+
+	if secret.Type != SecretTypeBasicAuth {
+		t.Errorf("expected type basic-auth, got %s", secret.Type)
+	}
+	if string(secret.Data["username"]) != "admin" {
+		t.Error("expected username")
+	}
+	if string(secret.Data["password"]) != "password123" {
+		t.Error("expected password")
+	}
+}
+
+func TestCreateSSHAuthSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, err := sm.CreateSSHAuthSecret("ssh-auth", "PRIVATE_KEY_CONTENT")
+	if err != nil {
+		t.Fatalf("failed to create SSH auth secret: %v", err)
+	}
+
+	if secret.Type != SecretTypeSSHAuth {
+		t.Errorf("expected type ssh-auth, got %s", secret.Type)
+	}
+	if string(secret.Data["ssh-privatekey"]) != "PRIVATE_KEY_CONTENT" {
+		t.Error("expected ssh-privatekey")
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, _ = sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+
+	secret, exists := sm.GetSecret("test-secret")
+	if !exists {
+		t.Error("expected secret to exist")
+	}
+	if secret.Name != "test-secret" {
+		t.Errorf("expected name 'test-secret', got '%s'", secret.Name)
+	}
+
+	_, exists = sm.GetSecret("nonexistent")
+	if exists {
+		t.Error("expected secret to not exist")
+	}
+}
+
+func TestUpdateSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, _ := sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+	oldVersion := secret.Version
+
+	updated, err := sm.UpdateSecret("test-secret", map[string]string{"key": "new-value"})
+	if err != nil {
+		t.Fatalf("failed to update secret: %v", err)
+	}
+
+	if string(updated.Data["key"]) != "new-value" {
+		t.Error("expected updated value")
+	}
+	if updated.Version != oldVersion+1 {
+		t.Error("expected version to increment")
+	}
+}
+
+func TestRotateSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, _ := sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+	oldVersion := secret.Version
+
+	rotated, err := sm.RotateSecret("test-secret", map[string]string{"key": "rotated-value"})
+	if err != nil {
+		t.Fatalf("failed to rotate secret: %v", err)
+	}
+
+	if string(rotated.Data["key"]) != "rotated-value" {
+		t.Error("expected rotated value")
+	}
+	if rotated.Version != oldVersion+1 {
+		t.Error("expected version to increment")
+	}
+	if rotated.Annotations["vaultaire.io/previous-version"] == "" {
+		t.Error("expected previous version annotation")
+	}
+	if rotated.Annotations["vaultaire.io/rotated-at"] == "" {
+		t.Error("expected rotated-at annotation")
+	}
+}
+
+func TestDeleteSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, _ = sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+
+	err := sm.DeleteSecret("test-secret")
+	if err != nil {
+		t.Fatalf("failed to delete secret: %v", err)
+	}
+
+	_, exists := sm.GetSecret("test-secret")
+	if exists {
+		t.Error("expected secret to be deleted")
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, _ = sm.CreateSecret("secret-a", map[string]string{"a": "1"}, SecretTypeOpaque)
+	_, _ = sm.CreateSecret("secret-b", map[string]string{"b": "2"}, SecretTypeOpaque)
+	_, _ = sm.CreateSecret("secret-c", map[string]string{"c": "3"}, SecretTypeOpaque)
+
+	secrets := sm.ListSecrets()
+
+	if len(secrets) != 3 {
+		t.Errorf("expected 3 secrets, got %d", len(secrets))
+	}
+
+	// Should be sorted
+	if secrets[0].Name != "secret-a" {
+		t.Error("expected secrets to be sorted")
+	}
+}
+
+func TestSecretToManifest(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	secret, _ := sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+
+	manifest := secret.ToManifest()
+
+	if manifest.Kind != KindSecret {
+		t.Errorf("expected kind Secret, got %s", manifest.Kind)
+	}
+	if manifest.Type != string(SecretTypeOpaque) {
+		t.Errorf("expected type Opaque, got %s", manifest.Type)
+	}
+	if manifest.Metadata.Annotations["vaultaire.io/hash"] == "" {
+		t.Error("expected hash annotation")
+	}
+	if manifest.Metadata.Annotations["vaultaire.io/version"] == "" {
+		t.Error("expected version annotation")
+	}
+}
+
+func TestEncryptDecryptSecret(t *testing.T) {
+	key, err := GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	sm := NewSecretManager("default", key)
+
+	_, _ = sm.CreateSecret("test-secret", map[string]string{
+		"password": "super-secret",
+	}, SecretTypeOpaque)
+
+	// Encrypt
+	if err := sm.EncryptSecret("test-secret"); err != nil {
+		t.Fatalf("failed to encrypt: %v", err)
+	}
+
+	secret, _ := sm.GetSecret("test-secret")
+	if !secret.Encrypted {
+		t.Error("expected secret to be marked as encrypted")
+	}
+
+	// Decrypt
+	decrypted, err := sm.DecryptSecret("test-secret")
+	if err != nil {
+		t.Fatalf("failed to decrypt: %v", err)
+	}
+
+	if string(decrypted["password"]) != "super-secret" {
+		t.Errorf("expected 'super-secret', got '%s'", string(decrypted["password"]))
+	}
+}
+
+func TestEncryptSecretNoKey(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, _ = sm.CreateSecret("test-secret", map[string]string{"key": "value"}, SecretTypeOpaque)
+
+	err := sm.EncryptSecret("test-secret")
+	if err == nil {
+		t.Error("expected error when encrypting without key")
+	}
+}
+
+func TestSealUnsealSecret(t *testing.T) {
+	key, _ := GenerateEncryptionKey()
+	sm := NewSecretManager("default", key)
+
+	_, _ = sm.CreateSecret("test-secret", map[string]string{
+		"api-key": "secret-api-key",
+	}, SecretTypeOpaque)
+
+	// Seal
+	sealed, err := sm.SealSecret("test-secret")
+	if err != nil {
+		t.Fatalf("failed to seal: %v", err)
+	}
+
+	if sealed.Name != "test-secret" {
+		t.Error("expected sealed secret name")
+	}
+	if len(sealed.EncryptedData) != 1 {
+		t.Error("expected encrypted data")
+	}
+
+	// Delete original
+	_ = sm.DeleteSecret("test-secret")
+
+	// Unseal
+	unsealed, err := sm.UnsealSecret(sealed)
+	if err != nil {
+		t.Fatalf("failed to unseal: %v", err)
+	}
+
+	if string(unsealed.Data["api-key"]) != "secret-api-key" {
+		t.Error("expected unsealed data to match original")
+	}
+}
+
+func TestSealedSecretToYAML(t *testing.T) {
+	sealed := &SealedSecret{
+		Name:      "test-secret",
+		Namespace: "default",
+		EncryptedData: map[string]string{
+			"key": "encrypted-value",
+		},
+		Type:      SecretTypeOpaque,
+		CreatedAt: time.Now(),
+	}
+
+	yaml, err := sealed.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if yaml == "" {
+		t.Error("expected non-empty YAML")
+	}
+}
+
+func TestDeriveEncryptionKey(t *testing.T) {
+	key := DeriveEncryptionKey("password123", "salt-value")
+
+	if len(key) != 32 {
+		t.Errorf("expected 32-byte key, got %d", len(key))
+	}
+
+	// Same inputs should produce same key
+	key2 := DeriveEncryptionKey("password123", "salt-value")
+	for i := range key {
+		if key[i] != key2[i] {
+			t.Error("expected deterministic key derivation")
+			break
+		}
+	}
+
+	// Different salt should produce different key
+	key3 := DeriveEncryptionKey("password123", "different-salt")
+	same := true
+	for i := range key {
+		if key[i] != key3[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("expected different salt to produce different key")
+	}
+}
+
+func TestGenerateEncryptionKey(t *testing.T) {
+	key, err := GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	if len(key) != 32 {
+		t.Errorf("expected 32-byte key, got %d", len(key))
+	}
+
+	// Should be random
+	key2, _ := GenerateEncryptionKey()
+	same := true
+	for i := range key {
+		if key[i] != key2[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("expected random keys to be different")
+	}
+}
+
+func TestParseEnvFile(t *testing.T) {
+	content := `
+# This is a comment
+DB_HOST=localhost
+DB_PORT=5432
+API_KEY="quoted-value"
+SINGLE_QUOTE='single'
+EMPTY=
+SPACES_IN_VALUE=hello world
+`
+
+	result := parseEnvFile(content)
+
+	tests := map[string]string{
+		"DB_HOST":         "localhost",
+		"DB_PORT":         "5432",
+		"API_KEY":         "quoted-value",
+		"SINGLE_QUOTE":    "single",
+		"EMPTY":           "",
+		"SPACES_IN_VALUE": "hello world",
+	}
+
+	for key, expected := range tests {
+		if result[key] != expected {
+			t.Errorf("expected %s='%s', got '%s'", key, expected, result[key])
+		}
+	}
+}
+
+func TestEnvSubstitution(t *testing.T) {
+	// Set test env vars
+	if err := os.Setenv("TEST_VAR", "test-value"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+	defer func() {
+		_ = os.Unsetenv("TEST_VAR")
+	}()
+
+	data := map[string]string{
+		"key1": "prefix-${TEST_VAR}-suffix",
+		"key2": "${TEST_VAR}",
+		"key3": "${NONEXISTENT}",
+		"key4": "no-vars",
+	}
+
+	result := EnvSubstitution(data)
+
+	if result["key1"] != "prefix-test-value-suffix" {
+		t.Errorf("expected 'prefix-test-value-suffix', got '%s'", result["key1"])
+	}
+	if result["key2"] != "test-value" {
+		t.Errorf("expected 'test-value', got '%s'", result["key2"])
+	}
+	if result["key3"] != "${NONEXISTENT}" {
+		t.Errorf("expected '${NONEXISTENT}' (unchanged), got '%s'", result["key3"])
+	}
+	if result["key4"] != "no-vars" {
+		t.Errorf("expected 'no-vars', got '%s'", result["key4"])
+	}
+}
+
+func TestMergeConfigMaps(t *testing.T) {
+	config1 := &ConfigMapData{
+		Name:      "config1",
+		Namespace: "default",
+		Data:      map[string]string{"key1": "value1"},
+		Labels:    map[string]string{"app": "test"},
+	}
+
+	config2 := &ConfigMapData{
+		Name:      "config2",
+		Namespace: "default",
+		Data:      map[string]string{"key2": "value2", "key1": "overwritten"},
+	}
+
+	merged := MergeConfigMaps("merged", config1, config2)
+
+	if merged.Name != "merged" {
+		t.Errorf("expected name 'merged', got '%s'", merged.Name)
+	}
+	if merged.Data["key1"] != "overwritten" {
+		t.Error("expected later value to override")
+	}
+	if merged.Data["key2"] != "value2" {
+		t.Error("expected key2 from config2")
+	}
+	if merged.Labels["app"] != "test" {
+		t.Error("expected labels to be merged")
+	}
+}
+
+func TestMergeConfigMapsWithNil(t *testing.T) {
+	config1 := &ConfigMapData{
+		Name: "config1",
+		Data: map[string]string{"key1": "value1"},
+	}
+
+	merged := MergeConfigMaps("merged", config1, nil)
+
+	if merged.Data["key1"] != "value1" {
+		t.Error("expected key1 from config1")
+	}
+}
+
+func TestValidateSecretData(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretType SecretType
+		data       map[string]string
+		expectErr  bool
+	}{
+		{
+			name:       "valid TLS",
+			secretType: SecretTypeTLS,
+			data:       map[string]string{"tls.crt": "cert", "tls.key": "key"},
+			expectErr:  false,
+		},
+		{
+			name:       "invalid TLS missing cert",
+			secretType: SecretTypeTLS,
+			data:       map[string]string{"tls.key": "key"},
+			expectErr:  true,
+		},
+		{
+			name:       "invalid TLS missing key",
+			secretType: SecretTypeTLS,
+			data:       map[string]string{"tls.crt": "cert"},
+			expectErr:  true,
+		},
+		{
+			name:       "valid docker config",
+			secretType: SecretTypeDockerConfigJSON,
+			data:       map[string]string{".dockerconfigjson": "{}"},
+			expectErr:  false,
+		},
+		{
+			name:       "invalid docker config",
+			secretType: SecretTypeDockerConfigJSON,
+			data:       map[string]string{},
+			expectErr:  true,
+		},
+		{
+			name:       "valid basic auth",
+			secretType: SecretTypeBasicAuth,
+			data:       map[string]string{"username": "user", "password": "pass"},
+			expectErr:  false,
+		},
+		{
+			name:       "invalid basic auth",
+			secretType: SecretTypeBasicAuth,
+			data:       map[string]string{"username": "user"},
+			expectErr:  true,
+		},
+		{
+			name:       "valid SSH auth",
+			secretType: SecretTypeSSHAuth,
+			data:       map[string]string{"ssh-privatekey": "key"},
+			expectErr:  false,
+		},
+		{
+			name:       "invalid SSH auth",
+			secretType: SecretTypeSSHAuth,
+			data:       map[string]string{},
+			expectErr:  true,
+		},
+		{
+			name:       "opaque no validation",
+			secretType: SecretTypeOpaque,
+			data:       map[string]string{},
+			expectErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSecretData(tt.secretType, tt.data)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestConfigWatcher(t *testing.T) {
+	cm := NewConfigMapManager("default")
+	sm := NewSecretManager("default", nil)
+
+	watcher := NewConfigWatcher(50 * time.Millisecond)
+
+	changeDetected := make(chan string, 1)
+	watcher.Watch("test-config", func(name, oldHash, newHash string) {
+		changeDetected <- name
+	})
+
+	// Create initial config
+	_, _ = cm.CreateConfigMap("test-config", map[string]string{"key": "value"})
+
+	watcher.Start(cm, sm)
+	defer watcher.Stop()
+
+	// Wait for initial hash to be recorded
+	time.Sleep(100 * time.Millisecond)
+
+	// Update config
+	_, _ = cm.UpdateConfigMap("test-config", map[string]string{"key": "new-value"})
+
+	// Wait for change detection
+	select {
+	case name := <-changeDetected:
+		if name != "test-config" {
+			t.Errorf("expected 'test-config', got '%s'", name)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Error("timeout waiting for change detection")
+	}
+}
+
+// Mock external secret source for testing
+type mockExternalSource struct {
+	secrets map[string]map[string][]byte
+}
+
+func (m *mockExternalSource) GetSecret(_ context.Context, path string) (map[string][]byte, error) {
+	if data, ok := m.secrets[path]; ok {
+		return data, nil
+	}
+	return nil, fmt.Errorf("secret not found: %s", path)
+}
+
+func (m *mockExternalSource) ListSecrets(_ context.Context, prefix string) ([]string, error) {
+	var result []string
+	for k := range m.secrets {
+		result = append(result, k)
+	}
+	return result, nil
+}
+
+func (m *mockExternalSource) Name() string {
+	return "mock"
+}
+
+func TestFetchExternalSecret(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	mockSource := &mockExternalSource{
+		secrets: map[string]map[string][]byte{
+			"secret/data/myapp": {
+				"username": []byte("admin"),
+				"password": []byte("secret123"),
+			},
+		},
+	}
+	sm.SetExternalSource(mockSource)
+
+	secret, err := sm.FetchExternalSecret(context.Background(), "myapp-secret", "secret/data/myapp", SecretTypeOpaque)
+	if err != nil {
+		t.Fatalf("failed to fetch external secret: %v", err)
+	}
+
+	if string(secret.Data["username"]) != "admin" {
+		t.Error("expected username from external source")
+	}
+	if secret.Annotations["vaultaire.io/external-source"] != "mock" {
+		t.Error("expected external source annotation")
+	}
+}
+
+func TestFetchExternalSecretNoSource(t *testing.T) {
+	sm := NewSecretManager("default", nil)
+
+	_, err := sm.FetchExternalSecret(context.Background(), "test", "path", SecretTypeOpaque)
+	if err == nil {
+		t.Error("expected error when no external source configured")
+	}
+}
+
+func TestCopyStringMap(t *testing.T) {
+	original := map[string]string{"a": "1", "b": "2"}
+	copied := copyStringMap(original)
+
+	// Modify copy
+	copied["c"] = "3"
+
+	// Original should be unchanged
+	if _, ok := original["c"]; ok {
+		t.Error("original should not be modified")
+	}
+}
+
+func TestCopyStringMapNil(t *testing.T) {
+	result := copyStringMap(nil)
+	if result != nil {
+		t.Error("expected nil for nil input")
+	}
+}

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -1,0 +1,1134 @@
+// internal/k8s/helm.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// HelmChart represents a Helm chart structure
+type HelmChart struct {
+	Name         string
+	Version      string
+	AppVersion   string
+	Description  string
+	Type         string // application or library
+	Keywords     []string
+	Home         string
+	Sources      []string
+	Maintainers  []ChartMaintainer
+	Icon         string
+	Deprecated   bool
+	KubeVersion  string
+	Dependencies []ChartDependency
+}
+
+// ChartMaintainer represents a chart maintainer
+type ChartMaintainer struct {
+	Name  string `yaml:"name"`
+	Email string `yaml:"email,omitempty"`
+	URL   string `yaml:"url,omitempty"`
+}
+
+// ChartDependency represents a chart dependency
+type ChartDependency struct {
+	Name       string   `yaml:"name"`
+	Version    string   `yaml:"version"`
+	Repository string   `yaml:"repository"`
+	Condition  string   `yaml:"condition,omitempty"`
+	Tags       []string `yaml:"tags,omitempty"`
+	Alias      string   `yaml:"alias,omitempty"`
+}
+
+// ChartYAML represents Chart.yaml structure
+type ChartYAML struct {
+	APIVersion   string            `yaml:"apiVersion"`
+	Name         string            `yaml:"name"`
+	Version      string            `yaml:"version"`
+	AppVersion   string            `yaml:"appVersion,omitempty"`
+	Description  string            `yaml:"description,omitempty"`
+	Type         string            `yaml:"type,omitempty"`
+	Keywords     []string          `yaml:"keywords,omitempty"`
+	Home         string            `yaml:"home,omitempty"`
+	Sources      []string          `yaml:"sources,omitempty"`
+	Maintainers  []ChartMaintainer `yaml:"maintainers,omitempty"`
+	Icon         string            `yaml:"icon,omitempty"`
+	Deprecated   bool              `yaml:"deprecated,omitempty"`
+	KubeVersion  string            `yaml:"kubeVersion,omitempty"`
+	Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
+}
+
+// HelmValues represents values.yaml structure for Vaultaire
+type HelmValues struct {
+	ReplicaCount       int                      `yaml:"replicaCount"`
+	Image              ImageConfig              `yaml:"image"`
+	ImagePullSecrets   []NameRef                `yaml:"imagePullSecrets,omitempty"`
+	NameOverride       string                   `yaml:"nameOverride,omitempty"`
+	FullnameOverride   string                   `yaml:"fullnameOverride,omitempty"`
+	ServiceAccount     ServiceAccountConfig     `yaml:"serviceAccount"`
+	PodAnnotations     map[string]string        `yaml:"podAnnotations,omitempty"`
+	PodSecurityContext PodSecurityContextConfig `yaml:"podSecurityContext,omitempty"`
+	SecurityContext    SecurityContextConfig    `yaml:"securityContext,omitempty"`
+	Service            ServiceConfig            `yaml:"service"`
+	Ingress            IngressConfig            `yaml:"ingress"`
+	Resources          ResourceConfig           `yaml:"resources,omitempty"`
+	Autoscaling        AutoscalingConfig        `yaml:"autoscaling"`
+	NodeSelector       map[string]string        `yaml:"nodeSelector,omitempty"`
+	Tolerations        []TolerationConfig       `yaml:"tolerations,omitempty"`
+	Affinity           map[string]interface{}   `yaml:"affinity,omitempty"`
+	Env                []EnvConfig              `yaml:"env,omitempty"`
+	EnvFrom            []EnvFromConfig          `yaml:"envFrom,omitempty"`
+	Persistence        PersistenceConfig        `yaml:"persistence"`
+	Config             map[string]interface{}   `yaml:"config,omitempty"`
+	Secrets            map[string]string        `yaml:"secrets,omitempty"`
+	Probes             ProbesConfig             `yaml:"probes"`
+	Metrics            MetricsConfig            `yaml:"metrics"`
+	PostgreSQL         PostgreSQLConfig         `yaml:"postgresql"`
+	Redis              RedisConfig              `yaml:"redis"`
+}
+
+// ImageConfig for container image settings
+type ImageConfig struct {
+	Repository string `yaml:"repository"`
+	Tag        string `yaml:"tag"`
+	PullPolicy string `yaml:"pullPolicy"`
+}
+
+// NameRef for simple name references
+type NameRef struct {
+	Name string `yaml:"name"`
+}
+
+// ServiceAccountConfig for service account settings
+type ServiceAccountConfig struct {
+	Create      bool              `yaml:"create"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Name        string            `yaml:"name,omitempty"`
+}
+
+// PodSecurityContextConfig for pod security
+type PodSecurityContextConfig struct {
+	FSGroup      int64 `yaml:"fsGroup,omitempty"`
+	RunAsUser    int64 `yaml:"runAsUser,omitempty"`
+	RunAsGroup   int64 `yaml:"runAsGroup,omitempty"`
+	RunAsNonRoot bool  `yaml:"runAsNonRoot,omitempty"`
+}
+
+// SecurityContextConfig for container security
+type SecurityContextConfig struct {
+	AllowPrivilegeEscalation bool      `yaml:"allowPrivilegeEscalation"`
+	ReadOnlyRootFilesystem   bool      `yaml:"readOnlyRootFilesystem"`
+	RunAsNonRoot             bool      `yaml:"runAsNonRoot"`
+	RunAsUser                int64     `yaml:"runAsUser,omitempty"`
+	Capabilities             CapConfig `yaml:"capabilities,omitempty"`
+}
+
+// CapConfig for Linux capabilities
+type CapConfig struct {
+	Drop []string `yaml:"drop,omitempty"`
+	Add  []string `yaml:"add,omitempty"`
+}
+
+// ServiceConfig for Kubernetes service
+type ServiceConfig struct {
+	Type string `yaml:"type"`
+	Port int    `yaml:"port"`
+}
+
+// IngressConfig for Kubernetes ingress
+type IngressConfig struct {
+	Enabled     bool              `yaml:"enabled"`
+	ClassName   string            `yaml:"className,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Hosts       []IngressHost     `yaml:"hosts,omitempty"`
+	TLS         []IngressTLS      `yaml:"tls,omitempty"`
+}
+
+// IngressHost for ingress host config
+type IngressHost struct {
+	Host  string        `yaml:"host"`
+	Paths []IngressPath `yaml:"paths"`
+}
+
+// IngressPath for ingress path config
+type IngressPath struct {
+	Path     string `yaml:"path"`
+	PathType string `yaml:"pathType"`
+}
+
+// IngressTLS for ingress TLS config
+type IngressTLS struct {
+	SecretName string   `yaml:"secretName"`
+	Hosts      []string `yaml:"hosts"`
+}
+
+// ResourceConfig for resource limits/requests
+type ResourceConfig struct {
+	Limits   map[string]string `yaml:"limits,omitempty"`
+	Requests map[string]string `yaml:"requests,omitempty"`
+}
+
+// AutoscalingConfig for HPA
+type AutoscalingConfig struct {
+	Enabled                           bool `yaml:"enabled"`
+	MinReplicas                       int  `yaml:"minReplicas"`
+	MaxReplicas                       int  `yaml:"maxReplicas"`
+	TargetCPUUtilizationPercentage    int  `yaml:"targetCPUUtilizationPercentage,omitempty"`
+	TargetMemoryUtilizationPercentage int  `yaml:"targetMemoryUtilizationPercentage,omitempty"`
+}
+
+// TolerationConfig for node tolerations
+type TolerationConfig struct {
+	Key      string `yaml:"key,omitempty"`
+	Operator string `yaml:"operator,omitempty"`
+	Value    string `yaml:"value,omitempty"`
+	Effect   string `yaml:"effect,omitempty"`
+}
+
+// EnvConfig for environment variables
+type EnvConfig struct {
+	Name      string        `yaml:"name"`
+	Value     string        `yaml:"value,omitempty"`
+	ValueFrom *EnvValueFrom `yaml:"valueFrom,omitempty"`
+}
+
+// EnvValueFrom for env var sources
+type EnvValueFrom struct {
+	SecretKeyRef    *KeyRefConfig `yaml:"secretKeyRef,omitempty"`
+	ConfigMapKeyRef *KeyRefConfig `yaml:"configMapKeyRef,omitempty"`
+}
+
+// KeyRefConfig for key references
+type KeyRefConfig struct {
+	Name string `yaml:"name"`
+	Key  string `yaml:"key"`
+}
+
+// EnvFromConfig for bulk env sources
+type EnvFromConfig struct {
+	SecretRef    *NameRef `yaml:"secretRef,omitempty"`
+	ConfigMapRef *NameRef `yaml:"configMapRef,omitempty"`
+}
+
+// PersistenceConfig for persistent storage
+type PersistenceConfig struct {
+	Enabled      bool              `yaml:"enabled"`
+	StorageClass string            `yaml:"storageClass,omitempty"`
+	AccessModes  []string          `yaml:"accessModes"`
+	Size         string            `yaml:"size"`
+	Annotations  map[string]string `yaml:"annotations,omitempty"`
+}
+
+// ProbesConfig for health probes
+type ProbesConfig struct {
+	Liveness  ProbeConfig `yaml:"liveness"`
+	Readiness ProbeConfig `yaml:"readiness"`
+	Startup   ProbeConfig `yaml:"startup,omitempty"`
+}
+
+// ProbeConfig for individual probe
+type ProbeConfig struct {
+	Enabled             bool   `yaml:"enabled"`
+	Path                string `yaml:"path,omitempty"`
+	Port                int    `yaml:"port,omitempty"`
+	InitialDelaySeconds int    `yaml:"initialDelaySeconds,omitempty"`
+	PeriodSeconds       int    `yaml:"periodSeconds,omitempty"`
+	TimeoutSeconds      int    `yaml:"timeoutSeconds,omitempty"`
+	FailureThreshold    int    `yaml:"failureThreshold,omitempty"`
+	SuccessThreshold    int    `yaml:"successThreshold,omitempty"`
+}
+
+// MetricsConfig for Prometheus metrics
+type MetricsConfig struct {
+	Enabled        bool                 `yaml:"enabled"`
+	Port           int                  `yaml:"port"`
+	ServiceMonitor ServiceMonitorConfig `yaml:"serviceMonitor"`
+}
+
+// ServiceMonitorConfig for Prometheus ServiceMonitor
+type ServiceMonitorConfig struct {
+	Enabled   bool              `yaml:"enabled"`
+	Namespace string            `yaml:"namespace,omitempty"`
+	Labels    map[string]string `yaml:"labels,omitempty"`
+	Interval  string            `yaml:"interval,omitempty"`
+}
+
+// PostgreSQLConfig for PostgreSQL subchart
+type PostgreSQLConfig struct {
+	Enabled  bool              `yaml:"enabled"`
+	Auth     PostgreSQLAuth    `yaml:"auth,omitempty"`
+	Primary  PostgreSQLPrimary `yaml:"primary,omitempty"`
+	External ExternalDB        `yaml:"external,omitempty"`
+}
+
+// PostgreSQLAuth for PostgreSQL authentication
+type PostgreSQLAuth struct {
+	Username       string            `yaml:"username,omitempty"`
+	Password       string            `yaml:"password,omitempty"`
+	Database       string            `yaml:"database,omitempty"`
+	ExistingSecret string            `yaml:"existingSecret,omitempty"`
+	SecretKeys     map[string]string `yaml:"secretKeys,omitempty"`
+}
+
+// PostgreSQLPrimary for PostgreSQL primary config
+type PostgreSQLPrimary struct {
+	Persistence PersistenceConfig `yaml:"persistence,omitempty"`
+}
+
+// ExternalDB for external database config
+type ExternalDB struct {
+	Host     string `yaml:"host,omitempty"`
+	Port     int    `yaml:"port,omitempty"`
+	Database string `yaml:"database,omitempty"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// RedisConfig for Redis subchart
+type RedisConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Auth     RedisAuth     `yaml:"auth,omitempty"`
+	Master   RedisMaster   `yaml:"master,omitempty"`
+	External ExternalRedis `yaml:"external,omitempty"`
+}
+
+// RedisAuth for Redis authentication
+type RedisAuth struct {
+	Enabled        bool   `yaml:"enabled"`
+	Password       string `yaml:"password,omitempty"`
+	ExistingSecret string `yaml:"existingSecret,omitempty"`
+}
+
+// RedisMaster for Redis master config
+type RedisMaster struct {
+	Persistence PersistenceConfig `yaml:"persistence,omitempty"`
+}
+
+// ExternalRedis for external Redis config
+type ExternalRedis struct {
+	Host     string `yaml:"host,omitempty"`
+	Port     int    `yaml:"port,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// HelmChartGenerator generates Helm charts
+type HelmChartGenerator struct {
+	Chart  HelmChart
+	Values HelmValues
+}
+
+// NewHelmChartGenerator creates a new Helm chart generator
+func NewHelmChartGenerator(name, version, appVersion string) *HelmChartGenerator {
+	return &HelmChartGenerator{
+		Chart: HelmChart{
+			Name:        name,
+			Version:     version,
+			AppVersion:  appVersion,
+			Description: fmt.Sprintf("A Helm chart for %s", name),
+			Type:        "application",
+			KubeVersion: ">= 1.19.0-0",
+		},
+		Values: DefaultHelmValues(),
+	}
+}
+
+// DefaultHelmValues returns default values for Vaultaire
+func DefaultHelmValues() HelmValues {
+	return HelmValues{
+		ReplicaCount: 1,
+		Image: ImageConfig{
+			Repository: "ghcr.io/fairforge/vaultaire",
+			Tag:        "latest",
+			PullPolicy: "IfNotPresent",
+		},
+		ServiceAccount: ServiceAccountConfig{
+			Create: true,
+		},
+		PodSecurityContext: PodSecurityContextConfig{
+			FSGroup:      1000,
+			RunAsNonRoot: true,
+		},
+		SecurityContext: SecurityContextConfig{
+			AllowPrivilegeEscalation: false,
+			ReadOnlyRootFilesystem:   true,
+			RunAsNonRoot:             true,
+			RunAsUser:                1000,
+			Capabilities: CapConfig{
+				Drop: []string{"ALL"},
+			},
+		},
+		Service: ServiceConfig{
+			Type: "ClusterIP",
+			Port: 80,
+		},
+		Ingress: IngressConfig{
+			Enabled: false,
+			Hosts: []IngressHost{
+				{
+					Host: "vaultaire.local",
+					Paths: []IngressPath{
+						{Path: "/", PathType: "Prefix"},
+					},
+				},
+			},
+		},
+		Resources: ResourceConfig{
+			Limits: map[string]string{
+				"cpu":    "1000m",
+				"memory": "1Gi",
+			},
+			Requests: map[string]string{
+				"cpu":    "100m",
+				"memory": "128Mi",
+			},
+		},
+		Autoscaling: AutoscalingConfig{
+			Enabled:                        false,
+			MinReplicas:                    1,
+			MaxReplicas:                    10,
+			TargetCPUUtilizationPercentage: 80,
+		},
+		Persistence: PersistenceConfig{
+			Enabled:     false,
+			AccessModes: []string{"ReadWriteOnce"},
+			Size:        "10Gi",
+		},
+		Probes: ProbesConfig{
+			Liveness: ProbeConfig{
+				Enabled:             true,
+				Path:                "/health",
+				Port:                8080,
+				InitialDelaySeconds: 30,
+				PeriodSeconds:       10,
+				TimeoutSeconds:      5,
+				FailureThreshold:    3,
+			},
+			Readiness: ProbeConfig{
+				Enabled:             true,
+				Path:                "/ready",
+				Port:                8080,
+				InitialDelaySeconds: 5,
+				PeriodSeconds:       5,
+				TimeoutSeconds:      3,
+				FailureThreshold:    3,
+			},
+		},
+		Metrics: MetricsConfig{
+			Enabled: true,
+			Port:    9090,
+			ServiceMonitor: ServiceMonitorConfig{
+				Enabled:  false,
+				Interval: "30s",
+			},
+		},
+		PostgreSQL: PostgreSQLConfig{
+			Enabled: true,
+			Auth: PostgreSQLAuth{
+				Username: "vaultaire",
+				Database: "vaultaire",
+			},
+			Primary: PostgreSQLPrimary{
+				Persistence: PersistenceConfig{
+					Enabled:     true,
+					Size:        "10Gi",
+					AccessModes: []string{"ReadWriteOnce"},
+				},
+			},
+		},
+		Redis: RedisConfig{
+			Enabled: true,
+			Auth: RedisAuth{
+				Enabled: true,
+			},
+			Master: RedisMaster{
+				Persistence: PersistenceConfig{
+					Enabled:     true,
+					Size:        "1Gi",
+					AccessModes: []string{"ReadWriteOnce"},
+				},
+			},
+		},
+	}
+}
+
+// WithMaintainer adds a maintainer to the chart
+func (g *HelmChartGenerator) WithMaintainer(name, email, url string) *HelmChartGenerator {
+	g.Chart.Maintainers = append(g.Chart.Maintainers, ChartMaintainer{
+		Name:  name,
+		Email: email,
+		URL:   url,
+	})
+	return g
+}
+
+// WithDependency adds a dependency to the chart
+func (g *HelmChartGenerator) WithDependency(name, version, repo string) *HelmChartGenerator {
+	g.Chart.Dependencies = append(g.Chart.Dependencies, ChartDependency{
+		Name:       name,
+		Version:    version,
+		Repository: repo,
+	})
+	return g
+}
+
+// WithKeywords adds keywords to the chart
+func (g *HelmChartGenerator) WithKeywords(keywords ...string) *HelmChartGenerator {
+	g.Chart.Keywords = append(g.Chart.Keywords, keywords...)
+	return g
+}
+
+// GenerateChartYAML generates Chart.yaml content
+func (g *HelmChartGenerator) GenerateChartYAML() (string, error) {
+	chart := ChartYAML{
+		APIVersion:   "v2",
+		Name:         g.Chart.Name,
+		Version:      g.Chart.Version,
+		AppVersion:   g.Chart.AppVersion,
+		Description:  g.Chart.Description,
+		Type:         g.Chart.Type,
+		Keywords:     g.Chart.Keywords,
+		Home:         g.Chart.Home,
+		Sources:      g.Chart.Sources,
+		Maintainers:  g.Chart.Maintainers,
+		Icon:         g.Chart.Icon,
+		KubeVersion:  g.Chart.KubeVersion,
+		Dependencies: g.Chart.Dependencies,
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(chart); err != nil {
+		return "", fmt.Errorf("failed to encode Chart.yaml: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// GenerateValuesYAML generates values.yaml content
+func (g *HelmChartGenerator) GenerateValuesYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(g.Values); err != nil {
+		return "", fmt.Errorf("failed to encode values.yaml: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// HelmTemplate represents a Helm template file
+type HelmTemplate struct {
+	Name    string
+	Content string
+}
+
+// GenerateTemplates generates all Helm template files
+func (g *HelmChartGenerator) GenerateTemplates() []HelmTemplate {
+	return []HelmTemplate{
+		{Name: "_helpers.tpl", Content: g.generateHelpersTpl()},
+		{Name: "serviceaccount.yaml", Content: g.generateServiceAccountTpl()},
+		{Name: "configmap.yaml", Content: g.generateConfigMapTpl()},
+		{Name: "secret.yaml", Content: g.generateSecretTpl()},
+		{Name: "deployment.yaml", Content: g.generateDeploymentTpl()},
+		{Name: "service.yaml", Content: g.generateServiceTpl()},
+		{Name: "ingress.yaml", Content: g.generateIngressTpl()},
+		{Name: "hpa.yaml", Content: g.generateHPATpl()},
+		{Name: "pvc.yaml", Content: g.generatePVCTpl()},
+		{Name: "servicemonitor.yaml", Content: g.generateServiceMonitorTpl()},
+		{Name: "NOTES.txt", Content: g.generateNotesTpl()},
+	}
+}
+
+func (g *HelmChartGenerator) generateHelpersTpl() string {
+	return `{{/*
+Expand the name of the chart.
+*/}}
+{{- define "` + g.Chart.Name + `.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "` + g.Chart.Name + `.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "` + g.Chart.Name + `.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "` + g.Chart.Name + `.labels" -}}
+helm.sh/chart: {{ include "` + g.Chart.Name + `.chart" . }}
+{{ include "` + g.Chart.Name + `.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "` + g.Chart.Name + `.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "` + g.Chart.Name + `.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "` + g.Chart.Name + `.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "` + g.Chart.Name + `.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name
+*/}}
+{{- define "` + g.Chart.Name + `.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateServiceAccountTpl() string {
+	return `{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "` + g.Chart.Name + `.serviceAccountName" . }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateConfigMapTpl() string {
+	return `{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}-config
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateSecretTpl() string {
+	return `{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}-secrets
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateDeploymentTpl() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "` + g.Chart.Name + `.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "` + g.Chart.Name + `.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "` + g.Chart.Name + `.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "` + g.Chart.Name + `.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: {{ .Values.probes.liveness.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: {{ .Values.probes.readiness.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.config }}
+            - name: config
+              mountPath: /etc/` + g.Chart.Name + `
+              readOnly: true
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "` + g.Chart.Name + `.fullname" . }}-config
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "` + g.Chart.Name + `.fullname" . }}-data
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateServiceTpl() string {
+	return `apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector:
+    {{- include "` + g.Chart.Name + `.selectorLabels" . | nindent 4 }}
+`
+}
+
+func (g *HelmChartGenerator) generateIngressTpl() string {
+	return `{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "` + g.Chart.Name + `.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateHPATpl() string {
+	return `{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generatePVCTpl() string {
+	return `{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}-data
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateServiceMonitorTpl() string {
+	return `{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "` + g.Chart.Name + `.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "` + g.Chart.Name + `.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "` + g.Chart.Name + `.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+{{- end }}
+`
+}
+
+func (g *HelmChartGenerator) generateNotesTpl() string {
+	return `1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "` + g.Chart.Name + `.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "` + g.Chart.Name + `.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "` + g.Chart.Name + `.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "` + g.Chart.Name + `.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+2. ` + g.Chart.Name + ` is now deployed!
+
+   Dashboard: kubectl port-forward svc/{{ include "` + g.Chart.Name + `.fullname" . }} 8080:{{ .Values.service.port }}
+   Metrics:   kubectl port-forward svc/{{ include "` + g.Chart.Name + `.fullname" . }} {{ .Values.metrics.port }}:{{ .Values.metrics.port }}
+`
+}
+
+// WriteToDirectory writes the complete Helm chart to a directory
+func (g *HelmChartGenerator) WriteToDirectory(baseDir string) error {
+	chartDir := filepath.Join(baseDir, g.Chart.Name)
+
+	// Create directory structure
+	dirs := []string{
+		chartDir,
+		filepath.Join(chartDir, "templates"),
+		filepath.Join(chartDir, "templates", "tests"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	// Write Chart.yaml
+	chartYAML, err := g.GenerateChartYAML()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(chartYAML), 0644); err != nil {
+		return fmt.Errorf("failed to write Chart.yaml: %w", err)
+	}
+
+	// Write values.yaml
+	valuesYAML, err := g.GenerateValuesYAML()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte(valuesYAML), 0644); err != nil {
+		return fmt.Errorf("failed to write values.yaml: %w", err)
+	}
+
+	// Write templates
+	for _, tpl := range g.GenerateTemplates() {
+		path := filepath.Join(chartDir, "templates", tpl.Name)
+		if err := os.WriteFile(path, []byte(tpl.Content), 0644); err != nil {
+			return fmt.Errorf("failed to write template %s: %w", tpl.Name, err)
+		}
+	}
+
+	// Write .helmignore
+	helmignore := `# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+`
+	if err := os.WriteFile(filepath.Join(chartDir, ".helmignore"), []byte(helmignore), 0644); err != nil {
+		return fmt.Errorf("failed to write .helmignore: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateChart performs basic validation on the chart
+func (g *HelmChartGenerator) ValidateChart() []string {
+	var errors []string
+
+	if g.Chart.Name == "" {
+		errors = append(errors, "chart name is required")
+	}
+	if g.Chart.Version == "" {
+		errors = append(errors, "chart version is required")
+	}
+	if !isValidSemVer(g.Chart.Version) {
+		errors = append(errors, "chart version must be valid semver")
+	}
+	if g.Values.ReplicaCount < 0 {
+		errors = append(errors, "replicaCount must be non-negative")
+	}
+	if g.Values.Image.Repository == "" {
+		errors = append(errors, "image repository is required")
+	}
+
+	return errors
+}
+
+// isValidSemVer checks if a string is valid semver
+func isValidSemVer(v string) bool {
+	if v == "" {
+		return false
+	}
+
+	// Strip any prerelease suffix (everything after first -)
+	mainVersion := strings.Split(v, "-")[0]
+
+	parts := strings.Split(mainVersion, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, c := range part {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// RenderTemplate renders a Helm template with values (for testing)
+func RenderTemplate(templateContent string, values interface{}) (string, error) {
+	tmpl, err := template.New("test").Funcs(helmFuncMap()).Parse(templateContent)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, values); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// helmFuncMap returns common Helm template functions
+func helmFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"quote": func(s string) string { return fmt.Sprintf("%q", s) },
+		"default": func(d, v interface{}) interface{} {
+			if v == nil || v == "" {
+				return d
+			}
+			return v
+		},
+		"contains": func(substr, s string) bool { return strings.Contains(s, substr) },
+		"replace":  strings.ReplaceAll,
+		"trunc": func(n int, s string) string {
+			if len(s) > n {
+				return s[:n]
+			}
+			return s
+		},
+		"trimSuffix": func(suffix, s string) string { return strings.TrimSuffix(s, suffix) },
+		"nindent": func(n int, s string) string {
+			return "\n" + strings.Repeat(" ", n) + strings.ReplaceAll(s, "\n", "\n"+strings.Repeat(" ", n))
+		},
+		"toYaml":  func(v interface{}) string { b, _ := yaml.Marshal(v); return string(b) },
+		"include": func(name string, data interface{}) string { return "" }, // Placeholder
+		"printf":  fmt.Sprintf,
+	}
+}

--- a/internal/k8s/helm_test.go
+++ b/internal/k8s/helm_test.go
@@ -1,0 +1,637 @@
+// internal/k8s/helm_test.go
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewHelmChartGenerator(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+
+	if gen.Chart.Name != "vaultaire" {
+		t.Errorf("expected name 'vaultaire', got '%s'", gen.Chart.Name)
+	}
+	if gen.Chart.Version != "1.0.0" {
+		t.Errorf("expected version '1.0.0', got '%s'", gen.Chart.Version)
+	}
+	if gen.Chart.AppVersion != "v1.0.0" {
+		t.Errorf("expected appVersion 'v1.0.0', got '%s'", gen.Chart.AppVersion)
+	}
+	if gen.Chart.Type != "application" {
+		t.Errorf("expected type 'application', got '%s'", gen.Chart.Type)
+	}
+}
+
+func TestDefaultHelmValues(t *testing.T) {
+	values := DefaultHelmValues()
+
+	if values.ReplicaCount != 1 {
+		t.Errorf("expected replicaCount 1, got %d", values.ReplicaCount)
+	}
+	if values.Image.PullPolicy != "IfNotPresent" {
+		t.Errorf("expected pullPolicy 'IfNotPresent', got '%s'", values.Image.PullPolicy)
+	}
+	if !values.ServiceAccount.Create {
+		t.Error("expected serviceAccount.create to be true")
+	}
+	if values.Service.Type != "ClusterIP" {
+		t.Errorf("expected service type 'ClusterIP', got '%s'", values.Service.Type)
+	}
+	if !values.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("expected readOnlyRootFilesystem to be true")
+	}
+}
+
+func TestWithMaintainer(t *testing.T) {
+	gen := NewHelmChartGenerator("test", "1.0.0", "v1.0.0")
+	gen.WithMaintainer("John Doe", "john@example.com", "https://example.com")
+
+	if len(gen.Chart.Maintainers) != 1 {
+		t.Fatalf("expected 1 maintainer, got %d", len(gen.Chart.Maintainers))
+	}
+	if gen.Chart.Maintainers[0].Name != "John Doe" {
+		t.Errorf("expected maintainer name 'John Doe', got '%s'", gen.Chart.Maintainers[0].Name)
+	}
+	if gen.Chart.Maintainers[0].Email != "john@example.com" {
+		t.Errorf("expected maintainer email 'john@example.com', got '%s'", gen.Chart.Maintainers[0].Email)
+	}
+}
+
+func TestWithDependency(t *testing.T) {
+	gen := NewHelmChartGenerator("test", "1.0.0", "v1.0.0")
+	gen.WithDependency("postgresql", "12.0.0", "https://charts.bitnami.com/bitnami")
+
+	if len(gen.Chart.Dependencies) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(gen.Chart.Dependencies))
+	}
+	if gen.Chart.Dependencies[0].Name != "postgresql" {
+		t.Errorf("expected dependency name 'postgresql', got '%s'", gen.Chart.Dependencies[0].Name)
+	}
+}
+
+func TestWithKeywords(t *testing.T) {
+	gen := NewHelmChartGenerator("test", "1.0.0", "v1.0.0")
+	gen.WithKeywords("storage", "s3", "cloud")
+
+	if len(gen.Chart.Keywords) != 3 {
+		t.Fatalf("expected 3 keywords, got %d", len(gen.Chart.Keywords))
+	}
+}
+
+func TestGenerateChartYAML(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	gen.WithMaintainer("FairForge", "support@fairforge.com", "")
+	gen.WithKeywords("storage", "s3")
+
+	yaml, err := gen.GenerateChartYAML()
+	if err != nil {
+		t.Fatalf("failed to generate Chart.yaml: %v", err)
+	}
+
+	if !strings.Contains(yaml, "apiVersion: v2") {
+		t.Error("expected apiVersion v2")
+	}
+	if !strings.Contains(yaml, "name: vaultaire") {
+		t.Error("expected name vaultaire")
+	}
+	if !strings.Contains(yaml, "version: 1.0.0") {
+		t.Error("expected version 1.0.0")
+	}
+	if !strings.Contains(yaml, "appVersion: v1.0.0") {
+		t.Error("expected appVersion v1.0.0")
+	}
+	if !strings.Contains(yaml, "type: application") {
+		t.Error("expected type application")
+	}
+}
+
+func TestGenerateValuesYAML(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+
+	yaml, err := gen.GenerateValuesYAML()
+	if err != nil {
+		t.Fatalf("failed to generate values.yaml: %v", err)
+	}
+
+	if !strings.Contains(yaml, "replicaCount: 1") {
+		t.Error("expected replicaCount in values")
+	}
+	if !strings.Contains(yaml, "repository: ghcr.io/fairforge/vaultaire") {
+		t.Error("expected image repository in values")
+	}
+	if !strings.Contains(yaml, "pullPolicy: IfNotPresent") {
+		t.Error("expected pullPolicy in values")
+	}
+}
+
+func TestGenerateTemplates(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+
+	templates := gen.GenerateTemplates()
+
+	expectedTemplates := []string{
+		"_helpers.tpl",
+		"serviceaccount.yaml",
+		"configmap.yaml",
+		"secret.yaml",
+		"deployment.yaml",
+		"service.yaml",
+		"ingress.yaml",
+		"hpa.yaml",
+		"pvc.yaml",
+		"servicemonitor.yaml",
+		"NOTES.txt",
+	}
+
+	if len(templates) != len(expectedTemplates) {
+		t.Errorf("expected %d templates, got %d", len(expectedTemplates), len(templates))
+	}
+
+	templateNames := make(map[string]bool)
+	for _, tpl := range templates {
+		templateNames[tpl.Name] = true
+	}
+
+	for _, expected := range expectedTemplates {
+		if !templateNames[expected] {
+			t.Errorf("missing template: %s", expected)
+		}
+	}
+}
+
+func TestHelpersTpl(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	templates := gen.GenerateTemplates()
+
+	var helpersTpl string
+	for _, tpl := range templates {
+		if tpl.Name == "_helpers.tpl" {
+			helpersTpl = tpl.Content
+			break
+		}
+	}
+
+	if !strings.Contains(helpersTpl, "define \"vaultaire.name\"") {
+		t.Error("expected vaultaire.name helper")
+	}
+	if !strings.Contains(helpersTpl, "define \"vaultaire.fullname\"") {
+		t.Error("expected vaultaire.fullname helper")
+	}
+	if !strings.Contains(helpersTpl, "define \"vaultaire.labels\"") {
+		t.Error("expected vaultaire.labels helper")
+	}
+	if !strings.Contains(helpersTpl, "define \"vaultaire.selectorLabels\"") {
+		t.Error("expected vaultaire.selectorLabels helper")
+	}
+}
+
+func TestDeploymentTpl(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	templates := gen.GenerateTemplates()
+
+	var deploymentTpl string
+	for _, tpl := range templates {
+		if tpl.Name == "deployment.yaml" {
+			deploymentTpl = tpl.Content
+			break
+		}
+	}
+
+	// Check for key sections
+	if !strings.Contains(deploymentTpl, "kind: Deployment") {
+		t.Error("expected kind Deployment")
+	}
+	if !strings.Contains(deploymentTpl, "securityContext") {
+		t.Error("expected securityContext")
+	}
+	if !strings.Contains(deploymentTpl, "livenessProbe") {
+		t.Error("expected livenessProbe")
+	}
+	if !strings.Contains(deploymentTpl, "readinessProbe") {
+		t.Error("expected readinessProbe")
+	}
+	if !strings.Contains(deploymentTpl, "resources") {
+		t.Error("expected resources")
+	}
+}
+
+func TestServiceTpl(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	templates := gen.GenerateTemplates()
+
+	var serviceTpl string
+	for _, tpl := range templates {
+		if tpl.Name == "service.yaml" {
+			serviceTpl = tpl.Content
+			break
+		}
+	}
+
+	if !strings.Contains(serviceTpl, "kind: Service") {
+		t.Error("expected kind Service")
+	}
+	if !strings.Contains(serviceTpl, ".Values.service.type") {
+		t.Error("expected service type from values")
+	}
+	if !strings.Contains(serviceTpl, ".Values.service.port") {
+		t.Error("expected service port from values")
+	}
+}
+
+func TestIngressTpl(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	templates := gen.GenerateTemplates()
+
+	var ingressTpl string
+	for _, tpl := range templates {
+		if tpl.Name == "ingress.yaml" {
+			ingressTpl = tpl.Content
+			break
+		}
+	}
+
+	if !strings.Contains(ingressTpl, "{{- if .Values.ingress.enabled -}}") {
+		t.Error("expected ingress enabled check")
+	}
+	if !strings.Contains(ingressTpl, "kind: Ingress") {
+		t.Error("expected kind Ingress")
+	}
+	if !strings.Contains(ingressTpl, "networking.k8s.io/v1") {
+		t.Error("expected networking.k8s.io/v1 apiVersion")
+	}
+}
+
+func TestHPATpl(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	templates := gen.GenerateTemplates()
+
+	var hpaTpl string
+	for _, tpl := range templates {
+		if tpl.Name == "hpa.yaml" {
+			hpaTpl = tpl.Content
+			break
+		}
+	}
+
+	if !strings.Contains(hpaTpl, "{{- if .Values.autoscaling.enabled }}") {
+		t.Error("expected autoscaling enabled check")
+	}
+	if !strings.Contains(hpaTpl, "kind: HorizontalPodAutoscaler") {
+		t.Error("expected kind HorizontalPodAutoscaler")
+	}
+}
+
+func TestValidateChart(t *testing.T) {
+	tests := []struct {
+		name        string
+		chart       *HelmChartGenerator
+		expectError bool
+	}{
+		{
+			name:        "valid chart",
+			chart:       NewHelmChartGenerator("test", "1.0.0", "v1.0.0"),
+			expectError: false,
+		},
+		{
+			name: "missing name",
+			chart: &HelmChartGenerator{
+				Chart: HelmChart{
+					Version: "1.0.0",
+				},
+				Values: DefaultHelmValues(),
+			},
+			expectError: true,
+		},
+		{
+			name: "missing version",
+			chart: &HelmChartGenerator{
+				Chart: HelmChart{
+					Name: "test",
+				},
+				Values: DefaultHelmValues(),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid semver",
+			chart: &HelmChartGenerator{
+				Chart: HelmChart{
+					Name:    "test",
+					Version: "invalid",
+				},
+				Values: DefaultHelmValues(),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := tt.chart.ValidateChart()
+			hasError := len(errors) > 0
+			if hasError != tt.expectError {
+				t.Errorf("expected error: %v, got errors: %v", tt.expectError, errors)
+			}
+		})
+	}
+}
+
+func TestIsValidSemVer(t *testing.T) {
+	tests := []struct {
+		version string
+		valid   bool
+	}{
+		{"1.0.0", true},
+		{"0.1.0", true},
+		{"1.0", true},
+		{"1.0.0-alpha", true},
+		{"1.0.0-beta.1", true},
+		{"invalid", false},
+		{"1.0.0.0", false},
+		{"v1.0.0", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := isValidSemVer(tt.version)
+			if result != tt.valid {
+				t.Errorf("isValidSemVer(%s) = %v, want %v", tt.version, result, tt.valid)
+			}
+		})
+	}
+}
+
+func TestWriteToDirectory(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	gen.WithMaintainer("FairForge", "support@fairforge.com", "")
+	gen.WithKeywords("storage", "s3", "cloud")
+	gen.WithDependency("postgresql", "12.0.0", "https://charts.bitnami.com/bitnami")
+
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "helm-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Write chart
+	if err := gen.WriteToDirectory(tmpDir); err != nil {
+		t.Fatalf("failed to write chart: %v", err)
+	}
+
+	// Verify files exist
+	chartDir := filepath.Join(tmpDir, "vaultaire")
+
+	expectedFiles := []string{
+		"Chart.yaml",
+		"values.yaml",
+		".helmignore",
+		"templates/_helpers.tpl",
+		"templates/deployment.yaml",
+		"templates/service.yaml",
+		"templates/serviceaccount.yaml",
+		"templates/configmap.yaml",
+		"templates/secret.yaml",
+		"templates/ingress.yaml",
+		"templates/hpa.yaml",
+		"templates/pvc.yaml",
+		"templates/servicemonitor.yaml",
+		"templates/NOTES.txt",
+	}
+
+	for _, file := range expectedFiles {
+		path := filepath.Join(chartDir, file)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", file)
+		}
+	}
+
+	// Verify Chart.yaml content
+	chartYAML, err := os.ReadFile(filepath.Join(chartDir, "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read Chart.yaml: %v", err)
+	}
+
+	var chart ChartYAML
+	if err := yaml.Unmarshal(chartYAML, &chart); err != nil {
+		t.Fatalf("failed to parse Chart.yaml: %v", err)
+	}
+
+	if chart.Name != "vaultaire" {
+		t.Errorf("expected chart name 'vaultaire', got '%s'", chart.Name)
+	}
+	if len(chart.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(chart.Dependencies))
+	}
+}
+
+func TestValuesYAMLParseable(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+
+	yamlContent, err := gen.GenerateValuesYAML()
+	if err != nil {
+		t.Fatalf("failed to generate values.yaml: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlContent), &parsed); err != nil {
+		t.Fatalf("values.yaml is not valid YAML: %v", err)
+	}
+
+	// Check key sections exist
+	if _, ok := parsed["replicaCount"]; !ok {
+		t.Error("missing replicaCount")
+	}
+	if _, ok := parsed["image"]; !ok {
+		t.Error("missing image")
+	}
+	if _, ok := parsed["service"]; !ok {
+		t.Error("missing service")
+	}
+	if _, ok := parsed["ingress"]; !ok {
+		t.Error("missing ingress")
+	}
+	if _, ok := parsed["resources"]; !ok {
+		t.Error("missing resources")
+	}
+}
+
+func TestChartYAMLParseable(t *testing.T) {
+	gen := NewHelmChartGenerator("vaultaire", "1.0.0", "v1.0.0")
+	gen.WithMaintainer("Test", "test@test.com", "")
+	gen.WithDependency("redis", "17.0.0", "https://charts.bitnami.com/bitnami")
+
+	yamlContent, err := gen.GenerateChartYAML()
+	if err != nil {
+		t.Fatalf("failed to generate Chart.yaml: %v", err)
+	}
+
+	var parsed ChartYAML
+	if err := yaml.Unmarshal([]byte(yamlContent), &parsed); err != nil {
+		t.Fatalf("Chart.yaml is not valid YAML: %v", err)
+	}
+
+	if parsed.APIVersion != "v2" {
+		t.Errorf("expected apiVersion v2, got %s", parsed.APIVersion)
+	}
+	if len(parsed.Maintainers) != 1 {
+		t.Errorf("expected 1 maintainer, got %d", len(parsed.Maintainers))
+	}
+	if len(parsed.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(parsed.Dependencies))
+	}
+}
+
+func TestSecurityContextValues(t *testing.T) {
+	values := DefaultHelmValues()
+
+	// Verify security best practices
+	if values.SecurityContext.AllowPrivilegeEscalation {
+		t.Error("allowPrivilegeEscalation should be false")
+	}
+	if !values.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("readOnlyRootFilesystem should be true")
+	}
+	if !values.SecurityContext.RunAsNonRoot {
+		t.Error("runAsNonRoot should be true")
+	}
+	if len(values.SecurityContext.Capabilities.Drop) == 0 {
+		t.Error("should drop ALL capabilities")
+	}
+	if values.SecurityContext.Capabilities.Drop[0] != "ALL" {
+		t.Error("should drop ALL capabilities")
+	}
+}
+
+func TestProbesConfig(t *testing.T) {
+	values := DefaultHelmValues()
+
+	if !values.Probes.Liveness.Enabled {
+		t.Error("liveness probe should be enabled by default")
+	}
+	if !values.Probes.Readiness.Enabled {
+		t.Error("readiness probe should be enabled by default")
+	}
+	if values.Probes.Liveness.Path != "/health" {
+		t.Errorf("expected liveness path '/health', got '%s'", values.Probes.Liveness.Path)
+	}
+	if values.Probes.Liveness.InitialDelaySeconds != 30 {
+		t.Errorf("expected liveness initialDelaySeconds 30, got %d", values.Probes.Liveness.InitialDelaySeconds)
+	}
+}
+
+func TestAutoscalingConfig(t *testing.T) {
+	values := DefaultHelmValues()
+
+	if values.Autoscaling.Enabled {
+		t.Error("autoscaling should be disabled by default")
+	}
+	if values.Autoscaling.MinReplicas != 1 {
+		t.Errorf("expected minReplicas 1, got %d", values.Autoscaling.MinReplicas)
+	}
+	if values.Autoscaling.MaxReplicas != 10 {
+		t.Errorf("expected maxReplicas 10, got %d", values.Autoscaling.MaxReplicas)
+	}
+}
+
+func TestDatabaseSubcharts(t *testing.T) {
+	values := DefaultHelmValues()
+
+	// PostgreSQL
+	if !values.PostgreSQL.Enabled {
+		t.Error("postgresql should be enabled by default")
+	}
+	if values.PostgreSQL.Auth.Database != "vaultaire" {
+		t.Errorf("expected database 'vaultaire', got '%s'", values.PostgreSQL.Auth.Database)
+	}
+
+	// Redis
+	if !values.Redis.Enabled {
+		t.Error("redis should be enabled by default")
+	}
+	if !values.Redis.Auth.Enabled {
+		t.Error("redis auth should be enabled")
+	}
+}
+
+func TestIngressConfig(t *testing.T) {
+	values := DefaultHelmValues()
+
+	if values.Ingress.Enabled {
+		t.Error("ingress should be disabled by default")
+	}
+	if len(values.Ingress.Hosts) == 0 {
+		t.Error("should have default host configuration")
+	}
+	if values.Ingress.Hosts[0].Host != "vaultaire.local" {
+		t.Errorf("expected default host 'vaultaire.local', got '%s'", values.Ingress.Hosts[0].Host)
+	}
+}
+
+func TestMetricsConfig(t *testing.T) {
+	values := DefaultHelmValues()
+
+	if !values.Metrics.Enabled {
+		t.Error("metrics should be enabled by default")
+	}
+	if values.Metrics.Port != 9090 {
+		t.Errorf("expected metrics port 9090, got %d", values.Metrics.Port)
+	}
+	if values.Metrics.ServiceMonitor.Enabled {
+		t.Error("serviceMonitor should be disabled by default")
+	}
+}
+
+func TestFluentChaining(t *testing.T) {
+	gen := NewHelmChartGenerator("test", "1.0.0", "v1.0.0").
+		WithMaintainer("A", "a@a.com", "").
+		WithMaintainer("B", "b@b.com", "").
+		WithDependency("dep1", "1.0.0", "http://example.com").
+		WithKeywords("k1", "k2")
+
+	if len(gen.Chart.Maintainers) != 2 {
+		t.Error("expected 2 maintainers")
+	}
+	if len(gen.Chart.Dependencies) != 1 {
+		t.Error("expected 1 dependency")
+	}
+	if len(gen.Chart.Keywords) != 2 {
+		t.Error("expected 2 keywords")
+	}
+}
+
+func TestHelmFuncMap(t *testing.T) {
+	funcs := helmFuncMap()
+
+	// Test quote
+	quoteFunc := funcs["quote"].(func(string) string)
+	if quoteFunc("test") != `"test"` {
+		t.Error("quote function failed")
+	}
+
+	// Test contains
+	containsFunc := funcs["contains"].(func(string, string) bool)
+	if !containsFunc("hello", "helloworld") {
+		t.Error("contains function failed")
+	}
+
+	// Test trunc
+	truncFunc := funcs["trunc"].(func(int, string) string)
+	if truncFunc(3, "hello") != "hel" {
+		t.Error("trunc function failed")
+	}
+
+	// Test trimSuffix
+	trimSuffixFunc := funcs["trimSuffix"].(func(string, string) string)
+	if trimSuffixFunc("-test", "hello-test") != "hello" {
+		t.Error("trimSuffix function failed")
+	}
+}

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -1,0 +1,792 @@
+// internal/k8s/ingress.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// IngressManager manages Kubernetes Ingress resources
+type IngressManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewIngressManager creates a new Ingress manager
+func NewIngressManager(namespace string) *IngressManager {
+	return &IngressManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// K8sIngressConfig configures an Ingress resource
+type K8sIngressConfig struct {
+	Name             string
+	Namespace        string
+	Labels           map[string]string
+	Annotations      map[string]string
+	IngressClassName string
+	TLS              []K8sIngressTLS
+	Rules            []IngressRule
+	DefaultBackend   *IngressBackend
+}
+
+// K8sIngressTLS configures TLS for an Ingress
+type K8sIngressTLS struct {
+	Hosts      []string `yaml:"hosts,omitempty"`
+	SecretName string   `yaml:"secretName,omitempty"`
+}
+
+// IngressRule defines an Ingress rule
+type IngressRule struct {
+	Host string
+	HTTP *HTTPIngressRuleValue
+}
+
+// HTTPIngressRuleValue defines HTTP rules
+type HTTPIngressRuleValue struct {
+	Paths []HTTPIngressPath `yaml:"paths"`
+}
+
+// HTTPIngressPath defines a path-based routing rule
+type HTTPIngressPath struct {
+	Path     string          `yaml:"path"`
+	PathType string          `yaml:"pathType"` // Exact, Prefix, ImplementationSpecific
+	Backend  *IngressBackend `yaml:"backend"`
+}
+
+// IngressBackend defines the backend service
+type IngressBackend struct {
+	Service  *IngressServiceBackend  `yaml:"service,omitempty"`
+	Resource *IngressResourceBackend `yaml:"resource,omitempty"`
+}
+
+// IngressServiceBackend references a Service
+type IngressServiceBackend struct {
+	Name string            `yaml:"name"`
+	Port K8sIngressSvcPort `yaml:"port"`
+}
+
+// K8sIngressSvcPort identifies a service port
+type K8sIngressSvcPort struct {
+	Name   string `yaml:"name,omitempty"`
+	Number int    `yaml:"number,omitempty"`
+}
+
+// IngressResourceBackend references a resource
+type IngressResourceBackend struct {
+	APIGroup string `yaml:"apiGroup"`
+	Kind     string `yaml:"kind"`
+	Name     string `yaml:"name"`
+}
+
+// IngressResource represents a Kubernetes Ingress
+type IngressResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       IngressSpec      `yaml:"spec"`
+}
+
+// IngressSpec defines the Ingress specification
+type IngressSpec struct {
+	IngressClassName string          `yaml:"ingressClassName,omitempty"`
+	TLS              []K8sIngressTLS `yaml:"tls,omitempty"`
+	Rules            []IngressRule   `yaml:"rules,omitempty"` // Changed from IngressRuleSpec
+	DefaultBackend   *IngressBackend `yaml:"defaultBackend,omitempty"`
+}
+
+// IngressRuleSpec defines a rule in the spec
+type IngressRuleSpec struct {
+	Host string                `yaml:"host,omitempty"`
+	HTTP *HTTPIngressRuleValue `yaml:"http,omitempty"`
+}
+
+// GenerateIngress creates an Ingress resource
+func (im *IngressManager) GenerateIngress(config K8sIngressConfig) *IngressResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	labels := copyStringMap(im.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	annotations := copyStringMap(config.Annotations)
+
+	return &IngressResource{
+		APIVersion: "networking.k8s.io/v1",
+		Kind:       "Ingress",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: IngressSpec{
+			IngressClassName: config.IngressClassName,
+			TLS:              config.TLS,
+			Rules:            config.Rules, // Direct assignment now works
+			DefaultBackend:   config.DefaultBackend,
+		},
+	}
+}
+
+// ToYAML converts the Ingress to YAML
+func (i *IngressResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(i); err != nil {
+		return "", fmt.Errorf("failed to encode ingress: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// NginxIngressConfig provides nginx-specific configuration
+type NginxIngressConfig struct {
+	// Basic settings
+	ProxyBodySize       string
+	ProxyConnectTimeout int
+	ProxySendTimeout    int
+	ProxyReadTimeout    int
+
+	// SSL settings
+	SSLRedirect      bool
+	ForceSSLRedirect bool
+	SSLCiphers       string
+	SSLProtocols     string
+
+	// Backend settings
+	BackendProtocol string // HTTP, HTTPS, GRPC, GRPCS
+	UpstreamHashBy  string
+
+	// Rate limiting
+	RateLimitConnections int
+	RateLimitRPS         int
+	RateLimitRPM         int
+
+	// CORS
+	CORSEnabled          bool
+	CORSAllowOrigin      string
+	CORSAllowMethods     string
+	CORSAllowHeaders     string
+	CORSExposeHeaders    string
+	CORSAllowCredentials bool
+	CORSMaxAge           int
+
+	// Authentication
+	AuthType   string // basic, digest, external
+	AuthSecret string
+	AuthRealm  string
+	AuthURL    string
+
+	// Rewrites
+	RewriteTarget string
+	AppRoot       string
+
+	// Whitelist/Blacklist
+	WhitelistSourceRange string
+	DenylistSourceRange  string
+
+	// Custom snippets
+	ServerSnippet        string
+	ConfigurationSnippet string
+	StreamSnippet        string
+
+	// Canary settings
+	CanaryEnabled     bool
+	CanaryWeight      int
+	CanaryHeader      string
+	CanaryHeaderValue string
+	CanaryCookie      string
+
+	// Misc
+	ClientMaxBodySize    string
+	ProxyBuffering       string
+	ProxyBufferSize      string
+	ProxyMaxTempFileSize string
+	UseRegex             bool
+	EnableModsecurity    bool
+	ModsecuritySnippet   string
+}
+
+// ToAnnotations converts nginx config to annotations
+func (n *NginxIngressConfig) ToAnnotations() map[string]string {
+	annotations := make(map[string]string)
+
+	// Basic settings
+	if n.ProxyBodySize != "" {
+		annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = n.ProxyBodySize
+	}
+	if n.ProxyConnectTimeout > 0 {
+		annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"] = fmt.Sprintf("%d", n.ProxyConnectTimeout)
+	}
+	if n.ProxySendTimeout > 0 {
+		annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] = fmt.Sprintf("%d", n.ProxySendTimeout)
+	}
+	if n.ProxyReadTimeout > 0 {
+		annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = fmt.Sprintf("%d", n.ProxyReadTimeout)
+	}
+
+	// SSL settings
+	if n.SSLRedirect {
+		annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
+	}
+	if n.ForceSSLRedirect {
+		annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
+	}
+	if n.SSLCiphers != "" {
+		annotations["nginx.ingress.kubernetes.io/ssl-ciphers"] = n.SSLCiphers
+	}
+	if n.SSLProtocols != "" {
+		annotations["nginx.ingress.kubernetes.io/ssl-protocols"] = n.SSLProtocols
+	}
+
+	// Backend settings
+	if n.BackendProtocol != "" {
+		annotations["nginx.ingress.kubernetes.io/backend-protocol"] = n.BackendProtocol
+	}
+	if n.UpstreamHashBy != "" {
+		annotations["nginx.ingress.kubernetes.io/upstream-hash-by"] = n.UpstreamHashBy
+	}
+
+	// Rate limiting
+	if n.RateLimitConnections > 0 {
+		annotations["nginx.ingress.kubernetes.io/limit-connections"] = fmt.Sprintf("%d", n.RateLimitConnections)
+	}
+	if n.RateLimitRPS > 0 {
+		annotations["nginx.ingress.kubernetes.io/limit-rps"] = fmt.Sprintf("%d", n.RateLimitRPS)
+	}
+	if n.RateLimitRPM > 0 {
+		annotations["nginx.ingress.kubernetes.io/limit-rpm"] = fmt.Sprintf("%d", n.RateLimitRPM)
+	}
+
+	// CORS
+	if n.CORSEnabled {
+		annotations["nginx.ingress.kubernetes.io/enable-cors"] = "true"
+		if n.CORSAllowOrigin != "" {
+			annotations["nginx.ingress.kubernetes.io/cors-allow-origin"] = n.CORSAllowOrigin
+		}
+		if n.CORSAllowMethods != "" {
+			annotations["nginx.ingress.kubernetes.io/cors-allow-methods"] = n.CORSAllowMethods
+		}
+		if n.CORSAllowHeaders != "" {
+			annotations["nginx.ingress.kubernetes.io/cors-allow-headers"] = n.CORSAllowHeaders
+		}
+		if n.CORSExposeHeaders != "" {
+			annotations["nginx.ingress.kubernetes.io/cors-expose-headers"] = n.CORSExposeHeaders
+		}
+		if n.CORSAllowCredentials {
+			annotations["nginx.ingress.kubernetes.io/cors-allow-credentials"] = "true"
+		}
+		if n.CORSMaxAge > 0 {
+			annotations["nginx.ingress.kubernetes.io/cors-max-age"] = fmt.Sprintf("%d", n.CORSMaxAge)
+		}
+	}
+
+	// Authentication
+	if n.AuthType != "" {
+		annotations["nginx.ingress.kubernetes.io/auth-type"] = n.AuthType
+	}
+	if n.AuthSecret != "" {
+		annotations["nginx.ingress.kubernetes.io/auth-secret"] = n.AuthSecret
+	}
+	if n.AuthRealm != "" {
+		annotations["nginx.ingress.kubernetes.io/auth-realm"] = n.AuthRealm
+	}
+	if n.AuthURL != "" {
+		annotations["nginx.ingress.kubernetes.io/auth-url"] = n.AuthURL
+	}
+
+	// Rewrites
+	if n.RewriteTarget != "" {
+		annotations["nginx.ingress.kubernetes.io/rewrite-target"] = n.RewriteTarget
+	}
+	if n.AppRoot != "" {
+		annotations["nginx.ingress.kubernetes.io/app-root"] = n.AppRoot
+	}
+
+	// Whitelist/Blacklist
+	if n.WhitelistSourceRange != "" {
+		annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = n.WhitelistSourceRange
+	}
+	if n.DenylistSourceRange != "" {
+		annotations["nginx.ingress.kubernetes.io/denylist-source-range"] = n.DenylistSourceRange
+	}
+
+	// Custom snippets
+	if n.ServerSnippet != "" {
+		annotations["nginx.ingress.kubernetes.io/server-snippet"] = n.ServerSnippet
+	}
+	if n.ConfigurationSnippet != "" {
+		annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = n.ConfigurationSnippet
+	}
+	if n.StreamSnippet != "" {
+		annotations["nginx.ingress.kubernetes.io/stream-snippet"] = n.StreamSnippet
+	}
+
+	// Canary settings
+	if n.CanaryEnabled {
+		annotations["nginx.ingress.kubernetes.io/canary"] = "true"
+		if n.CanaryWeight > 0 {
+			annotations["nginx.ingress.kubernetes.io/canary-weight"] = fmt.Sprintf("%d", n.CanaryWeight)
+		}
+		if n.CanaryHeader != "" {
+			annotations["nginx.ingress.kubernetes.io/canary-by-header"] = n.CanaryHeader
+			if n.CanaryHeaderValue != "" {
+				annotations["nginx.ingress.kubernetes.io/canary-by-header-value"] = n.CanaryHeaderValue
+			}
+		}
+		if n.CanaryCookie != "" {
+			annotations["nginx.ingress.kubernetes.io/canary-by-cookie"] = n.CanaryCookie
+		}
+	}
+
+	// Misc
+	if n.ClientMaxBodySize != "" {
+		annotations["nginx.ingress.kubernetes.io/client-max-body-size"] = n.ClientMaxBodySize
+	}
+	if n.ProxyBuffering != "" {
+		annotations["nginx.ingress.kubernetes.io/proxy-buffering"] = n.ProxyBuffering
+	}
+	if n.ProxyBufferSize != "" {
+		annotations["nginx.ingress.kubernetes.io/proxy-buffer-size"] = n.ProxyBufferSize
+	}
+	if n.ProxyMaxTempFileSize != "" {
+		annotations["nginx.ingress.kubernetes.io/proxy-max-temp-file-size"] = n.ProxyMaxTempFileSize
+	}
+	if n.UseRegex {
+		annotations["nginx.ingress.kubernetes.io/use-regex"] = "true"
+	}
+	if n.EnableModsecurity {
+		annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] = "true"
+		if n.ModsecuritySnippet != "" {
+			annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"] = n.ModsecuritySnippet
+		}
+	}
+
+	return annotations
+}
+
+// TraefikIngressConfig provides Traefik-specific configuration
+type TraefikIngressConfig struct {
+	EntryPoints      []string
+	Priority         int
+	TLSOptions       string
+	TLSCertResolver  string
+	Middlewares      []string
+	Sticky           bool
+	StickyCookieName string
+	PassHostHeader   bool
+	ServersTransport string
+}
+
+// ToAnnotations converts Traefik config to annotations
+func (t *TraefikIngressConfig) ToAnnotations() map[string]string {
+	annotations := make(map[string]string)
+
+	if len(t.EntryPoints) > 0 {
+		annotations["traefik.ingress.kubernetes.io/router.entrypoints"] = strings.Join(t.EntryPoints, ",")
+	}
+	if t.Priority > 0 {
+		annotations["traefik.ingress.kubernetes.io/router.priority"] = fmt.Sprintf("%d", t.Priority)
+	}
+	if t.TLSOptions != "" {
+		annotations["traefik.ingress.kubernetes.io/router.tls.options"] = t.TLSOptions
+	}
+	if t.TLSCertResolver != "" {
+		annotations["traefik.ingress.kubernetes.io/router.tls.certresolver"] = t.TLSCertResolver
+	}
+	if len(t.Middlewares) > 0 {
+		annotations["traefik.ingress.kubernetes.io/router.middlewares"] = strings.Join(t.Middlewares, ",")
+	}
+	if t.Sticky {
+		annotations["traefik.ingress.kubernetes.io/service.sticky.cookie"] = "true"
+		if t.StickyCookieName != "" {
+			annotations["traefik.ingress.kubernetes.io/service.sticky.cookie.name"] = t.StickyCookieName
+		}
+	}
+	if !t.PassHostHeader {
+		annotations["traefik.ingress.kubernetes.io/service.passhostheader"] = "false"
+	}
+	if t.ServersTransport != "" {
+		annotations["traefik.ingress.kubernetes.io/service.serverstransport"] = t.ServersTransport
+	}
+
+	return annotations
+}
+
+// AWSALBIngressConfig provides AWS ALB-specific configuration
+type AWSALBIngressConfig struct {
+	Scheme                  string
+	IPAddressType           string
+	LoadBalancerName        string
+	SecurityGroups          []string
+	Subnets                 []string
+	Tags                    map[string]string
+	ListenPorts             string
+	CertificateARN          string
+	SSLPolicy               string
+	SSLRedirect             string
+	TargetType              string
+	BackendProtocol         string
+	BackendProtocolVersion  string
+	HealthCheckPath         string
+	HealthCheckPort         string
+	HealthCheckInterval     int
+	HealthCheckTimeout      int
+	HealthyThreshold        int
+	UnhealthyThreshold      int
+	SuccessCodes            string
+	WAFv2ACLArn             string
+	CognitoUserPoolARN      string
+	CognitoUserPoolClientID string
+	CognitoUserPoolDomain   string
+	AuthOnUnauthenticated   string
+	Actions                 string
+}
+
+// ToAnnotations converts AWS ALB config to annotations
+func (a *AWSALBIngressConfig) ToAnnotations() map[string]string {
+	annotations := map[string]string{
+		"kubernetes.io/ingress.class": "alb",
+	}
+
+	if a.Scheme != "" {
+		annotations["alb.ingress.kubernetes.io/scheme"] = a.Scheme
+	}
+	if a.IPAddressType != "" {
+		annotations["alb.ingress.kubernetes.io/ip-address-type"] = a.IPAddressType
+	}
+	if a.LoadBalancerName != "" {
+		annotations["alb.ingress.kubernetes.io/load-balancer-name"] = a.LoadBalancerName
+	}
+	if len(a.SecurityGroups) > 0 {
+		annotations["alb.ingress.kubernetes.io/security-groups"] = strings.Join(a.SecurityGroups, ",")
+	}
+	if len(a.Subnets) > 0 {
+		annotations["alb.ingress.kubernetes.io/subnets"] = strings.Join(a.Subnets, ",")
+	}
+	if len(a.Tags) > 0 {
+		var tags []string
+		for k, v := range a.Tags {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+		}
+		annotations["alb.ingress.kubernetes.io/tags"] = strings.Join(tags, ",")
+	}
+	if a.ListenPorts != "" {
+		annotations["alb.ingress.kubernetes.io/listen-ports"] = a.ListenPorts
+	}
+	if a.CertificateARN != "" {
+		annotations["alb.ingress.kubernetes.io/certificate-arn"] = a.CertificateARN
+	}
+	if a.SSLPolicy != "" {
+		annotations["alb.ingress.kubernetes.io/ssl-policy"] = a.SSLPolicy
+	}
+	if a.SSLRedirect != "" {
+		annotations["alb.ingress.kubernetes.io/ssl-redirect"] = a.SSLRedirect
+	}
+	if a.TargetType != "" {
+		annotations["alb.ingress.kubernetes.io/target-type"] = a.TargetType
+	}
+	if a.BackendProtocol != "" {
+		annotations["alb.ingress.kubernetes.io/backend-protocol"] = a.BackendProtocol
+	}
+	if a.BackendProtocolVersion != "" {
+		annotations["alb.ingress.kubernetes.io/backend-protocol-version"] = a.BackendProtocolVersion
+	}
+	if a.HealthCheckPath != "" {
+		annotations["alb.ingress.kubernetes.io/healthcheck-path"] = a.HealthCheckPath
+	}
+	if a.HealthCheckPort != "" {
+		annotations["alb.ingress.kubernetes.io/healthcheck-port"] = a.HealthCheckPort
+	}
+	if a.HealthCheckInterval > 0 {
+		annotations["alb.ingress.kubernetes.io/healthcheck-interval-seconds"] = fmt.Sprintf("%d", a.HealthCheckInterval)
+	}
+	if a.HealthCheckTimeout > 0 {
+		annotations["alb.ingress.kubernetes.io/healthcheck-timeout-seconds"] = fmt.Sprintf("%d", a.HealthCheckTimeout)
+	}
+	if a.HealthyThreshold > 0 {
+		annotations["alb.ingress.kubernetes.io/healthy-threshold-count"] = fmt.Sprintf("%d", a.HealthyThreshold)
+	}
+	if a.UnhealthyThreshold > 0 {
+		annotations["alb.ingress.kubernetes.io/unhealthy-threshold-count"] = fmt.Sprintf("%d", a.UnhealthyThreshold)
+	}
+	if a.SuccessCodes != "" {
+		annotations["alb.ingress.kubernetes.io/success-codes"] = a.SuccessCodes
+	}
+	if a.WAFv2ACLArn != "" {
+		annotations["alb.ingress.kubernetes.io/wafv2-acl-arn"] = a.WAFv2ACLArn
+	}
+	if a.CognitoUserPoolARN != "" {
+		annotations["alb.ingress.kubernetes.io/auth-type"] = "cognito"
+		annotations["alb.ingress.kubernetes.io/auth-idp-cognito"] = fmt.Sprintf(`{"UserPoolArn":"%s","UserPoolClientId":"%s","UserPoolDomain":"%s"}`,
+			a.CognitoUserPoolARN, a.CognitoUserPoolClientID, a.CognitoUserPoolDomain)
+		if a.AuthOnUnauthenticated != "" {
+			annotations["alb.ingress.kubernetes.io/auth-on-unauthenticated-request"] = a.AuthOnUnauthenticated
+		}
+	}
+	if a.Actions != "" {
+		annotations["alb.ingress.kubernetes.io/actions"] = a.Actions
+	}
+
+	return annotations
+}
+
+// GCPIngressConfig provides GCP-specific configuration
+type GCPIngressConfig struct {
+	GlobalStaticIPName   string
+	RegionalStaticIPName string
+	BackendConfigName    string
+	ManagedCertificates  []string
+	PreSharedCerts       []string
+	HealthCheckPath      string
+	CDNEnabled           bool
+	IAPEnabled           bool
+	IAPClientID          string
+	IAPClientSecret      string
+}
+
+// ToAnnotations converts GCP config to annotations
+func (g *GCPIngressConfig) ToAnnotations() map[string]string {
+	annotations := make(map[string]string)
+
+	if g.GlobalStaticIPName != "" {
+		annotations["kubernetes.io/ingress.global-static-ip-name"] = g.GlobalStaticIPName
+	}
+	if g.RegionalStaticIPName != "" {
+		annotations["kubernetes.io/ingress.regional-static-ip-name"] = g.RegionalStaticIPName
+	}
+	if g.BackendConfigName != "" {
+		annotations["cloud.google.com/backend-config"] = fmt.Sprintf(`{"default": "%s"}`, g.BackendConfigName)
+	}
+	if len(g.ManagedCertificates) > 0 {
+		annotations["networking.gke.io/managed-certificates"] = strings.Join(g.ManagedCertificates, ",")
+	}
+	if len(g.PreSharedCerts) > 0 {
+		annotations["ingress.gcp.kubernetes.io/pre-shared-cert"] = strings.Join(g.PreSharedCerts, ",")
+	}
+
+	return annotations
+}
+
+// IngressBuilder provides a fluent interface for building Ingress resources
+type IngressBuilder struct {
+	config        K8sIngressConfig
+	nginxConfig   *NginxIngressConfig
+	traefikConfig *TraefikIngressConfig
+	albConfig     *AWSALBIngressConfig
+	gcpConfig     *GCPIngressConfig
+}
+
+// NewIngressBuilder creates a new Ingress builder
+func NewIngressBuilder(name, namespace string) *IngressBuilder {
+	return &IngressBuilder{
+		config: K8sIngressConfig{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: make(map[string]string),
+			Labels:      make(map[string]string),
+		},
+	}
+}
+
+// WithIngressClass sets the ingress class
+func (b *IngressBuilder) WithIngressClass(className string) *IngressBuilder {
+	b.config.IngressClassName = className
+	return b
+}
+
+// WithTLS adds TLS configuration
+func (b *IngressBuilder) WithTLS(hosts []string, secretName string) *IngressBuilder {
+	b.config.TLS = append(b.config.TLS, K8sIngressTLS{
+		Hosts:      hosts,
+		SecretName: secretName,
+	})
+	return b
+}
+
+// WithRule adds a routing rule
+func (b *IngressBuilder) WithRule(host string, paths ...HTTPIngressPath) *IngressBuilder {
+	b.config.Rules = append(b.config.Rules, IngressRule{
+		Host: host,
+		HTTP: &HTTPIngressRuleValue{Paths: paths},
+	})
+	return b
+}
+
+// WithDefaultBackend sets the default backend
+func (b *IngressBuilder) WithDefaultBackend(serviceName string, port int) *IngressBuilder {
+	b.config.DefaultBackend = &IngressBackend{
+		Service: &IngressServiceBackend{
+			Name: serviceName,
+			Port: K8sIngressSvcPort{Number: port},
+		},
+	}
+	return b
+}
+
+// WithNginx adds nginx-specific configuration
+func (b *IngressBuilder) WithNginx(config *NginxIngressConfig) *IngressBuilder {
+	b.nginxConfig = config
+	return b
+}
+
+// WithTraefik adds Traefik-specific configuration
+func (b *IngressBuilder) WithTraefik(config *TraefikIngressConfig) *IngressBuilder {
+	b.traefikConfig = config
+	return b
+}
+
+// WithAWSALB adds AWS ALB-specific configuration
+func (b *IngressBuilder) WithAWSALB(config *AWSALBIngressConfig) *IngressBuilder {
+	b.albConfig = config
+	return b
+}
+
+// WithGCP adds GCP-specific configuration
+func (b *IngressBuilder) WithGCP(config *GCPIngressConfig) *IngressBuilder {
+	b.gcpConfig = config
+	return b
+}
+
+// WithAnnotation adds a custom annotation
+func (b *IngressBuilder) WithAnnotation(key, value string) *IngressBuilder {
+	b.config.Annotations[key] = value
+	return b
+}
+
+// WithLabel adds a custom label
+func (b *IngressBuilder) WithLabel(key, value string) *IngressBuilder {
+	b.config.Labels[key] = value
+	return b
+}
+
+// Build creates the Ingress resource
+func (b *IngressBuilder) Build() *IngressResource {
+	im := NewIngressManager(b.config.Namespace)
+
+	// Merge provider-specific annotations
+	if b.nginxConfig != nil {
+		for k, v := range b.nginxConfig.ToAnnotations() {
+			b.config.Annotations[k] = v
+		}
+	}
+	if b.traefikConfig != nil {
+		for k, v := range b.traefikConfig.ToAnnotations() {
+			b.config.Annotations[k] = v
+		}
+	}
+	if b.albConfig != nil {
+		for k, v := range b.albConfig.ToAnnotations() {
+			b.config.Annotations[k] = v
+		}
+	}
+	if b.gcpConfig != nil {
+		for k, v := range b.gcpConfig.ToAnnotations() {
+			b.config.Annotations[k] = v
+		}
+	}
+
+	return im.GenerateIngress(b.config)
+}
+
+// PathPrefix creates an HTTPIngressPath with Prefix path type
+func PathPrefix(path, serviceName string, port int) HTTPIngressPath {
+	return HTTPIngressPath{
+		Path:     path,
+		PathType: "Prefix",
+		Backend: &IngressBackend{
+			Service: &IngressServiceBackend{
+				Name: serviceName,
+				Port: K8sIngressSvcPort{Number: port},
+			},
+		},
+	}
+}
+
+// PathExact creates an HTTPIngressPath with Exact path type
+func PathExact(path, serviceName string, port int) HTTPIngressPath {
+	return HTTPIngressPath{
+		Path:     path,
+		PathType: "Exact",
+		Backend: &IngressBackend{
+			Service: &IngressServiceBackend{
+				Name: serviceName,
+				Port: K8sIngressSvcPort{Number: port},
+			},
+		},
+	}
+}
+
+// PathImplementationSpecific creates an HTTPIngressPath with ImplementationSpecific path type
+func PathImplementationSpecific(path, serviceName string, port int) HTTPIngressPath {
+	return HTTPIngressPath{
+		Path:     path,
+		PathType: "ImplementationSpecific",
+		Backend: &IngressBackend{
+			Service: &IngressServiceBackend{
+				Name: serviceName,
+				Port: K8sIngressSvcPort{Number: port},
+			},
+		},
+	}
+}
+
+// GenerateVaultaireIngress creates a complete Ingress configuration for Vaultaire
+func GenerateVaultaireIngress(namespace, host, tlsSecretName, ingressClass string) *IngressResource {
+	builder := NewIngressBuilder("vaultaire", namespace).
+		WithIngressClass(ingressClass).
+		WithTLS([]string{host}, tlsSecretName).
+		WithRule(host,
+			PathPrefix("/api", "vaultaire-api", 8080),
+			PathPrefix("/health", "vaultaire-api", 8080),
+			PathPrefix("/metrics", "vaultaire-api", 9090),
+			PathPrefix("/", "vaultaire-web", 80),
+		).
+		WithNginx(&NginxIngressConfig{
+			SSLRedirect:         true,
+			ProxyBodySize:       "100m",
+			ProxyReadTimeout:    300,
+			ProxySendTimeout:    300,
+			ProxyConnectTimeout: 60,
+			CORSEnabled:         true,
+			CORSAllowOrigin:     "*",
+			CORSAllowMethods:    "GET, POST, PUT, DELETE, OPTIONS",
+			CORSAllowHeaders:    "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization",
+		})
+
+	return builder.Build()
+}
+
+// IngressSet represents a collection of Ingress resources
+type IngressSet struct {
+	Resources []*IngressResource
+}
+
+// Add adds an Ingress resource to the set
+func (s *IngressSet) Add(r *IngressResource) {
+	s.Resources = append(s.Resources, r)
+}
+
+// ToYAML converts all Ingress resources to multi-document YAML
+func (s *IngressSet) ToYAML() (string, error) {
+	var parts []string
+	for _, r := range s.Resources {
+		yaml, err := r.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+	return strings.Join(parts, "---\n"), nil
+}

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -1,0 +1,571 @@
+// internal/k8s/ingress_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewIngressManager(t *testing.T) {
+	im := NewIngressManager("default")
+
+	if im.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", im.namespace)
+	}
+	if im.labels["app.kubernetes.io/managed-by"] != "vaultaire" {
+		t.Error("expected managed-by label")
+	}
+}
+
+func TestGenerateIngress(t *testing.T) {
+	im := NewIngressManager("default")
+
+	ingress := im.GenerateIngress(K8sIngressConfig{
+		Name:             "test-ingress",
+		IngressClassName: "nginx",
+		TLS: []K8sIngressTLS{
+			{
+				Hosts:      []string{"example.com"},
+				SecretName: "example-tls",
+			},
+		},
+		Rules: []IngressRule{
+			{
+				Host: "example.com",
+				HTTP: &HTTPIngressRuleValue{
+					Paths: []HTTPIngressPath{
+						{
+							Path:     "/",
+							PathType: "Prefix",
+							Backend: &IngressBackend{
+								Service: &IngressServiceBackend{
+									Name: "example-service",
+									Port: K8sIngressSvcPort{Number: 80},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if ingress.Kind != "Ingress" {
+		t.Errorf("expected kind Ingress, got %s", ingress.Kind)
+	}
+	if ingress.APIVersion != "networking.k8s.io/v1" {
+		t.Errorf("expected apiVersion networking.k8s.io/v1, got %s", ingress.APIVersion)
+	}
+	if ingress.Metadata.Name != "test-ingress" {
+		t.Errorf("expected name 'test-ingress', got '%s'", ingress.Metadata.Name)
+	}
+	if ingress.Spec.IngressClassName != "nginx" {
+		t.Errorf("expected ingressClassName 'nginx', got '%s'", ingress.Spec.IngressClassName)
+	}
+}
+
+func TestIngressDefaultNamespace(t *testing.T) {
+	im := NewIngressManager("production")
+
+	ingress := im.GenerateIngress(K8sIngressConfig{
+		Name: "test-ingress",
+	})
+
+	if ingress.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", ingress.Metadata.Namespace)
+	}
+}
+
+func TestIngressNamespaceOverride(t *testing.T) {
+	im := NewIngressManager("production")
+
+	ingress := im.GenerateIngress(K8sIngressConfig{
+		Name:      "test-ingress",
+		Namespace: "staging",
+	})
+
+	if ingress.Metadata.Namespace != "staging" {
+		t.Errorf("expected namespace 'staging', got '%s'", ingress.Metadata.Namespace)
+	}
+}
+
+func TestIngressToYAML(t *testing.T) {
+	im := NewIngressManager("default")
+
+	ingress := im.GenerateIngress(K8sIngressConfig{
+		Name:             "test-ingress",
+		IngressClassName: "nginx",
+		Rules: []IngressRule{
+			{
+				Host: "example.com",
+				HTTP: &HTTPIngressRuleValue{
+					Paths: []HTTPIngressPath{
+						PathPrefix("/", "example-service", 80),
+					},
+				},
+			},
+		},
+	})
+
+	yaml, err := ingress.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: Ingress") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "networking.k8s.io/v1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestNginxIngressConfigBasic(t *testing.T) {
+	config := &NginxIngressConfig{
+		ProxyBodySize:       "100m",
+		ProxyConnectTimeout: 60,
+		ProxySendTimeout:    60,
+		ProxyReadTimeout:    60,
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/proxy-body-size"] != "100m" {
+		t.Error("expected proxy-body-size annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"] != "60" {
+		t.Error("expected proxy-connect-timeout annotation")
+	}
+}
+
+func TestNginxIngressConfigSSL(t *testing.T) {
+	config := &NginxIngressConfig{
+		SSLRedirect:      true,
+		ForceSSLRedirect: true,
+		SSLCiphers:       "ECDHE-RSA-AES128-GCM-SHA256",
+		SSLProtocols:     "TLSv1.2 TLSv1.3",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/ssl-redirect"] != "true" {
+		t.Error("expected ssl-redirect annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] != "true" {
+		t.Error("expected force-ssl-redirect annotation")
+	}
+}
+
+func TestNginxIngressConfigCORS(t *testing.T) {
+	config := &NginxIngressConfig{
+		CORSEnabled:          true,
+		CORSAllowOrigin:      "*",
+		CORSAllowMethods:     "GET, POST",
+		CORSAllowHeaders:     "Authorization",
+		CORSAllowCredentials: true,
+		CORSMaxAge:           3600,
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/enable-cors"] != "true" {
+		t.Error("expected enable-cors annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/cors-allow-origin"] != "*" {
+		t.Error("expected cors-allow-origin annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/cors-allow-credentials"] != "true" {
+		t.Error("expected cors-allow-credentials annotation")
+	}
+}
+
+func TestNginxIngressConfigRateLimit(t *testing.T) {
+	config := &NginxIngressConfig{
+		RateLimitConnections: 10,
+		RateLimitRPS:         100,
+		RateLimitRPM:         1000,
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/limit-connections"] != "10" {
+		t.Error("expected limit-connections annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/limit-rps"] != "100" {
+		t.Error("expected limit-rps annotation")
+	}
+}
+
+func TestNginxIngressConfigCanary(t *testing.T) {
+	config := &NginxIngressConfig{
+		CanaryEnabled:     true,
+		CanaryWeight:      20,
+		CanaryHeader:      "x-canary",
+		CanaryHeaderValue: "true",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/canary"] != "true" {
+		t.Error("expected canary annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/canary-weight"] != "20" {
+		t.Error("expected canary-weight annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/canary-by-header"] != "x-canary" {
+		t.Error("expected canary-by-header annotation")
+	}
+}
+
+func TestNginxIngressConfigAuth(t *testing.T) {
+	config := &NginxIngressConfig{
+		AuthType:   "basic",
+		AuthSecret: "auth-secret",
+		AuthRealm:  "Authentication Required",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/auth-type"] != "basic" {
+		t.Error("expected auth-type annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/auth-secret"] != "auth-secret" {
+		t.Error("expected auth-secret annotation")
+	}
+}
+
+func TestNginxIngressConfigRewrite(t *testing.T) {
+	config := &NginxIngressConfig{
+		RewriteTarget: "/$1",
+		AppRoot:       "/app",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/rewrite-target"] != "/$1" {
+		t.Error("expected rewrite-target annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/app-root"] != "/app" {
+		t.Error("expected app-root annotation")
+	}
+}
+
+func TestTraefikIngressConfig(t *testing.T) {
+	config := &TraefikIngressConfig{
+		EntryPoints:      []string{"websecure"},
+		Priority:         100,
+		TLSCertResolver:  "letsencrypt",
+		Middlewares:      []string{"default-headers@kubernetescrd"},
+		Sticky:           true,
+		StickyCookieName: "server",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["traefik.ingress.kubernetes.io/router.entrypoints"] != "websecure" {
+		t.Error("expected entrypoints annotation")
+	}
+	if annotations["traefik.ingress.kubernetes.io/router.priority"] != "100" {
+		t.Error("expected priority annotation")
+	}
+	if annotations["traefik.ingress.kubernetes.io/service.sticky.cookie"] != "true" {
+		t.Error("expected sticky cookie annotation")
+	}
+}
+
+func TestAWSALBIngressConfig(t *testing.T) {
+	config := &AWSALBIngressConfig{
+		Scheme:          "internet-facing",
+		IPAddressType:   "ipv4",
+		TargetType:      "ip",
+		SecurityGroups:  []string{"sg-12345"},
+		Subnets:         []string{"subnet-1", "subnet-2"},
+		CertificateARN:  "arn:aws:acm:us-east-1:123456789:certificate/abc",
+		SSLPolicy:       "ELBSecurityPolicy-TLS-1-2-2017-01",
+		HealthCheckPath: "/health",
+		Tags:            map[string]string{"env": "prod"},
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["kubernetes.io/ingress.class"] != "alb" {
+		t.Error("expected alb ingress class")
+	}
+	if annotations["alb.ingress.kubernetes.io/scheme"] != "internet-facing" {
+		t.Error("expected scheme annotation")
+	}
+	if annotations["alb.ingress.kubernetes.io/target-type"] != "ip" {
+		t.Error("expected target-type annotation")
+	}
+	if !strings.Contains(annotations["alb.ingress.kubernetes.io/tags"], "env=prod") {
+		t.Error("expected tags annotation")
+	}
+}
+
+func TestAWSALBCognitoConfig(t *testing.T) {
+	config := &AWSALBIngressConfig{
+		CognitoUserPoolARN:      "arn:aws:cognito-idp:us-east-1:123456789:userpool/abc",
+		CognitoUserPoolClientID: "client-id",
+		CognitoUserPoolDomain:   "auth.example.com",
+		AuthOnUnauthenticated:   "authenticate",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["alb.ingress.kubernetes.io/auth-type"] != "cognito" {
+		t.Error("expected auth-type cognito")
+	}
+	if !strings.Contains(annotations["alb.ingress.kubernetes.io/auth-idp-cognito"], "UserPoolArn") {
+		t.Error("expected cognito config annotation")
+	}
+}
+
+func TestGCPIngressConfig(t *testing.T) {
+	config := &GCPIngressConfig{
+		GlobalStaticIPName:  "my-static-ip",
+		BackendConfigName:   "my-backend-config",
+		ManagedCertificates: []string{"cert-1", "cert-2"},
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["kubernetes.io/ingress.global-static-ip-name"] != "my-static-ip" {
+		t.Error("expected global-static-ip-name annotation")
+	}
+	if !strings.Contains(annotations["cloud.google.com/backend-config"], "my-backend-config") {
+		t.Error("expected backend-config annotation")
+	}
+	if annotations["networking.gke.io/managed-certificates"] != "cert-1,cert-2" {
+		t.Error("expected managed-certificates annotation")
+	}
+}
+
+func TestIngressBuilder(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithIngressClass("nginx").
+		WithTLS([]string{"example.com"}, "tls-secret").
+		WithRule("example.com",
+			PathPrefix("/api", "api-service", 8080),
+			PathPrefix("/", "web-service", 80),
+		).
+		WithAnnotation("custom", "value").
+		WithLabel("env", "prod").
+		Build()
+
+	if ingress.Metadata.Name != "test" {
+		t.Errorf("expected name 'test', got '%s'", ingress.Metadata.Name)
+	}
+	if ingress.Spec.IngressClassName != "nginx" {
+		t.Error("expected nginx ingress class")
+	}
+	if len(ingress.Spec.TLS) != 1 {
+		t.Error("expected 1 TLS config")
+	}
+	if len(ingress.Spec.Rules) != 1 {
+		t.Error("expected 1 rule")
+	}
+	if ingress.Metadata.Annotations["custom"] != "value" {
+		t.Error("expected custom annotation")
+	}
+	if ingress.Metadata.Labels["env"] != "prod" {
+		t.Error("expected env label")
+	}
+}
+
+func TestIngressBuilderWithNginx(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithNginx(&NginxIngressConfig{
+			SSLRedirect:   true,
+			ProxyBodySize: "50m",
+		}).
+		Build()
+
+	if ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] != "true" {
+		t.Error("expected nginx ssl-redirect annotation")
+	}
+}
+
+func TestIngressBuilderWithDefaultBackend(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithDefaultBackend("default-service", 80).
+		Build()
+
+	if ingress.Spec.DefaultBackend == nil {
+		t.Fatal("expected default backend")
+	}
+	if ingress.Spec.DefaultBackend.Service.Name != "default-service" {
+		t.Error("expected default-service name")
+	}
+}
+
+func TestPathPrefix(t *testing.T) {
+	path := PathPrefix("/api", "api-service", 8080)
+
+	if path.Path != "/api" {
+		t.Errorf("expected path '/api', got '%s'", path.Path)
+	}
+	if path.PathType != "Prefix" {
+		t.Errorf("expected pathType 'Prefix', got '%s'", path.PathType)
+	}
+	if path.Backend.Service.Name != "api-service" {
+		t.Error("expected api-service")
+	}
+	if path.Backend.Service.Port.Number != 8080 {
+		t.Errorf("expected port 8080, got %d", path.Backend.Service.Port.Number)
+	}
+}
+
+func TestPathExact(t *testing.T) {
+	path := PathExact("/health", "health-service", 8080)
+
+	if path.PathType != "Exact" {
+		t.Errorf("expected pathType 'Exact', got '%s'", path.PathType)
+	}
+}
+
+func TestPathImplementationSpecific(t *testing.T) {
+	path := PathImplementationSpecific("/legacy/*", "legacy-service", 80)
+
+	if path.PathType != "ImplementationSpecific" {
+		t.Errorf("expected pathType 'ImplementationSpecific', got '%s'", path.PathType)
+	}
+}
+
+func TestGenerateVaultaireIngress(t *testing.T) {
+	ingress := GenerateVaultaireIngress("vaultaire", "api.vaultaire.io", "vaultaire-tls", "nginx")
+
+	if ingress.Metadata.Name != "vaultaire" {
+		t.Errorf("expected name 'vaultaire', got '%s'", ingress.Metadata.Name)
+	}
+	if ingress.Metadata.Namespace != "vaultaire" {
+		t.Errorf("expected namespace 'vaultaire', got '%s'", ingress.Metadata.Namespace)
+	}
+
+	// Check TLS
+	if len(ingress.Spec.TLS) != 1 {
+		t.Fatal("expected 1 TLS config")
+	}
+	if ingress.Spec.TLS[0].SecretName != "vaultaire-tls" {
+		t.Error("expected vaultaire-tls secret")
+	}
+
+	// Check rules
+	if len(ingress.Spec.Rules) != 1 {
+		t.Fatal("expected 1 rule")
+	}
+	if ingress.Spec.Rules[0].Host != "api.vaultaire.io" {
+		t.Error("expected api.vaultaire.io host")
+	}
+
+	// Check paths
+	paths := ingress.Spec.Rules[0].HTTP.Paths
+	if len(paths) != 4 {
+		t.Errorf("expected 4 paths, got %d", len(paths))
+	}
+
+	// Check nginx annotations
+	if ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] != "true" {
+		t.Error("expected ssl-redirect annotation")
+	}
+	if ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/enable-cors"] != "true" {
+		t.Error("expected enable-cors annotation")
+	}
+}
+
+func TestIngressSet(t *testing.T) {
+	im := NewIngressManager("default")
+
+	set := &IngressSet{}
+	set.Add(im.GenerateIngress(K8sIngressConfig{Name: "ingress-1"}))
+	set.Add(im.GenerateIngress(K8sIngressConfig{Name: "ingress-2"}))
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 2 {
+		t.Errorf("expected 2 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestIngressWithMultipleTLS(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithTLS([]string{"app1.example.com"}, "tls-app1").
+		WithTLS([]string{"app2.example.com"}, "tls-app2").
+		Build()
+
+	if len(ingress.Spec.TLS) != 2 {
+		t.Errorf("expected 2 TLS configs, got %d", len(ingress.Spec.TLS))
+	}
+}
+
+func TestIngressWithMultipleRules(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithRule("app1.example.com", PathPrefix("/", "app1", 80)).
+		WithRule("app2.example.com", PathPrefix("/", "app2", 80)).
+		Build()
+
+	if len(ingress.Spec.Rules) != 2 {
+		t.Errorf("expected 2 rules, got %d", len(ingress.Spec.Rules))
+	}
+}
+
+func TestNginxSnippets(t *testing.T) {
+	config := &NginxIngressConfig{
+		ServerSnippet:        "add_header X-Frame-Options DENY;",
+		ConfigurationSnippet: "proxy_set_header X-Real-IP $remote_addr;",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/server-snippet"] != "add_header X-Frame-Options DENY;" {
+		t.Error("expected server-snippet annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/configuration-snippet"] != "proxy_set_header X-Real-IP $remote_addr;" {
+		t.Error("expected configuration-snippet annotation")
+	}
+}
+
+func TestNginxWhitelist(t *testing.T) {
+	config := &NginxIngressConfig{
+		WhitelistSourceRange: "10.0.0.0/8,192.168.0.0/16",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] != "10.0.0.0/8,192.168.0.0/16" {
+		t.Error("expected whitelist-source-range annotation")
+	}
+}
+
+func TestNginxModSecurity(t *testing.T) {
+	config := &NginxIngressConfig{
+		EnableModsecurity:  true,
+		ModsecuritySnippet: "SecRuleEngine On",
+	}
+
+	annotations := config.ToAnnotations()
+
+	if annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] != "true" {
+		t.Error("expected enable-modsecurity annotation")
+	}
+	if annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"] != "SecRuleEngine On" {
+		t.Error("expected modsecurity-snippet annotation")
+	}
+}
+
+func TestIngressBuilderMultipleProviders(t *testing.T) {
+	ingress := NewIngressBuilder("test", "default").
+		WithNginx(&NginxIngressConfig{SSLRedirect: true}).
+		WithAnnotation("custom", "value").
+		Build()
+
+	if ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] != "true" {
+		t.Error("expected nginx annotation")
+	}
+	if ingress.Metadata.Annotations["custom"] != "value" {
+		t.Error("expected custom annotation")
+	}
+}

--- a/internal/k8s/istio.go
+++ b/internal/k8s/istio.go
@@ -1,0 +1,1233 @@
+// internal/k8s/istio.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// IstioResourceKind represents Istio CRD types
+type IstioResourceKind string
+
+const (
+	KindVirtualService        IstioResourceKind = "VirtualService"
+	KindDestinationRule       IstioResourceKind = "DestinationRule"
+	KindGateway               IstioResourceKind = "Gateway"
+	KindServiceEntry          IstioResourceKind = "ServiceEntry"
+	KindSidecar               IstioResourceKind = "Sidecar"
+	KindAuthorizationPolicy   IstioResourceKind = "AuthorizationPolicy"
+	KindPeerAuthentication    IstioResourceKind = "PeerAuthentication"
+	KindRequestAuthentication IstioResourceKind = "RequestAuthentication"
+	KindEnvoyFilter           IstioResourceKind = "EnvoyFilter"
+)
+
+// IstioManager manages Istio resources
+type IstioManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewIstioManager creates a new Istio manager
+func NewIstioManager(namespace string) *IstioManager {
+	return &IstioManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// IstioResource represents a generic Istio resource
+type IstioResource struct {
+	APIVersion string                 `yaml:"apiVersion"`
+	Kind       IstioResourceKind      `yaml:"kind"`
+	Metadata   ManifestMetadata       `yaml:"metadata"`
+	Spec       map[string]interface{} `yaml:"spec"`
+}
+
+// ToYAML converts the resource to YAML
+func (r *IstioResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(r); err != nil {
+		return "", fmt.Errorf("failed to encode Istio resource: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// VirtualServiceConfig configures a VirtualService
+type VirtualServiceConfig struct {
+	Name      string
+	Namespace string
+	Hosts     []string
+	Gateways  []string
+	HTTP      []HTTPRoute
+	TCP       []TCPRoute
+	TLS       []TLSRoute
+}
+
+// HTTPRoute defines HTTP routing rules
+type HTTPRoute struct {
+	Name             string
+	Match            []HTTPMatchRequest
+	Route            []HTTPRouteDestination
+	Timeout          string
+	Retries          *HTTPRetry
+	Fault            *HTTPFaultInjection
+	Headers          *HeadersConfig
+	Mirror           *HTTPRouteDestination
+	MirrorPercentage *Percentage
+	CorsPolicy       *CorsPolicy
+}
+
+// HTTPMatchRequest defines HTTP match conditions
+type HTTPMatchRequest struct {
+	URI           *StringMatch
+	Scheme        *StringMatch
+	Method        *StringMatch
+	Authority     *StringMatch
+	Headers       map[string]*StringMatch
+	QueryParams   map[string]*StringMatch
+	SourceLabels  map[string]string
+	Port          int
+	IgnoreUriCase bool
+}
+
+// StringMatch defines string matching rules
+type StringMatch struct {
+	Exact  string `yaml:"exact,omitempty"`
+	Prefix string `yaml:"prefix,omitempty"`
+	Regex  string `yaml:"regex,omitempty"`
+}
+
+// HTTPRouteDestination defines a route destination
+type HTTPRouteDestination struct {
+	Destination Destination    `yaml:"destination"`
+	Weight      int            `yaml:"weight,omitempty"`
+	Headers     *HeadersConfig `yaml:"headers,omitempty"`
+}
+
+// Destination defines the destination service
+type Destination struct {
+	Host   string        `yaml:"host"`
+	Subset string        `yaml:"subset,omitempty"`
+	Port   *PortSelector `yaml:"port,omitempty"`
+}
+
+// PortSelector selects a port by number or name
+type PortSelector struct {
+	Number int `yaml:"number,omitempty"`
+}
+
+// HTTPRetry defines retry policy
+type HTTPRetry struct {
+	Attempts      int    `yaml:"attempts"`
+	PerTryTimeout string `yaml:"perTryTimeout,omitempty"`
+	RetryOn       string `yaml:"retryOn,omitempty"`
+}
+
+// HTTPFaultInjection defines fault injection
+type HTTPFaultInjection struct {
+	Delay *FaultDelay `yaml:"delay,omitempty"`
+	Abort *FaultAbort `yaml:"abort,omitempty"`
+}
+
+// FaultDelay defines delay fault injection
+type FaultDelay struct {
+	Percentage *Percentage `yaml:"percentage,omitempty"`
+	FixedDelay string      `yaml:"fixedDelay"`
+}
+
+// FaultAbort defines abort fault injection
+type FaultAbort struct {
+	Percentage *Percentage `yaml:"percentage,omitempty"`
+	HTTPStatus int         `yaml:"httpStatus"`
+}
+
+// Percentage defines a percentage value
+type Percentage struct {
+	Value float64 `yaml:"value"`
+}
+
+// HeadersConfig defines header manipulation
+type HeadersConfig struct {
+	Request  *HeaderOperations `yaml:"request,omitempty"`
+	Response *HeaderOperations `yaml:"response,omitempty"`
+}
+
+// HeaderOperations defines header operations
+type HeaderOperations struct {
+	Set    map[string]string `yaml:"set,omitempty"`
+	Add    map[string]string `yaml:"add,omitempty"`
+	Remove []string          `yaml:"remove,omitempty"`
+}
+
+// CorsPolicy defines CORS policy
+type CorsPolicy struct {
+	AllowOrigins     []StringMatch `yaml:"allowOrigins,omitempty"`
+	AllowMethods     []string      `yaml:"allowMethods,omitempty"`
+	AllowHeaders     []string      `yaml:"allowHeaders,omitempty"`
+	ExposeHeaders    []string      `yaml:"exposeHeaders,omitempty"`
+	MaxAge           string        `yaml:"maxAge,omitempty"`
+	AllowCredentials bool          `yaml:"allowCredentials,omitempty"`
+}
+
+// TCPRoute defines TCP routing
+type TCPRoute struct {
+	Match []TCPMatchRequest     `yaml:"match,omitempty"`
+	Route []TCPRouteDestination `yaml:"route"`
+}
+
+// TCPMatchRequest defines TCP match conditions
+type TCPMatchRequest struct {
+	DestinationSubnets []string          `yaml:"destinationSubnets,omitempty"`
+	Port               int               `yaml:"port,omitempty"`
+	SourceLabels       map[string]string `yaml:"sourceLabels,omitempty"`
+	Gateways           []string          `yaml:"gateways,omitempty"`
+}
+
+// TCPRouteDestination defines TCP route destination
+type TCPRouteDestination struct {
+	Destination Destination `yaml:"destination"`
+	Weight      int         `yaml:"weight,omitempty"`
+}
+
+// TLSRoute defines TLS routing
+type TLSRoute struct {
+	Match []TLSMatchAttributes  `yaml:"match"`
+	Route []TCPRouteDestination `yaml:"route"`
+}
+
+// TLSMatchAttributes defines TLS match conditions
+type TLSMatchAttributes struct {
+	SNIHosts           []string          `yaml:"sniHosts"`
+	DestinationSubnets []string          `yaml:"destinationSubnets,omitempty"`
+	Port               int               `yaml:"port,omitempty"`
+	SourceLabels       map[string]string `yaml:"sourceLabels,omitempty"`
+	Gateways           []string          `yaml:"gateways,omitempty"`
+}
+
+// GenerateVirtualService creates a VirtualService resource
+func (im *IstioManager) GenerateVirtualService(config VirtualServiceConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := map[string]interface{}{
+		"hosts": config.Hosts,
+	}
+
+	if len(config.Gateways) > 0 {
+		spec["gateways"] = config.Gateways
+	}
+
+	if len(config.HTTP) > 0 {
+		httpRoutes := make([]map[string]interface{}, 0, len(config.HTTP))
+		for _, route := range config.HTTP {
+			httpRoute := make(map[string]interface{})
+
+			if route.Name != "" {
+				httpRoute["name"] = route.Name
+			}
+
+			if len(route.Match) > 0 {
+				httpRoute["match"] = convertHTTPMatches(route.Match)
+			}
+
+			if len(route.Route) > 0 {
+				httpRoute["route"] = convertHTTPDestinations(route.Route)
+			}
+
+			if route.Timeout != "" {
+				httpRoute["timeout"] = route.Timeout
+			}
+
+			if route.Retries != nil {
+				httpRoute["retries"] = route.Retries
+			}
+
+			if route.Fault != nil {
+				httpRoute["fault"] = route.Fault
+			}
+
+			if route.Headers != nil {
+				httpRoute["headers"] = route.Headers
+			}
+
+			if route.Mirror != nil {
+				httpRoute["mirror"] = route.Mirror
+			}
+
+			if route.CorsPolicy != nil {
+				httpRoute["corsPolicy"] = route.CorsPolicy
+			}
+
+			httpRoutes = append(httpRoutes, httpRoute)
+		}
+		spec["http"] = httpRoutes
+	}
+
+	if len(config.TCP) > 0 {
+		spec["tcp"] = config.TCP
+	}
+
+	if len(config.TLS) > 0 {
+		spec["tls"] = config.TLS
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "networking.istio.io/v1beta1",
+		Kind:       KindVirtualService,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+func convertHTTPMatches(matches []HTTPMatchRequest) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(matches))
+	for _, match := range matches {
+		m := make(map[string]interface{})
+
+		if match.URI != nil {
+			m["uri"] = match.URI
+		}
+		if match.Scheme != nil {
+			m["scheme"] = match.Scheme
+		}
+		if match.Method != nil {
+			m["method"] = match.Method
+		}
+		if match.Authority != nil {
+			m["authority"] = match.Authority
+		}
+		if len(match.Headers) > 0 {
+			m["headers"] = match.Headers
+		}
+		if len(match.QueryParams) > 0 {
+			m["queryParams"] = match.QueryParams
+		}
+		if len(match.SourceLabels) > 0 {
+			m["sourceLabels"] = match.SourceLabels
+		}
+		if match.Port > 0 {
+			m["port"] = match.Port
+		}
+		if match.IgnoreUriCase {
+			m["ignoreUriCase"] = true
+		}
+
+		result = append(result, m)
+	}
+	return result
+}
+
+func convertHTTPDestinations(destinations []HTTPRouteDestination) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(destinations))
+	for _, dest := range destinations {
+		d := map[string]interface{}{
+			"destination": dest.Destination,
+		}
+		if dest.Weight > 0 {
+			d["weight"] = dest.Weight
+		}
+		if dest.Headers != nil {
+			d["headers"] = dest.Headers
+		}
+		result = append(result, d)
+	}
+	return result
+}
+
+// DestinationRuleConfig configures a DestinationRule
+type DestinationRuleConfig struct {
+	Name          string
+	Namespace     string
+	Host          string
+	TrafficPolicy *TrafficPolicy
+	Subsets       []Subset
+}
+
+// TrafficPolicy defines traffic policy
+type TrafficPolicy struct {
+	ConnectionPool    *ConnectionPoolSettings `yaml:"connectionPool,omitempty"`
+	LoadBalancer      *LoadBalancerSettings   `yaml:"loadBalancer,omitempty"`
+	OutlierDetection  *OutlierDetection       `yaml:"outlierDetection,omitempty"`
+	TLS               *TLSSettings            `yaml:"tls,omitempty"`
+	PortLevelSettings []PortTrafficPolicy     `yaml:"portLevelSettings,omitempty"`
+}
+
+// ConnectionPoolSettings defines connection pool
+type ConnectionPoolSettings struct {
+	TCP  *TCPSettings  `yaml:"tcp,omitempty"`
+	HTTP *HTTPSettings `yaml:"http,omitempty"`
+}
+
+// TCPSettings defines TCP connection settings
+type TCPSettings struct {
+	MaxConnections int           `yaml:"maxConnections,omitempty"`
+	ConnectTimeout string        `yaml:"connectTimeout,omitempty"`
+	TCPKeepalive   *TCPKeepalive `yaml:"tcpKeepalive,omitempty"`
+}
+
+// TCPKeepalive defines TCP keepalive settings
+type TCPKeepalive struct {
+	Probes   int    `yaml:"probes,omitempty"`
+	Time     string `yaml:"time,omitempty"`
+	Interval string `yaml:"interval,omitempty"`
+}
+
+// HTTPSettings defines HTTP connection settings
+type HTTPSettings struct {
+	H2UpgradePolicy          string `yaml:"h2UpgradePolicy,omitempty"`
+	HTTP1MaxPendingRequests  int    `yaml:"http1MaxPendingRequests,omitempty"`
+	HTTP2MaxRequests         int    `yaml:"http2MaxRequests,omitempty"`
+	MaxRequestsPerConnection int    `yaml:"maxRequestsPerConnection,omitempty"`
+	MaxRetries               int    `yaml:"maxRetries,omitempty"`
+	IdleTimeout              string `yaml:"idleTimeout,omitempty"`
+}
+
+// LoadBalancerSettings defines load balancer settings
+type LoadBalancerSettings struct {
+	Simple             string             `yaml:"simple,omitempty"`
+	ConsistentHash     *ConsistentHashLB  `yaml:"consistentHash,omitempty"`
+	LocalityLbSetting  *LocalityLBSetting `yaml:"localityLbSetting,omitempty"`
+	WarmupDurationSecs string             `yaml:"warmupDurationSecs,omitempty"`
+}
+
+// ConsistentHashLB defines consistent hash load balancing
+type ConsistentHashLB struct {
+	HTTPHeaderName         string      `yaml:"httpHeaderName,omitempty"`
+	HTTPCookie             *HTTPCookie `yaml:"httpCookie,omitempty"`
+	UseSourceIP            bool        `yaml:"useSourceIp,omitempty"`
+	HTTPQueryParameterName string      `yaml:"httpQueryParameterName,omitempty"`
+	MinimumRingSize        int         `yaml:"minimumRingSize,omitempty"`
+}
+
+// HTTPCookie defines cookie-based hashing
+type HTTPCookie struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path,omitempty"`
+	TTL  string `yaml:"ttl,omitempty"`
+}
+
+// LocalityLBSetting defines locality load balancing
+type LocalityLBSetting struct {
+	Distribute []LocalityDistribution `yaml:"distribute,omitempty"`
+	Failover   []LocalityFailover     `yaml:"failover,omitempty"`
+	Enabled    *bool                  `yaml:"enabled,omitempty"`
+}
+
+// LocalityDistribution defines traffic distribution
+type LocalityDistribution struct {
+	From string         `yaml:"from"`
+	To   map[string]int `yaml:"to"`
+}
+
+// LocalityFailover defines failover policy
+type LocalityFailover struct {
+	From string `yaml:"from"`
+	To   string `yaml:"to"`
+}
+
+// OutlierDetection defines outlier detection
+type OutlierDetection struct {
+	Consecutive5xxErrors           int    `yaml:"consecutive5xxErrors,omitempty"`
+	ConsecutiveGatewayErrors       int    `yaml:"consecutiveGatewayErrors,omitempty"`
+	ConsecutiveLocalOriginFailures int    `yaml:"consecutiveLocalOriginFailures,omitempty"`
+	Interval                       string `yaml:"interval,omitempty"`
+	BaseEjectionTime               string `yaml:"baseEjectionTime,omitempty"`
+	MaxEjectionPercent             int    `yaml:"maxEjectionPercent,omitempty"`
+	MinHealthPercent               int    `yaml:"minHealthPercent,omitempty"`
+	SplitExternalLocalOriginErrors bool   `yaml:"splitExternalLocalOriginErrors,omitempty"`
+}
+
+// TLSSettings defines TLS settings
+type TLSSettings struct {
+	Mode               string   `yaml:"mode"`
+	ClientCertificate  string   `yaml:"clientCertificate,omitempty"`
+	PrivateKey         string   `yaml:"privateKey,omitempty"`
+	CACertificates     string   `yaml:"caCertificates,omitempty"`
+	CredentialName     string   `yaml:"credentialName,omitempty"`
+	SubjectAltNames    []string `yaml:"subjectAltNames,omitempty"`
+	SNI                string   `yaml:"sni,omitempty"`
+	InsecureSkipVerify bool     `yaml:"insecureSkipVerify,omitempty"`
+}
+
+// PortTrafficPolicy defines per-port traffic policy
+type PortTrafficPolicy struct {
+	Port             *PortSelector           `yaml:"port"`
+	ConnectionPool   *ConnectionPoolSettings `yaml:"connectionPool,omitempty"`
+	LoadBalancer     *LoadBalancerSettings   `yaml:"loadBalancer,omitempty"`
+	OutlierDetection *OutlierDetection       `yaml:"outlierDetection,omitempty"`
+	TLS              *TLSSettings            `yaml:"tls,omitempty"`
+}
+
+// Subset defines a service subset
+type Subset struct {
+	Name          string            `yaml:"name"`
+	Labels        map[string]string `yaml:"labels"`
+	TrafficPolicy *TrafficPolicy    `yaml:"trafficPolicy,omitempty"`
+}
+
+// GenerateDestinationRule creates a DestinationRule resource
+func (im *IstioManager) GenerateDestinationRule(config DestinationRuleConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := map[string]interface{}{
+		"host": config.Host,
+	}
+
+	if config.TrafficPolicy != nil {
+		spec["trafficPolicy"] = config.TrafficPolicy
+	}
+
+	if len(config.Subsets) > 0 {
+		spec["subsets"] = config.Subsets
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "networking.istio.io/v1beta1",
+		Kind:       KindDestinationRule,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// GatewayConfig configures an Istio Gateway
+type GatewayConfig struct {
+	Name      string
+	Namespace string
+	Selector  map[string]string
+	Servers   []GatewayServer
+}
+
+// GatewayServer defines a gateway server
+type GatewayServer struct {
+	Port  *GatewayPort `yaml:"port"`
+	Hosts []string     `yaml:"hosts"`
+	TLS   *GatewayTLS  `yaml:"tls,omitempty"`
+	Name  string       `yaml:"name,omitempty"`
+}
+
+// GatewayPort defines gateway port
+type GatewayPort struct {
+	Number   int    `yaml:"number"`
+	Name     string `yaml:"name"`
+	Protocol string `yaml:"protocol"`
+}
+
+// GatewayTLS defines gateway TLS settings
+type GatewayTLS struct {
+	Mode               string   `yaml:"mode"`
+	CredentialName     string   `yaml:"credentialName,omitempty"`
+	ServerCertificate  string   `yaml:"serverCertificate,omitempty"`
+	PrivateKey         string   `yaml:"privateKey,omitempty"`
+	CACertificates     string   `yaml:"caCertificates,omitempty"`
+	SubjectAltNames    []string `yaml:"subjectAltNames,omitempty"`
+	MinProtocolVersion string   `yaml:"minProtocolVersion,omitempty"`
+	MaxProtocolVersion string   `yaml:"maxProtocolVersion,omitempty"`
+	CipherSuites       []string `yaml:"cipherSuites,omitempty"`
+}
+
+// GenerateGateway creates a Gateway resource
+func (im *IstioManager) GenerateGateway(config GatewayConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	if config.Selector == nil {
+		config.Selector = map[string]string{
+			"istio": "ingressgateway",
+		}
+	}
+
+	spec := map[string]interface{}{
+		"selector": config.Selector,
+		"servers":  config.Servers,
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "networking.istio.io/v1beta1",
+		Kind:       KindGateway,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// AuthorizationPolicyConfig configures an AuthorizationPolicy
+type AuthorizationPolicyConfig struct {
+	Name      string
+	Namespace string
+	Selector  *WorkloadSelector
+	Action    string // ALLOW, DENY, CUSTOM, AUDIT
+	Rules     []AuthorizationRule
+	Provider  *AuthorizationProvider
+}
+
+// WorkloadSelector selects workloads
+type WorkloadSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+// AuthorizationRule defines authorization rules
+type AuthorizationRule struct {
+	From []RuleFrom  `yaml:"from,omitempty"`
+	To   []RuleTo    `yaml:"to,omitempty"`
+	When []Condition `yaml:"when,omitempty"`
+}
+
+// RuleFrom defines source rules
+type RuleFrom struct {
+	Source *Source `yaml:"source"`
+}
+
+// Source defines traffic source
+type Source struct {
+	Principals           []string `yaml:"principals,omitempty"`
+	NotPrincipals        []string `yaml:"notPrincipals,omitempty"`
+	RequestPrincipals    []string `yaml:"requestPrincipals,omitempty"`
+	NotRequestPrincipals []string `yaml:"notRequestPrincipals,omitempty"`
+	Namespaces           []string `yaml:"namespaces,omitempty"`
+	NotNamespaces        []string `yaml:"notNamespaces,omitempty"`
+	IpBlocks             []string `yaml:"ipBlocks,omitempty"`
+	NotIpBlocks          []string `yaml:"notIpBlocks,omitempty"`
+	RemoteIpBlocks       []string `yaml:"remoteIpBlocks,omitempty"`
+	NotRemoteIpBlocks    []string `yaml:"notRemoteIpBlocks,omitempty"`
+}
+
+// RuleTo defines target rules
+type RuleTo struct {
+	Operation *Operation `yaml:"operation"`
+}
+
+// Operation defines operation rules
+type Operation struct {
+	Hosts      []string `yaml:"hosts,omitempty"`
+	NotHosts   []string `yaml:"notHosts,omitempty"`
+	Ports      []string `yaml:"ports,omitempty"`
+	NotPorts   []string `yaml:"notPorts,omitempty"`
+	Methods    []string `yaml:"methods,omitempty"`
+	NotMethods []string `yaml:"notMethods,omitempty"`
+	Paths      []string `yaml:"paths,omitempty"`
+	NotPaths   []string `yaml:"notPaths,omitempty"`
+}
+
+// Condition defines additional conditions
+type Condition struct {
+	Key       string   `yaml:"key"`
+	Values    []string `yaml:"values,omitempty"`
+	NotValues []string `yaml:"notValues,omitempty"`
+}
+
+// AuthorizationProvider defines external authorization provider
+type AuthorizationProvider struct {
+	Name string `yaml:"name"`
+}
+
+// GenerateAuthorizationPolicy creates an AuthorizationPolicy resource
+func (im *IstioManager) GenerateAuthorizationPolicy(config AuthorizationPolicyConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := make(map[string]interface{})
+
+	if config.Selector != nil {
+		spec["selector"] = config.Selector
+	}
+
+	if config.Action != "" {
+		spec["action"] = config.Action
+	}
+
+	if len(config.Rules) > 0 {
+		spec["rules"] = config.Rules
+	}
+
+	if config.Provider != nil {
+		spec["provider"] = config.Provider
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "security.istio.io/v1beta1",
+		Kind:       KindAuthorizationPolicy,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// PeerAuthenticationConfig configures PeerAuthentication
+type PeerAuthenticationConfig struct {
+	Name          string
+	Namespace     string
+	Selector      *WorkloadSelector
+	MTLS          *PeerAuthenticationMTLS
+	PortLevelMTLS map[int]*PeerAuthenticationMTLS
+}
+
+// PeerAuthenticationMTLS defines mTLS settings
+type PeerAuthenticationMTLS struct {
+	Mode string `yaml:"mode"` // STRICT, PERMISSIVE, DISABLE, UNSET
+}
+
+// GeneratePeerAuthentication creates a PeerAuthentication resource
+func (im *IstioManager) GeneratePeerAuthentication(config PeerAuthenticationConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := make(map[string]interface{})
+
+	if config.Selector != nil {
+		spec["selector"] = config.Selector
+	}
+
+	if config.MTLS != nil {
+		spec["mtls"] = config.MTLS
+	}
+
+	if len(config.PortLevelMTLS) > 0 {
+		spec["portLevelMtls"] = config.PortLevelMTLS
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "security.istio.io/v1beta1",
+		Kind:       KindPeerAuthentication,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// RequestAuthenticationConfig configures RequestAuthentication
+type RequestAuthenticationConfig struct {
+	Name      string
+	Namespace string
+	Selector  *WorkloadSelector
+	JWTRules  []JWTRule
+}
+
+// JWTRule defines JWT authentication rules
+type JWTRule struct {
+	Issuer                string          `yaml:"issuer"`
+	Audiences             []string        `yaml:"audiences,omitempty"`
+	JwksURI               string          `yaml:"jwksUri,omitempty"`
+	Jwks                  string          `yaml:"jwks,omitempty"`
+	FromHeaders           []JWTHeader     `yaml:"fromHeaders,omitempty"`
+	FromParams            []string        `yaml:"fromParams,omitempty"`
+	OutputPayloadToHeader string          `yaml:"outputPayloadToHeader,omitempty"`
+	ForwardOriginalToken  bool            `yaml:"forwardOriginalToken,omitempty"`
+	OutputClaimToHeaders  []ClaimToHeader `yaml:"outputClaimToHeaders,omitempty"`
+}
+
+// JWTHeader defines where to extract JWT
+type JWTHeader struct {
+	Name   string `yaml:"name"`
+	Prefix string `yaml:"prefix,omitempty"`
+}
+
+// ClaimToHeader maps claims to headers
+type ClaimToHeader struct {
+	Header string `yaml:"header"`
+	Claim  string `yaml:"claim"`
+}
+
+// GenerateRequestAuthentication creates a RequestAuthentication resource
+func (im *IstioManager) GenerateRequestAuthentication(config RequestAuthenticationConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := make(map[string]interface{})
+
+	if config.Selector != nil {
+		spec["selector"] = config.Selector
+	}
+
+	if len(config.JWTRules) > 0 {
+		spec["jwtRules"] = config.JWTRules
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "security.istio.io/v1beta1",
+		Kind:       KindRequestAuthentication,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// IstioServicePort defines service port for Istio ServiceEntry
+type IstioServicePort struct {
+	Number     int    `yaml:"number"`
+	Protocol   string `yaml:"protocol"`
+	Name       string `yaml:"name"`
+	TargetPort int    `yaml:"targetPort,omitempty"`
+}
+
+// ServiceEntryConfig configures a ServiceEntry
+type ServiceEntryConfig struct {
+	Name       string
+	Namespace  string
+	Hosts      []string
+	Addresses  []string
+	Ports      []IstioServicePort // Changed from ServicePort
+	Location   string             // MESH_EXTERNAL, MESH_INTERNAL
+	Resolution string             // NONE, STATIC, DNS, DNS_ROUND_ROBIN
+	Endpoints  []WorkloadEntry
+}
+
+// WorkloadEntry defines a workload endpoint
+type WorkloadEntry struct {
+	Address  string            `yaml:"address"`
+	Ports    map[string]int    `yaml:"ports,omitempty"`
+	Labels   map[string]string `yaml:"labels,omitempty"`
+	Network  string            `yaml:"network,omitempty"`
+	Locality string            `yaml:"locality,omitempty"`
+	Weight   int               `yaml:"weight,omitempty"`
+}
+
+// GenerateServiceEntry creates a ServiceEntry resource
+func (im *IstioManager) GenerateServiceEntry(config ServiceEntryConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := map[string]interface{}{
+		"hosts": config.Hosts,
+		"ports": config.Ports,
+	}
+
+	if len(config.Addresses) > 0 {
+		spec["addresses"] = config.Addresses
+	}
+
+	if config.Location != "" {
+		spec["location"] = config.Location
+	}
+
+	if config.Resolution != "" {
+		spec["resolution"] = config.Resolution
+	}
+
+	if len(config.Endpoints) > 0 {
+		spec["endpoints"] = config.Endpoints
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "networking.istio.io/v1beta1",
+		Kind:       KindServiceEntry,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// SidecarConfig configures a Sidecar resource
+type SidecarConfig struct {
+	Name                  string
+	Namespace             string
+	WorkloadSelector      *WorkloadSelector
+	Ingress               []IstioIngressListener
+	Egress                []IstioEgressListener
+	OutboundTrafficPolicy *OutboundTrafficPolicy
+}
+
+// IstioIngressListener defines sidecar ingress
+type IstioIngressListener struct {
+	Port            *SidecarPort `yaml:"port"`
+	Bind            string       `yaml:"bind,omitempty"`
+	CaptureMode     string       `yaml:"captureMode,omitempty"`
+	DefaultEndpoint string       `yaml:"defaultEndpoint,omitempty"`
+}
+
+// IstioEgressListener defines sidecar egress
+type IstioEgressListener struct {
+	Port        *SidecarPort `yaml:"port,omitempty"`
+	Bind        string       `yaml:"bind,omitempty"`
+	CaptureMode string       `yaml:"captureMode,omitempty"`
+	Hosts       []string     `yaml:"hosts"`
+}
+
+// SidecarPort defines sidecar port
+type SidecarPort struct {
+	Number   int    `yaml:"number"`
+	Protocol string `yaml:"protocol"`
+	Name     string `yaml:"name,omitempty"`
+}
+
+// OutboundTrafficPolicy defines outbound traffic policy
+type OutboundTrafficPolicy struct {
+	Mode string `yaml:"mode"` // REGISTRY_ONLY, ALLOW_ANY
+}
+
+// GenerateSidecar creates a Sidecar resource
+func (im *IstioManager) GenerateSidecar(config SidecarConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	spec := make(map[string]interface{})
+
+	if config.WorkloadSelector != nil {
+		spec["workloadSelector"] = config.WorkloadSelector
+	}
+
+	if len(config.Ingress) > 0 {
+		spec["ingress"] = config.Ingress
+	}
+
+	if len(config.Egress) > 0 {
+		spec["egress"] = config.Egress
+	}
+
+	if config.OutboundTrafficPolicy != nil {
+		spec["outboundTrafficPolicy"] = config.OutboundTrafficPolicy
+	}
+
+	labels := copyStringMap(im.labels)
+
+	return &IstioResource{
+		APIVersion: "networking.istio.io/v1beta1",
+		Kind:       KindSidecar,
+		Metadata: ManifestMetadata{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}
+
+// IstioResourceSet represents a collection of Istio resources
+type IstioResourceSet struct {
+	Resources []*IstioResource
+}
+
+// Add adds an Istio resource to the set
+func (s *IstioResourceSet) Add(r *IstioResource) {
+	s.Resources = append(s.Resources, r)
+}
+
+// ToYAML converts all resources to a multi-document YAML
+func (s *IstioResourceSet) ToYAML() (string, error) {
+	var parts []string
+	for _, r := range s.Resources {
+		yaml, err := r.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+	return strings.Join(parts, "---\n"), nil
+}
+
+// GenerateVaultaireIstioConfig generates a complete Istio configuration for Vaultaire
+func GenerateVaultaireIstioConfig(namespace, host string) (*IstioResourceSet, error) {
+	im := NewIstioManager(namespace)
+	set := &IstioResourceSet{}
+
+	// Gateway
+	gateway := im.GenerateGateway(GatewayConfig{
+		Name: "vaultaire-gateway",
+		Servers: []GatewayServer{
+			{
+				Port: &GatewayPort{
+					Number:   443,
+					Name:     "https",
+					Protocol: "HTTPS",
+				},
+				Hosts: []string{host},
+				TLS: &GatewayTLS{
+					Mode:           "SIMPLE",
+					CredentialName: "vaultaire-tls",
+				},
+			},
+			{
+				Port: &GatewayPort{
+					Number:   80,
+					Name:     "http",
+					Protocol: "HTTP",
+				},
+				Hosts: []string{host},
+			},
+		},
+	})
+	set.Add(gateway)
+
+	// VirtualService
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:     "vaultaire",
+		Hosts:    []string{host},
+		Gateways: []string{"vaultaire-gateway"},
+		HTTP: []HTTPRoute{
+			{
+				Name: "main",
+				Match: []HTTPMatchRequest{
+					{URI: &StringMatch{Prefix: "/"}},
+				},
+				Route: []HTTPRouteDestination{
+					{
+						Destination: Destination{
+							Host: "vaultaire",
+							Port: &PortSelector{Number: 80},
+						},
+						Weight: 100,
+					},
+				},
+				Retries: &HTTPRetry{
+					Attempts:      3,
+					PerTryTimeout: "2s",
+					RetryOn:       "5xx,reset,connect-failure",
+				},
+				Timeout: "30s",
+			},
+		},
+	})
+	set.Add(vs)
+
+	// DestinationRule
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "vaultaire",
+		Host: "vaultaire",
+		TrafficPolicy: &TrafficPolicy{
+			ConnectionPool: &ConnectionPoolSettings{
+				TCP: &TCPSettings{
+					MaxConnections: 100,
+					ConnectTimeout: "10s",
+				},
+				HTTP: &HTTPSettings{
+					H2UpgradePolicy:          "UPGRADE",
+					HTTP2MaxRequests:         1000,
+					MaxRequestsPerConnection: 100,
+				},
+			},
+			OutlierDetection: &OutlierDetection{
+				Consecutive5xxErrors: 5,
+				Interval:             "30s",
+				BaseEjectionTime:     "30s",
+				MaxEjectionPercent:   50,
+			},
+		},
+		Subsets: []Subset{
+			{
+				Name:   "v1",
+				Labels: map[string]string{"version": "v1"},
+			},
+		},
+	})
+	set.Add(dr)
+
+	// PeerAuthentication (mTLS)
+	pa := im.GeneratePeerAuthentication(PeerAuthenticationConfig{
+		Name: "vaultaire-mtls",
+		Selector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "vaultaire"},
+		},
+		MTLS: &PeerAuthenticationMTLS{
+			Mode: "STRICT",
+		},
+	})
+	set.Add(pa)
+
+	// AuthorizationPolicy
+	authz := im.GenerateAuthorizationPolicy(AuthorizationPolicyConfig{
+		Name: "vaultaire-authz",
+		Selector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "vaultaire"},
+		},
+		Action: "ALLOW",
+		Rules: []AuthorizationRule{
+			{
+				To: []RuleTo{
+					{
+						Operation: &Operation{
+							Methods: []string{"GET", "POST", "PUT", "DELETE", "HEAD"},
+						},
+					},
+				},
+			},
+		},
+	})
+	set.Add(authz)
+
+	return set, nil
+}
+
+// CanaryDeploymentConfig defines canary deployment settings
+type CanaryDeploymentConfig struct {
+	ServiceName   string
+	Namespace     string
+	StableVersion string
+	CanaryVersion string
+	CanaryWeight  int
+	Headers       map[string]string // Header-based routing to canary
+}
+
+// GenerateCanaryVirtualService creates VirtualService for canary deployment
+func (im *IstioManager) GenerateCanaryVirtualService(config CanaryDeploymentConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	routes := []HTTPRoute{}
+
+	// Header-based routing to canary (for testing)
+	if len(config.Headers) > 0 {
+		headerMatch := make(map[string]*StringMatch)
+		for k, v := range config.Headers {
+			headerMatch[k] = &StringMatch{Exact: v}
+		}
+
+		routes = append(routes, HTTPRoute{
+			Name: "canary-header",
+			Match: []HTTPMatchRequest{
+				{Headers: headerMatch},
+			},
+			Route: []HTTPRouteDestination{
+				{
+					Destination: Destination{
+						Host:   config.ServiceName,
+						Subset: config.CanaryVersion,
+					},
+					Weight: 100,
+				},
+			},
+		})
+	}
+
+	// Weight-based routing
+	routes = append(routes, HTTPRoute{
+		Name: "primary",
+		Route: []HTTPRouteDestination{
+			{
+				Destination: Destination{
+					Host:   config.ServiceName,
+					Subset: config.StableVersion,
+				},
+				Weight: 100 - config.CanaryWeight,
+			},
+			{
+				Destination: Destination{
+					Host:   config.ServiceName,
+					Subset: config.CanaryVersion,
+				},
+				Weight: config.CanaryWeight,
+			},
+		},
+	})
+
+	return im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  config.ServiceName + "-canary",
+		Hosts: []string{config.ServiceName},
+		HTTP:  routes,
+	})
+}
+
+// CircuitBreakerConfig defines circuit breaker settings
+type CircuitBreakerConfig struct {
+	ServiceName          string
+	Namespace            string
+	MaxConnections       int
+	HTTP2MaxRequests     int
+	MaxRequestsPerConn   int
+	Consecutive5xxErrors int
+	EjectionInterval     time.Duration
+	BaseEjectionTime     time.Duration
+	MaxEjectionPercent   int
+}
+
+// GenerateCircuitBreaker creates a DestinationRule with circuit breaker
+func (im *IstioManager) GenerateCircuitBreaker(config CircuitBreakerConfig) *IstioResource {
+	if config.Namespace == "" {
+		config.Namespace = im.namespace
+	}
+
+	// Set defaults
+	if config.MaxConnections == 0 {
+		config.MaxConnections = 100
+	}
+	if config.HTTP2MaxRequests == 0 {
+		config.HTTP2MaxRequests = 1000
+	}
+	if config.Consecutive5xxErrors == 0 {
+		config.Consecutive5xxErrors = 5
+	}
+	if config.EjectionInterval == 0 {
+		config.EjectionInterval = 10 * time.Second
+	}
+	if config.BaseEjectionTime == 0 {
+		config.BaseEjectionTime = 30 * time.Second
+	}
+	if config.MaxEjectionPercent == 0 {
+		config.MaxEjectionPercent = 50
+	}
+
+	return im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: config.ServiceName + "-circuit-breaker",
+		Host: config.ServiceName,
+		TrafficPolicy: &TrafficPolicy{
+			ConnectionPool: &ConnectionPoolSettings{
+				TCP: &TCPSettings{
+					MaxConnections: config.MaxConnections,
+				},
+				HTTP: &HTTPSettings{
+					HTTP2MaxRequests:         config.HTTP2MaxRequests,
+					MaxRequestsPerConnection: config.MaxRequestsPerConn,
+				},
+			},
+			OutlierDetection: &OutlierDetection{
+				Consecutive5xxErrors: config.Consecutive5xxErrors,
+				Interval:             config.EjectionInterval.String(),
+				BaseEjectionTime:     config.BaseEjectionTime.String(),
+				MaxEjectionPercent:   config.MaxEjectionPercent,
+			},
+		},
+	})
+}

--- a/internal/k8s/istio_test.go
+++ b/internal/k8s/istio_test.go
@@ -1,0 +1,827 @@
+// internal/k8s/istio_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewIstioManager(t *testing.T) {
+	im := NewIstioManager("default")
+
+	if im.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", im.namespace)
+	}
+	if im.labels["app.kubernetes.io/managed-by"] != "vaultaire" {
+		t.Error("expected managed-by label")
+	}
+}
+
+func TestGenerateVirtualService(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:     "test-service",
+		Hosts:    []string{"test.example.com"},
+		Gateways: []string{"my-gateway"},
+		HTTP: []HTTPRoute{
+			{
+				Name: "main",
+				Match: []HTTPMatchRequest{
+					{URI: &StringMatch{Prefix: "/api"}},
+				},
+				Route: []HTTPRouteDestination{
+					{
+						Destination: Destination{
+							Host: "test-service",
+							Port: &PortSelector{Number: 8080},
+						},
+						Weight: 100,
+					},
+				},
+				Timeout: "30s",
+			},
+		},
+	})
+
+	if vs.Kind != KindVirtualService {
+		t.Errorf("expected kind VirtualService, got %s", vs.Kind)
+	}
+	if vs.APIVersion != "networking.istio.io/v1beta1" {
+		t.Errorf("expected apiVersion networking.istio.io/v1beta1, got %s", vs.APIVersion)
+	}
+	if vs.Metadata.Name != "test-service" {
+		t.Errorf("expected name 'test-service', got '%s'", vs.Metadata.Name)
+	}
+	if vs.Metadata.Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", vs.Metadata.Namespace)
+	}
+
+	hosts, ok := vs.Spec["hosts"].([]string)
+	if !ok || len(hosts) != 1 || hosts[0] != "test.example.com" {
+		t.Error("expected hosts to be set correctly")
+	}
+}
+
+func TestVirtualServiceWithRetries(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test-service",
+		Hosts: []string{"test.example.com"},
+		HTTP: []HTTPRoute{
+			{
+				Route: []HTTPRouteDestination{
+					{Destination: Destination{Host: "test-service"}},
+				},
+				Retries: &HTTPRetry{
+					Attempts:      3,
+					PerTryTimeout: "2s",
+					RetryOn:       "5xx",
+				},
+			},
+		},
+	})
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+	if len(httpRoutes) != 1 {
+		t.Fatal("expected 1 HTTP route")
+	}
+
+	retries := httpRoutes[0]["retries"].(*HTTPRetry)
+	if retries.Attempts != 3 {
+		t.Errorf("expected 3 retry attempts, got %d", retries.Attempts)
+	}
+}
+
+func TestVirtualServiceWithFaultInjection(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test-service",
+		Hosts: []string{"test.example.com"},
+		HTTP: []HTTPRoute{
+			{
+				Route: []HTTPRouteDestination{
+					{Destination: Destination{Host: "test-service"}},
+				},
+				Fault: &HTTPFaultInjection{
+					Delay: &FaultDelay{
+						FixedDelay: "5s",
+						Percentage: &Percentage{Value: 10},
+					},
+					Abort: &FaultAbort{
+						HTTPStatus: 503,
+						Percentage: &Percentage{Value: 5},
+					},
+				},
+			},
+		},
+	})
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+	fault := httpRoutes[0]["fault"].(*HTTPFaultInjection)
+
+	if fault.Delay.FixedDelay != "5s" {
+		t.Error("expected delay to be 5s")
+	}
+	if fault.Abort.HTTPStatus != 503 {
+		t.Error("expected abort status 503")
+	}
+}
+
+func TestGenerateDestinationRule(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "test-service",
+		Host: "test-service.default.svc.cluster.local",
+		TrafficPolicy: &TrafficPolicy{
+			ConnectionPool: &ConnectionPoolSettings{
+				TCP: &TCPSettings{
+					MaxConnections: 100,
+				},
+				HTTP: &HTTPSettings{
+					HTTP2MaxRequests: 1000,
+				},
+			},
+			LoadBalancer: &LoadBalancerSettings{
+				Simple: "ROUND_ROBIN",
+			},
+		},
+		Subsets: []Subset{
+			{
+				Name:   "v1",
+				Labels: map[string]string{"version": "v1"},
+			},
+			{
+				Name:   "v2",
+				Labels: map[string]string{"version": "v2"},
+			},
+		},
+	})
+
+	if dr.Kind != KindDestinationRule {
+		t.Errorf("expected kind DestinationRule, got %s", dr.Kind)
+	}
+
+	host := dr.Spec["host"].(string)
+	if host != "test-service.default.svc.cluster.local" {
+		t.Errorf("expected host to be set, got '%s'", host)
+	}
+
+	subsets := dr.Spec["subsets"].([]Subset)
+	if len(subsets) != 2 {
+		t.Errorf("expected 2 subsets, got %d", len(subsets))
+	}
+}
+
+func TestDestinationRuleWithOutlierDetection(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "test-service",
+		Host: "test-service",
+		TrafficPolicy: &TrafficPolicy{
+			OutlierDetection: &OutlierDetection{
+				Consecutive5xxErrors: 5,
+				Interval:             "30s",
+				BaseEjectionTime:     "30s",
+				MaxEjectionPercent:   50,
+			},
+		},
+	})
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+	if policy.OutlierDetection.Consecutive5xxErrors != 5 {
+		t.Error("expected consecutive5xxErrors to be 5")
+	}
+}
+
+func TestGenerateGateway(t *testing.T) {
+	im := NewIstioManager("default")
+
+	gw := im.GenerateGateway(GatewayConfig{
+		Name: "test-gateway",
+		Servers: []GatewayServer{
+			{
+				Port: &GatewayPort{
+					Number:   443,
+					Name:     "https",
+					Protocol: "HTTPS",
+				},
+				Hosts: []string{"*.example.com"},
+				TLS: &GatewayTLS{
+					Mode:           "SIMPLE",
+					CredentialName: "my-cert",
+				},
+			},
+			{
+				Port: &GatewayPort{
+					Number:   80,
+					Name:     "http",
+					Protocol: "HTTP",
+				},
+				Hosts: []string{"*.example.com"},
+			},
+		},
+	})
+
+	if gw.Kind != KindGateway {
+		t.Errorf("expected kind Gateway, got %s", gw.Kind)
+	}
+
+	servers := gw.Spec["servers"].([]GatewayServer)
+	if len(servers) != 2 {
+		t.Errorf("expected 2 servers, got %d", len(servers))
+	}
+
+	if servers[0].TLS.CredentialName != "my-cert" {
+		t.Error("expected TLS credential name")
+	}
+}
+
+func TestGatewayDefaultSelector(t *testing.T) {
+	im := NewIstioManager("default")
+
+	gw := im.GenerateGateway(GatewayConfig{
+		Name: "test-gateway",
+		Servers: []GatewayServer{
+			{
+				Port:  &GatewayPort{Number: 80, Name: "http", Protocol: "HTTP"},
+				Hosts: []string{"example.com"},
+			},
+		},
+	})
+
+	selector := gw.Spec["selector"].(map[string]string)
+	if selector["istio"] != "ingressgateway" {
+		t.Error("expected default selector istio=ingressgateway")
+	}
+}
+
+func TestGenerateAuthorizationPolicy(t *testing.T) {
+	im := NewIstioManager("default")
+
+	authz := im.GenerateAuthorizationPolicy(AuthorizationPolicyConfig{
+		Name: "test-authz",
+		Selector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "test"},
+		},
+		Action: "ALLOW",
+		Rules: []AuthorizationRule{
+			{
+				From: []RuleFrom{
+					{
+						Source: &Source{
+							Principals: []string{"cluster.local/ns/default/sa/test"},
+						},
+					},
+				},
+				To: []RuleTo{
+					{
+						Operation: &Operation{
+							Methods: []string{"GET", "POST"},
+							Paths:   []string{"/api/*"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if authz.Kind != KindAuthorizationPolicy {
+		t.Errorf("expected kind AuthorizationPolicy, got %s", authz.Kind)
+	}
+	if authz.APIVersion != "security.istio.io/v1beta1" {
+		t.Errorf("expected security.istio.io/v1beta1, got %s", authz.APIVersion)
+	}
+
+	action := authz.Spec["action"].(string)
+	if action != "ALLOW" {
+		t.Errorf("expected action ALLOW, got %s", action)
+	}
+}
+
+func TestGeneratePeerAuthentication(t *testing.T) {
+	im := NewIstioManager("default")
+
+	pa := im.GeneratePeerAuthentication(PeerAuthenticationConfig{
+		Name: "test-mtls",
+		Selector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "test"},
+		},
+		MTLS: &PeerAuthenticationMTLS{
+			Mode: "STRICT",
+		},
+	})
+
+	if pa.Kind != KindPeerAuthentication {
+		t.Errorf("expected kind PeerAuthentication, got %s", pa.Kind)
+	}
+
+	mtls := pa.Spec["mtls"].(*PeerAuthenticationMTLS)
+	if mtls.Mode != "STRICT" {
+		t.Errorf("expected mTLS mode STRICT, got %s", mtls.Mode)
+	}
+}
+
+func TestGenerateRequestAuthentication(t *testing.T) {
+	im := NewIstioManager("default")
+
+	ra := im.GenerateRequestAuthentication(RequestAuthenticationConfig{
+		Name: "test-jwt",
+		Selector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "test"},
+		},
+		JWTRules: []JWTRule{
+			{
+				Issuer:    "https://auth.example.com",
+				Audiences: []string{"api.example.com"},
+				JwksURI:   "https://auth.example.com/.well-known/jwks.json",
+				FromHeaders: []JWTHeader{
+					{Name: "Authorization", Prefix: "Bearer "},
+				},
+			},
+		},
+	})
+
+	if ra.Kind != KindRequestAuthentication {
+		t.Errorf("expected kind RequestAuthentication, got %s", ra.Kind)
+	}
+
+	rules := ra.Spec["jwtRules"].([]JWTRule)
+	if len(rules) != 1 {
+		t.Fatal("expected 1 JWT rule")
+	}
+	if rules[0].Issuer != "https://auth.example.com" {
+		t.Error("expected issuer to be set")
+	}
+}
+
+func TestGenerateServiceEntry(t *testing.T) {
+	im := NewIstioManager("default")
+
+	se := im.GenerateServiceEntry(ServiceEntryConfig{
+		Name:       "external-api",
+		Hosts:      []string{"api.external.com"},
+		Addresses:  []string{"192.168.1.1"},
+		Location:   "MESH_EXTERNAL",
+		Resolution: "DNS",
+		Ports: []IstioServicePort{
+			{
+				Number:   443,
+				Protocol: "HTTPS",
+				Name:     "https",
+			},
+		},
+		Endpoints: []WorkloadEntry{
+			{
+				Address: "api.external.com",
+				Ports:   map[string]int{"https": 443},
+			},
+		},
+	})
+
+	if se.Kind != KindServiceEntry {
+		t.Errorf("expected kind ServiceEntry, got %s", se.Kind)
+	}
+
+	hosts := se.Spec["hosts"].([]string)
+	if len(hosts) != 1 || hosts[0] != "api.external.com" {
+		t.Error("expected hosts to be set")
+	}
+
+	location := se.Spec["location"].(string)
+	if location != "MESH_EXTERNAL" {
+		t.Errorf("expected location MESH_EXTERNAL, got %s", location)
+	}
+}
+
+func TestGenerateSidecar(t *testing.T) {
+	im := NewIstioManager("default")
+
+	sc := im.GenerateSidecar(SidecarConfig{
+		Name: "test-sidecar",
+		WorkloadSelector: &WorkloadSelector{
+			MatchLabels: map[string]string{"app": "test"},
+		},
+		Egress: []IstioEgressListener{
+			{
+				Hosts: []string{"./*", "istio-system/*"},
+			},
+		},
+		OutboundTrafficPolicy: &OutboundTrafficPolicy{
+			Mode: "REGISTRY_ONLY",
+		},
+	})
+
+	if sc.Kind != KindSidecar {
+		t.Errorf("expected kind Sidecar, got %s", sc.Kind)
+	}
+
+	egress := sc.Spec["egress"].([]IstioEgressListener)
+	if len(egress) != 1 {
+		t.Fatal("expected 1 egress listener")
+	}
+
+	policy := sc.Spec["outboundTrafficPolicy"].(*OutboundTrafficPolicy)
+	if policy.Mode != "REGISTRY_ONLY" {
+		t.Error("expected outbound mode REGISTRY_ONLY")
+	}
+}
+
+func TestIstioResourceToYAML(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test",
+		Hosts: []string{"test.example.com"},
+		HTTP: []HTTPRoute{
+			{
+				Route: []HTTPRouteDestination{
+					{Destination: Destination{Host: "test"}},
+				},
+			},
+		},
+	})
+
+	yaml, err := vs.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: VirtualService") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "networking.istio.io/v1beta1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestIstioResourceSetToYAML(t *testing.T) {
+	im := NewIstioManager("default")
+
+	set := &IstioResourceSet{}
+	set.Add(im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "vs1",
+		Hosts: []string{"host1"},
+	}))
+	set.Add(im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "dr1",
+		Host: "host1",
+	}))
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 2 {
+		t.Errorf("expected 2 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestGenerateVaultaireIstioConfig(t *testing.T) {
+	set, err := GenerateVaultaireIstioConfig("vaultaire", "api.vaultaire.io")
+	if err != nil {
+		t.Fatalf("failed to generate Istio config: %v", err)
+	}
+
+	if len(set.Resources) < 4 {
+		t.Errorf("expected at least 4 resources, got %d", len(set.Resources))
+	}
+
+	// Check for expected resource types
+	kinds := make(map[IstioResourceKind]int)
+	for _, r := range set.Resources {
+		kinds[r.Kind]++
+	}
+
+	if kinds[KindGateway] != 1 {
+		t.Error("expected 1 Gateway")
+	}
+	if kinds[KindVirtualService] != 1 {
+		t.Error("expected 1 VirtualService")
+	}
+	if kinds[KindDestinationRule] != 1 {
+		t.Error("expected 1 DestinationRule")
+	}
+	if kinds[KindPeerAuthentication] != 1 {
+		t.Error("expected 1 PeerAuthentication")
+	}
+}
+
+func TestGenerateCanaryVirtualService(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateCanaryVirtualService(CanaryDeploymentConfig{
+		ServiceName:   "myapp",
+		StableVersion: "v1",
+		CanaryVersion: "v2",
+		CanaryWeight:  10,
+		Headers: map[string]string{
+			"x-canary": "true",
+		},
+	})
+
+	if vs.Kind != KindVirtualService {
+		t.Errorf("expected kind VirtualService, got %s", vs.Kind)
+	}
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+
+	// Should have 2 routes: header-based and weight-based
+	if len(httpRoutes) != 2 {
+		t.Errorf("expected 2 HTTP routes, got %d", len(httpRoutes))
+	}
+}
+
+func TestGenerateCanaryWithoutHeaders(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateCanaryVirtualService(CanaryDeploymentConfig{
+		ServiceName:   "myapp",
+		StableVersion: "v1",
+		CanaryVersion: "v2",
+		CanaryWeight:  20,
+	})
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+
+	// Should have only 1 route (weight-based) when no headers specified
+	if len(httpRoutes) != 1 {
+		t.Errorf("expected 1 HTTP route, got %d", len(httpRoutes))
+	}
+}
+
+func TestGenerateCircuitBreaker(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateCircuitBreaker(CircuitBreakerConfig{
+		ServiceName:          "myapp",
+		MaxConnections:       50,
+		HTTP2MaxRequests:     500,
+		Consecutive5xxErrors: 3,
+		EjectionInterval:     20 * time.Second,
+		BaseEjectionTime:     60 * time.Second,
+		MaxEjectionPercent:   30,
+	})
+
+	if dr.Kind != KindDestinationRule {
+		t.Errorf("expected kind DestinationRule, got %s", dr.Kind)
+	}
+
+	if !strings.Contains(dr.Metadata.Name, "circuit-breaker") {
+		t.Error("expected name to contain 'circuit-breaker'")
+	}
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+
+	if policy.ConnectionPool.TCP.MaxConnections != 50 {
+		t.Errorf("expected maxConnections 50, got %d", policy.ConnectionPool.TCP.MaxConnections)
+	}
+
+	if policy.OutlierDetection.Consecutive5xxErrors != 3 {
+		t.Errorf("expected consecutive5xxErrors 3, got %d", policy.OutlierDetection.Consecutive5xxErrors)
+	}
+}
+
+func TestCircuitBreakerDefaults(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateCircuitBreaker(CircuitBreakerConfig{
+		ServiceName: "myapp",
+	})
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+
+	// Check defaults are applied
+	if policy.ConnectionPool.TCP.MaxConnections != 100 {
+		t.Errorf("expected default maxConnections 100, got %d", policy.ConnectionPool.TCP.MaxConnections)
+	}
+	if policy.OutlierDetection.Consecutive5xxErrors != 5 {
+		t.Errorf("expected default consecutive5xxErrors 5, got %d", policy.OutlierDetection.Consecutive5xxErrors)
+	}
+	if policy.OutlierDetection.MaxEjectionPercent != 50 {
+		t.Errorf("expected default maxEjectionPercent 50, got %d", policy.OutlierDetection.MaxEjectionPercent)
+	}
+}
+
+func TestVirtualServiceNamespaceDefault(t *testing.T) {
+	im := NewIstioManager("production")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test",
+		Hosts: []string{"test"},
+	})
+
+	if vs.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", vs.Metadata.Namespace)
+	}
+}
+
+func TestVirtualServiceNamespaceOverride(t *testing.T) {
+	im := NewIstioManager("production")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:      "test",
+		Namespace: "staging",
+		Hosts:     []string{"test"},
+	})
+
+	if vs.Metadata.Namespace != "staging" {
+		t.Errorf("expected namespace 'staging', got '%s'", vs.Metadata.Namespace)
+	}
+}
+
+func TestLoadBalancerConsistentHash(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "test",
+		Host: "test",
+		TrafficPolicy: &TrafficPolicy{
+			LoadBalancer: &LoadBalancerSettings{
+				ConsistentHash: &ConsistentHashLB{
+					HTTPHeaderName: "x-user-id",
+				},
+			},
+		},
+	})
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+	if policy.LoadBalancer.ConsistentHash.HTTPHeaderName != "x-user-id" {
+		t.Error("expected consistent hash by header")
+	}
+}
+
+func TestLoadBalancerCookieHash(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "test",
+		Host: "test",
+		TrafficPolicy: &TrafficPolicy{
+			LoadBalancer: &LoadBalancerSettings{
+				ConsistentHash: &ConsistentHashLB{
+					HTTPCookie: &HTTPCookie{
+						Name: "session",
+						TTL:  "3600s",
+					},
+				},
+			},
+		},
+	})
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+	if policy.LoadBalancer.ConsistentHash.HTTPCookie.Name != "session" {
+		t.Error("expected consistent hash by cookie")
+	}
+}
+
+func TestTLSSettings(t *testing.T) {
+	im := NewIstioManager("default")
+
+	dr := im.GenerateDestinationRule(DestinationRuleConfig{
+		Name: "test",
+		Host: "external-service",
+		TrafficPolicy: &TrafficPolicy{
+			TLS: &TLSSettings{
+				Mode:              "MUTUAL",
+				ClientCertificate: "/etc/certs/cert.pem",
+				PrivateKey:        "/etc/certs/key.pem",
+				CACertificates:    "/etc/certs/ca.pem",
+			},
+		},
+	})
+
+	policy := dr.Spec["trafficPolicy"].(*TrafficPolicy)
+	if policy.TLS.Mode != "MUTUAL" {
+		t.Errorf("expected TLS mode MUTUAL, got %s", policy.TLS.Mode)
+	}
+}
+
+func TestCorsPolicy(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test",
+		Hosts: []string{"test"},
+		HTTP: []HTTPRoute{
+			{
+				Route: []HTTPRouteDestination{
+					{Destination: Destination{Host: "test"}},
+				},
+				CorsPolicy: &CorsPolicy{
+					AllowOrigins: []StringMatch{
+						{Exact: "https://example.com"},
+					},
+					AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+					AllowHeaders:     []string{"Authorization", "Content-Type"},
+					AllowCredentials: true,
+					MaxAge:           "24h",
+				},
+			},
+		},
+	})
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+	cors := httpRoutes[0]["corsPolicy"].(*CorsPolicy)
+
+	if len(cors.AllowMethods) != 3 {
+		t.Error("expected 3 allowed methods")
+	}
+	if !cors.AllowCredentials {
+		t.Error("expected allowCredentials to be true")
+	}
+}
+
+func TestHeaderManipulation(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "test",
+		Hosts: []string{"test"},
+		HTTP: []HTTPRoute{
+			{
+				Route: []HTTPRouteDestination{
+					{
+						Destination: Destination{Host: "test"},
+						Headers: &HeadersConfig{
+							Request: &HeaderOperations{
+								Set:    map[string]string{"x-custom": "value"},
+								Remove: []string{"x-internal"},
+							},
+							Response: &HeaderOperations{
+								Add: map[string]string{"x-served-by": "vaultaire"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	httpRoutes := vs.Spec["http"].([]map[string]interface{})
+	if httpRoutes[0]["route"] == nil {
+		t.Fatal("expected route to be set")
+	}
+}
+
+func TestTCPRoute(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "tcp-service",
+		Hosts: []string{"tcp.example.com"},
+		TCP: []TCPRoute{
+			{
+				Match: []TCPMatchRequest{
+					{Port: 3306},
+				},
+				Route: []TCPRouteDestination{
+					{
+						Destination: Destination{
+							Host: "mysql",
+							Port: &PortSelector{Number: 3306},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	tcpRoutes := vs.Spec["tcp"].([]TCPRoute)
+	if len(tcpRoutes) != 1 {
+		t.Error("expected 1 TCP route")
+	}
+}
+
+func TestTLSRoute(t *testing.T) {
+	im := NewIstioManager("default")
+
+	vs := im.GenerateVirtualService(VirtualServiceConfig{
+		Name:  "tls-service",
+		Hosts: []string{"*.example.com"},
+		TLS: []TLSRoute{
+			{
+				Match: []TLSMatchAttributes{
+					{SNIHosts: []string{"secure.example.com"}},
+				},
+				Route: []TCPRouteDestination{
+					{
+						Destination: Destination{Host: "secure-backend"},
+					},
+				},
+			},
+		},
+	})
+
+	tlsRoutes := vs.Spec["tls"].([]TLSRoute)
+	if len(tlsRoutes) != 1 {
+		t.Error("expected 1 TLS route")
+	}
+}

--- a/internal/k8s/manifests.go
+++ b/internal/k8s/manifests.go
@@ -1,0 +1,852 @@
+// internal/k8s/manifests.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestKind represents Kubernetes resource types
+type ManifestKind string
+
+const (
+	KindDeployment              ManifestKind = "Deployment"
+	KindService                 ManifestKind = "Service"
+	KindConfigMap               ManifestKind = "ConfigMap"
+	KindSecret                  ManifestKind = "Secret"
+	KindIngress                 ManifestKind = "Ingress"
+	KindHorizontalPodAutoscaler ManifestKind = "HorizontalPodAutoscaler"
+	KindPodDisruptionBudget     ManifestKind = "PodDisruptionBudget"
+	KindServiceAccount          ManifestKind = "ServiceAccount"
+	KindRole                    ManifestKind = "Role"
+	KindRoleBinding             ManifestKind = "RoleBinding"
+	KindClusterRole             ManifestKind = "ClusterRole"
+	KindClusterRoleBinding      ManifestKind = "ClusterRoleBinding"
+	KindNetworkPolicy           ManifestKind = "NetworkPolicy"
+	KindPersistentVolumeClaim   ManifestKind = "PersistentVolumeClaim"
+	KindStatefulSet             ManifestKind = "StatefulSet"
+)
+
+// Manifest represents a Kubernetes manifest
+type Manifest struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       ManifestKind      `yaml:"kind"`
+	Metadata   ManifestMetadata  `yaml:"metadata"`
+	Spec       interface{}       `yaml:"spec,omitempty"`
+	Data       map[string]string `yaml:"data,omitempty"`
+	StringData map[string]string `yaml:"stringData,omitempty"`
+	Type       string            `yaml:"type,omitempty"`
+}
+
+// ManifestMetadata contains Kubernetes metadata
+type ManifestMetadata struct {
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// DeploymentSpec represents a Kubernetes Deployment spec
+type DeploymentSpec struct {
+	Replicas int                 `yaml:"replicas"`
+	Selector *LabelSelector      `yaml:"selector"`
+	Template PodTemplateSpec     `yaml:"template"`
+	Strategy *DeploymentStrategy `yaml:"strategy,omitempty"`
+}
+
+// DeploymentStrategy defines deployment update strategy
+type DeploymentStrategy struct {
+	Type          string                   `yaml:"type"`
+	RollingUpdate *RollingUpdateDeployment `yaml:"rollingUpdate,omitempty"`
+}
+
+// RollingUpdateDeployment controls rolling update
+type RollingUpdateDeployment struct {
+	MaxUnavailable string `yaml:"maxUnavailable,omitempty"`
+	MaxSurge       string `yaml:"maxSurge,omitempty"`
+}
+
+// LabelSelector for selecting pods
+type LabelSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+// PodTemplateSpec defines pod template
+type PodTemplateSpec struct {
+	Metadata ManifestMetadata `yaml:"metadata"`
+	Spec     PodSpec          `yaml:"spec"`
+}
+
+// PodSpec defines pod specification
+type PodSpec struct {
+	ServiceAccountName string              `yaml:"serviceAccountName,omitempty"`
+	Containers         []Container         `yaml:"containers"`
+	InitContainers     []Container         `yaml:"initContainers,omitempty"`
+	Volumes            []Volume            `yaml:"volumes,omitempty"`
+	NodeSelector       map[string]string   `yaml:"nodeSelector,omitempty"`
+	Tolerations        []Toleration        `yaml:"tolerations,omitempty"`
+	Affinity           *Affinity           `yaml:"affinity,omitempty"`
+	SecurityContext    *PodSecurityContext `yaml:"securityContext,omitempty"`
+}
+
+// Container defines a container spec
+type Container struct {
+	Name            string               `yaml:"name"`
+	Image           string               `yaml:"image"`
+	ImagePullPolicy string               `yaml:"imagePullPolicy,omitempty"`
+	Command         []string             `yaml:"command,omitempty"`
+	Args            []string             `yaml:"args,omitempty"`
+	Ports           []ContainerPort      `yaml:"ports,omitempty"`
+	Env             []EnvVar             `yaml:"env,omitempty"`
+	EnvFrom         []EnvFromSource      `yaml:"envFrom,omitempty"`
+	Resources       ResourceRequirements `yaml:"resources,omitempty"`
+	VolumeMounts    []VolumeMount        `yaml:"volumeMounts,omitempty"`
+	LivenessProbe   *Probe               `yaml:"livenessProbe,omitempty"`
+	ReadinessProbe  *Probe               `yaml:"readinessProbe,omitempty"`
+	StartupProbe    *Probe               `yaml:"startupProbe,omitempty"`
+	SecurityContext *SecurityContext     `yaml:"securityContext,omitempty"`
+}
+
+// ContainerPort defines exposed port
+type ContainerPort struct {
+	Name          string `yaml:"name,omitempty"`
+	ContainerPort int    `yaml:"containerPort"`
+	Protocol      string `yaml:"protocol,omitempty"`
+}
+
+// EnvVar defines environment variable
+type EnvVar struct {
+	Name      string        `yaml:"name"`
+	Value     string        `yaml:"value,omitempty"`
+	ValueFrom *EnvVarSource `yaml:"valueFrom,omitempty"`
+}
+
+// EnvVarSource for referencing secrets/configmaps
+type EnvVarSource struct {
+	SecretKeyRef    *KeySelector   `yaml:"secretKeyRef,omitempty"`
+	ConfigMapKeyRef *KeySelector   `yaml:"configMapKeyRef,omitempty"`
+	FieldRef        *FieldSelector `yaml:"fieldRef,omitempty"`
+}
+
+// KeySelector selects a key from secret/configmap
+type KeySelector struct {
+	Name string `yaml:"name"`
+	Key  string `yaml:"key"`
+}
+
+// FieldSelector selects a field from pod
+type FieldSelector struct {
+	FieldPath string `yaml:"fieldPath"`
+}
+
+// EnvFromSource for bulk env from secrets/configmaps
+type EnvFromSource struct {
+	SecretRef    *SecretEnvSource    `yaml:"secretRef,omitempty"`
+	ConfigMapRef *ConfigMapEnvSource `yaml:"configMapRef,omitempty"`
+	Prefix       string              `yaml:"prefix,omitempty"`
+}
+
+// SecretEnvSource references a secret
+type SecretEnvSource struct {
+	Name string `yaml:"name"`
+}
+
+// ConfigMapEnvSource references a configmap
+type ConfigMapEnvSource struct {
+	Name string `yaml:"name"`
+}
+
+// ResourceRequirements defines resource limits/requests
+type ResourceRequirements struct {
+	Limits   map[string]string `yaml:"limits,omitempty"`
+	Requests map[string]string `yaml:"requests,omitempty"`
+}
+
+// VolumeMount defines volume mount
+type VolumeMount struct {
+	Name      string `yaml:"name"`
+	MountPath string `yaml:"mountPath"`
+	SubPath   string `yaml:"subPath,omitempty"`
+	ReadOnly  bool   `yaml:"readOnly,omitempty"`
+}
+
+// Volume defines a volume
+type Volume struct {
+	Name                  string                             `yaml:"name"`
+	ConfigMap             *ConfigMapVolumeSource             `yaml:"configMap,omitempty"`
+	Secret                *SecretVolumeSource                `yaml:"secret,omitempty"`
+	EmptyDir              *EmptyDirVolumeSource              `yaml:"emptyDir,omitempty"`
+	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `yaml:"persistentVolumeClaim,omitempty"`
+}
+
+// ConfigMapVolumeSource references configmap for volume
+type ConfigMapVolumeSource struct {
+	Name string `yaml:"name"`
+}
+
+// SecretVolumeSource references secret for volume
+type SecretVolumeSource struct {
+	SecretName string `yaml:"secretName"`
+}
+
+// EmptyDirVolumeSource for ephemeral storage
+type EmptyDirVolumeSource struct {
+	Medium    string `yaml:"medium,omitempty"`
+	SizeLimit string `yaml:"sizeLimit,omitempty"`
+}
+
+// PersistentVolumeClaimVolumeSource references PVC
+type PersistentVolumeClaimVolumeSource struct {
+	ClaimName string `yaml:"claimName"`
+}
+
+// Probe defines health check probe
+type Probe struct {
+	HTTPGet             *HTTPGetAction   `yaml:"httpGet,omitempty"`
+	TCPSocket           *TCPSocketAction `yaml:"tcpSocket,omitempty"`
+	Exec                *ExecAction      `yaml:"exec,omitempty"`
+	InitialDelaySeconds int              `yaml:"initialDelaySeconds,omitempty"`
+	PeriodSeconds       int              `yaml:"periodSeconds,omitempty"`
+	TimeoutSeconds      int              `yaml:"timeoutSeconds,omitempty"`
+	SuccessThreshold    int              `yaml:"successThreshold,omitempty"`
+	FailureThreshold    int              `yaml:"failureThreshold,omitempty"`
+}
+
+// HTTPGetAction for HTTP probe
+type HTTPGetAction struct {
+	Path   string `yaml:"path"`
+	Port   int    `yaml:"port"`
+	Scheme string `yaml:"scheme,omitempty"`
+}
+
+// TCPSocketAction for TCP probe
+type TCPSocketAction struct {
+	Port int `yaml:"port"`
+}
+
+// ExecAction for exec probe
+type ExecAction struct {
+	Command []string `yaml:"command"`
+}
+
+// SecurityContext for container security
+type SecurityContext struct {
+	RunAsUser                int64         `yaml:"runAsUser,omitempty"`
+	RunAsGroup               int64         `yaml:"runAsGroup,omitempty"`
+	RunAsNonRoot             *bool         `yaml:"runAsNonRoot,omitempty"`
+	ReadOnlyRootFilesystem   *bool         `yaml:"readOnlyRootFilesystem,omitempty"`
+	AllowPrivilegeEscalation *bool         `yaml:"allowPrivilegeEscalation,omitempty"`
+	Capabilities             *Capabilities `yaml:"capabilities,omitempty"`
+}
+
+// PodSecurityContext for pod-level security
+type PodSecurityContext struct {
+	RunAsUser    int64 `yaml:"runAsUser,omitempty"`
+	RunAsGroup   int64 `yaml:"runAsGroup,omitempty"`
+	FSGroup      int64 `yaml:"fsGroup,omitempty"`
+	RunAsNonRoot *bool `yaml:"runAsNonRoot,omitempty"`
+}
+
+// Capabilities for Linux capabilities
+type Capabilities struct {
+	Add  []string `yaml:"add,omitempty"`
+	Drop []string `yaml:"drop,omitempty"`
+}
+
+// Toleration for node tolerations
+type Toleration struct {
+	Key               string `yaml:"key,omitempty"`
+	Operator          string `yaml:"operator,omitempty"`
+	Value             string `yaml:"value,omitempty"`
+	Effect            string `yaml:"effect,omitempty"`
+	TolerationSeconds *int64 `yaml:"tolerationSeconds,omitempty"`
+}
+
+// Affinity for pod scheduling
+type Affinity struct {
+	NodeAffinity    *NodeAffinity    `yaml:"nodeAffinity,omitempty"`
+	PodAffinity     *PodAffinity     `yaml:"podAffinity,omitempty"`
+	PodAntiAffinity *PodAntiAffinity `yaml:"podAntiAffinity,omitempty"`
+}
+
+// NodeAffinity for node selection
+type NodeAffinity struct {
+	RequiredDuringSchedulingIgnoredDuringExecution  *NodeSelector             `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	PreferredDuringSchedulingIgnoredDuringExecution []PreferredSchedulingTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+// NodeSelector for node requirements
+type NodeSelector struct {
+	NodeSelectorTerms []NodeSelectorTerm `yaml:"nodeSelectorTerms"`
+}
+
+// NodeSelectorTerm defines node selection criteria
+type NodeSelectorTerm struct {
+	MatchExpressions []NodeSelectorRequirement `yaml:"matchExpressions,omitempty"`
+}
+
+// NodeSelectorRequirement for node matching
+type NodeSelectorRequirement struct {
+	Key      string   `yaml:"key"`
+	Operator string   `yaml:"operator"`
+	Values   []string `yaml:"values,omitempty"`
+}
+
+// PreferredSchedulingTerm for soft node preferences
+type PreferredSchedulingTerm struct {
+	Weight     int              `yaml:"weight"`
+	Preference NodeSelectorTerm `yaml:"preference"`
+}
+
+// PodAffinity for pod co-location
+type PodAffinity struct {
+	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+// PodAntiAffinity for pod separation
+type PodAntiAffinity struct {
+	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+// PodAffinityTerm defines pod affinity criteria
+type PodAffinityTerm struct {
+	LabelSelector *LabelSelector `yaml:"labelSelector,omitempty"`
+	TopologyKey   string         `yaml:"topologyKey"`
+	Namespaces    []string       `yaml:"namespaces,omitempty"`
+}
+
+// WeightedPodAffinityTerm for soft pod preferences
+type WeightedPodAffinityTerm struct {
+	Weight          int             `yaml:"weight"`
+	PodAffinityTerm PodAffinityTerm `yaml:"podAffinityTerm"`
+}
+
+// ServiceSpec defines Service specification
+type ServiceSpec struct {
+	Type                  string            `yaml:"type,omitempty"`
+	Selector              map[string]string `yaml:"selector"`
+	Ports                 []ServicePort     `yaml:"ports"`
+	ClusterIP             string            `yaml:"clusterIP,omitempty"`
+	LoadBalancerIP        string            `yaml:"loadBalancerIP,omitempty"`
+	ExternalTrafficPolicy string            `yaml:"externalTrafficPolicy,omitempty"`
+	SessionAffinity       string            `yaml:"sessionAffinity,omitempty"`
+}
+
+// ServicePort defines service port
+type ServicePort struct {
+	Name       string `yaml:"name,omitempty"`
+	Protocol   string `yaml:"protocol,omitempty"`
+	Port       int    `yaml:"port"`
+	TargetPort int    `yaml:"targetPort,omitempty"`
+	NodePort   int    `yaml:"nodePort,omitempty"`
+}
+
+// ManifestGenerator generates Kubernetes manifests
+type ManifestGenerator struct {
+	AppName     string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// NewManifestGenerator creates a new manifest generator
+func NewManifestGenerator(appName, namespace string) *ManifestGenerator {
+	return &ManifestGenerator{
+		AppName:   appName,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/name":       appName,
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+		Annotations: make(map[string]string),
+	}
+}
+
+// WithLabels adds additional labels
+func (g *ManifestGenerator) WithLabels(labels map[string]string) *ManifestGenerator {
+	for k, v := range labels {
+		g.Labels[k] = v
+	}
+	return g
+}
+
+// WithAnnotations adds additional annotations
+func (g *ManifestGenerator) WithAnnotations(annotations map[string]string) *ManifestGenerator {
+	for k, v := range annotations {
+		g.Annotations[k] = v
+	}
+	return g
+}
+
+// DeploymentConfig configures deployment generation
+type DeploymentConfig struct {
+	Name             string
+	Image            string
+	Replicas         int
+	Port             int
+	CPURequest       string
+	CPULimit         string
+	MemoryRequest    string
+	MemoryLimit      string
+	EnvVars          map[string]string
+	SecretEnvVars    map[string]string // key -> secretName:secretKey
+	ConfigMapEnvVars map[string]string // key -> configMapName:configMapKey
+	HealthPath       string
+	HealthPort       int
+	Command          []string
+	Args             []string
+	Volumes          []VolumeConfig
+	ServiceAccount   string
+}
+
+// VolumeConfig for volume configuration
+type VolumeConfig struct {
+	Name      string
+	MountPath string
+	ConfigMap string
+	Secret    string
+	PVC       string
+	EmptyDir  bool
+	ReadOnly  bool
+}
+
+// GenerateDeployment creates a Deployment manifest
+func (g *ManifestGenerator) GenerateDeployment(cfg DeploymentConfig) (*Manifest, error) {
+	if cfg.Name == "" {
+		cfg.Name = g.AppName
+	}
+	if cfg.Replicas == 0 {
+		cfg.Replicas = 1
+	}
+	if cfg.HealthPath == "" {
+		cfg.HealthPath = "/health"
+	}
+	if cfg.HealthPort == 0 {
+		cfg.HealthPort = cfg.Port
+	}
+
+	labels := copyLabels(g.Labels)
+	labels["app.kubernetes.io/component"] = cfg.Name
+
+	container := Container{
+		Name:            cfg.Name,
+		Image:           cfg.Image,
+		ImagePullPolicy: "IfNotPresent",
+		Command:         cfg.Command,
+		Args:            cfg.Args,
+		Ports: []ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: cfg.Port,
+				Protocol:      "TCP",
+			},
+		},
+		Resources: ResourceRequirements{
+			Requests: map[string]string{
+				"cpu":    withDefault(cfg.CPURequest, "100m"),
+				"memory": withDefault(cfg.MemoryRequest, "128Mi"),
+			},
+			Limits: map[string]string{
+				"cpu":    withDefault(cfg.CPULimit, "500m"),
+				"memory": withDefault(cfg.MemoryLimit, "512Mi"),
+			},
+		},
+		LivenessProbe: &Probe{
+			HTTPGet: &HTTPGetAction{
+				Path: cfg.HealthPath,
+				Port: cfg.HealthPort,
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      5,
+			FailureThreshold:    3,
+		},
+		ReadinessProbe: &Probe{
+			HTTPGet: &HTTPGetAction{
+				Path: cfg.HealthPath,
+				Port: cfg.HealthPort,
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+			FailureThreshold:    3,
+		},
+		SecurityContext: &SecurityContext{
+			RunAsNonRoot:             boolPtr(true),
+			ReadOnlyRootFilesystem:   boolPtr(true),
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &Capabilities{
+				Drop: []string{"ALL"},
+			},
+		},
+	}
+
+	// Add environment variables
+	for k, v := range cfg.EnvVars {
+		container.Env = append(container.Env, EnvVar{Name: k, Value: v})
+	}
+
+	// Add secret-based env vars
+	for envName, ref := range cfg.SecretEnvVars {
+		parts := strings.SplitN(ref, ":", 2)
+		if len(parts) == 2 {
+			container.Env = append(container.Env, EnvVar{
+				Name: envName,
+				ValueFrom: &EnvVarSource{
+					SecretKeyRef: &KeySelector{
+						Name: parts[0],
+						Key:  parts[1],
+					},
+				},
+			})
+		}
+	}
+
+	// Add configmap-based env vars
+	for envName, ref := range cfg.ConfigMapEnvVars {
+		parts := strings.SplitN(ref, ":", 2)
+		if len(parts) == 2 {
+			container.Env = append(container.Env, EnvVar{
+				Name: envName,
+				ValueFrom: &EnvVarSource{
+					ConfigMapKeyRef: &KeySelector{
+						Name: parts[0],
+						Key:  parts[1],
+					},
+				},
+			})
+		}
+	}
+
+	// Add volumes
+	var volumes []Volume
+	for _, vol := range cfg.Volumes {
+		container.VolumeMounts = append(container.VolumeMounts, VolumeMount{
+			Name:      vol.Name,
+			MountPath: vol.MountPath,
+			ReadOnly:  vol.ReadOnly,
+		})
+
+		v := Volume{Name: vol.Name}
+		switch {
+		case vol.ConfigMap != "":
+			v.ConfigMap = &ConfigMapVolumeSource{Name: vol.ConfigMap}
+		case vol.Secret != "":
+			v.Secret = &SecretVolumeSource{SecretName: vol.Secret}
+		case vol.PVC != "":
+			v.PersistentVolumeClaim = &PersistentVolumeClaimVolumeSource{ClaimName: vol.PVC}
+		case vol.EmptyDir:
+			v.EmptyDir = &EmptyDirVolumeSource{}
+		}
+		volumes = append(volumes, v)
+	}
+
+	spec := DeploymentSpec{
+		Replicas: cfg.Replicas,
+		Selector: &LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name":      g.AppName,
+				"app.kubernetes.io/component": cfg.Name,
+			},
+		},
+		Strategy: &DeploymentStrategy{
+			Type: "RollingUpdate",
+			RollingUpdate: &RollingUpdateDeployment{
+				MaxUnavailable: "25%",
+				MaxSurge:       "25%",
+			},
+		},
+		Template: PodTemplateSpec{
+			Metadata: ManifestMetadata{
+				Labels:      labels,
+				Annotations: copyLabels(g.Annotations),
+			},
+			Spec: PodSpec{
+				ServiceAccountName: cfg.ServiceAccount,
+				Containers:         []Container{container},
+				Volumes:            volumes,
+				SecurityContext: &PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					FSGroup:      1000,
+				},
+			},
+		},
+	}
+
+	return &Manifest{
+		APIVersion: "apps/v1",
+		Kind:       KindDeployment,
+		Metadata: ManifestMetadata{
+			Name:        cfg.Name,
+			Namespace:   g.Namespace,
+			Labels:      labels,
+			Annotations: g.Annotations,
+		},
+		Spec: spec,
+	}, nil
+}
+
+// GenerateService creates a Service manifest
+func (g *ManifestGenerator) GenerateService(name string, port, targetPort int, serviceType string) *Manifest {
+	labels := copyLabels(g.Labels)
+	labels["app.kubernetes.io/component"] = name
+
+	if serviceType == "" {
+		serviceType = "ClusterIP"
+	}
+
+	spec := ServiceSpec{
+		Type: serviceType,
+		Selector: map[string]string{
+			"app.kubernetes.io/name":      g.AppName,
+			"app.kubernetes.io/component": name,
+		},
+		Ports: []ServicePort{
+			{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       port,
+				TargetPort: targetPort,
+			},
+		},
+	}
+
+	return &Manifest{
+		APIVersion: "v1",
+		Kind:       KindService,
+		Metadata: ManifestMetadata{
+			Name:        name,
+			Namespace:   g.Namespace,
+			Labels:      labels,
+			Annotations: g.Annotations,
+		},
+		Spec: spec,
+	}
+}
+
+// GenerateConfigMap creates a ConfigMap manifest
+func (g *ManifestGenerator) GenerateConfigMap(name string, data map[string]string) *Manifest {
+	labels := copyLabels(g.Labels)
+
+	return &Manifest{
+		APIVersion: "v1",
+		Kind:       KindConfigMap,
+		Metadata: ManifestMetadata{
+			Name:        name,
+			Namespace:   g.Namespace,
+			Labels:      labels,
+			Annotations: g.Annotations,
+		},
+		Data: data,
+	}
+}
+
+// GenerateSecret creates a Secret manifest
+func (g *ManifestGenerator) GenerateSecret(name string, data map[string]string, secretType string) *Manifest {
+	labels := copyLabels(g.Labels)
+
+	if secretType == "" {
+		secretType = "Opaque"
+	}
+
+	return &Manifest{
+		APIVersion: "v1",
+		Kind:       KindSecret,
+		Metadata: ManifestMetadata{
+			Name:        name,
+			Namespace:   g.Namespace,
+			Labels:      labels,
+			Annotations: g.Annotations,
+		},
+		StringData: data,
+		Type:       secretType,
+	}
+}
+
+// GenerateServiceAccount creates a ServiceAccount manifest
+func (g *ManifestGenerator) GenerateServiceAccount(name string) *Manifest {
+	labels := copyLabels(g.Labels)
+
+	return &Manifest{
+		APIVersion: "v1",
+		Kind:       KindServiceAccount,
+		Metadata: ManifestMetadata{
+			Name:        name,
+			Namespace:   g.Namespace,
+			Labels:      labels,
+			Annotations: g.Annotations,
+		},
+	}
+}
+
+// ToYAML converts manifest to YAML string
+func (m *Manifest) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(m); err != nil {
+		return "", fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ManifestSet represents a collection of manifests
+type ManifestSet struct {
+	Manifests []*Manifest
+}
+
+// Add adds a manifest to the set
+func (ms *ManifestSet) Add(m *Manifest) {
+	ms.Manifests = append(ms.Manifests, m)
+}
+
+// ToYAML converts all manifests to a single YAML document
+func (ms *ManifestSet) ToYAML() (string, error) {
+	var parts []string
+	for _, m := range ms.Manifests {
+		yaml, err := m.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+	return strings.Join(parts, "---\n"), nil
+}
+
+// GenerateVaultaireManifests generates all manifests for Vaultaire deployment
+func GenerateVaultaireManifests(namespace, image string, replicas int) (*ManifestSet, error) {
+	gen := NewManifestGenerator("vaultaire", namespace)
+	gen.WithLabels(map[string]string{
+		"app.kubernetes.io/version": "1.0.0",
+	})
+
+	ms := &ManifestSet{}
+
+	// ServiceAccount
+	ms.Add(gen.GenerateServiceAccount("vaultaire"))
+
+	// ConfigMap for configuration
+	ms.Add(gen.GenerateConfigMap("vaultaire-config", map[string]string{
+		"config.yaml": `
+server:
+  port: 8080
+  host: 0.0.0.0
+storage:
+  type: s3
+  endpoint: ${S3_ENDPOINT}
+database:
+  host: ${DB_HOST}
+  port: "5432"
+  name: vaultaire
+`,
+	}))
+
+	// Secret for sensitive data
+	ms.Add(gen.GenerateSecret("vaultaire-secrets", map[string]string{
+		"db-password":   "CHANGE_ME",
+		"s3-access-key": "CHANGE_ME",
+		"s3-secret-key": "CHANGE_ME",
+		"jwt-secret":    "CHANGE_ME",
+	}, "Opaque"))
+
+	// Deployment
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:           "vaultaire",
+		Image:          image,
+		Replicas:       replicas,
+		Port:           8080,
+		CPURequest:     "200m",
+		CPULimit:       "1000m",
+		MemoryRequest:  "256Mi",
+		MemoryLimit:    "1Gi",
+		HealthPath:     "/health",
+		HealthPort:     8080,
+		ServiceAccount: "vaultaire",
+		EnvVars: map[string]string{
+			"VAULTAIRE_ENV": "production",
+		},
+		SecretEnvVars: map[string]string{
+			"DB_PASSWORD":   "vaultaire-secrets:db-password",
+			"S3_ACCESS_KEY": "vaultaire-secrets:s3-access-key",
+			"S3_SECRET_KEY": "vaultaire-secrets:s3-secret-key",
+			"JWT_SECRET":    "vaultaire-secrets:jwt-secret",
+		},
+		Volumes: []VolumeConfig{
+			{
+				Name:      "config",
+				MountPath: "/etc/vaultaire",
+				ConfigMap: "vaultaire-config",
+				ReadOnly:  true,
+			},
+			{
+				Name:      "tmp",
+				MountPath: "/tmp",
+				EmptyDir:  true,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	ms.Add(deployment)
+
+	// Service
+	ms.Add(gen.GenerateService("vaultaire", 80, 8080, "ClusterIP"))
+
+	return ms, nil
+}
+
+// Helper functions
+func copyLabels(labels map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range labels {
+		result[k] = v
+	}
+	return result
+}
+
+func withDefault(value, defaultValue string) string {
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// ManifestTemplate for custom templates
+type ManifestTemplate struct {
+	tmpl *template.Template
+}
+
+// NewManifestTemplate creates a new manifest template
+func NewManifestTemplate(name, content string) (*ManifestTemplate, error) {
+	tmpl, err := template.New(name).Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+	return &ManifestTemplate{tmpl: tmpl}, nil
+}
+
+// Execute renders the template with given data
+func (mt *ManifestTemplate) Execute(data interface{}) (string, error) {
+	var buf bytes.Buffer
+	if err := mt.tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// GeneratedAt returns generation timestamp for manifest comments
+func GeneratedAt() string {
+	return fmt.Sprintf("# Generated by Vaultaire at %s\n", time.Now().Format(time.RFC3339))
+}

--- a/internal/k8s/manifests_test.go
+++ b/internal/k8s/manifests_test.go
@@ -1,0 +1,568 @@
+// internal/k8s/manifests_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewManifestGenerator(t *testing.T) {
+	gen := NewManifestGenerator("myapp", "production")
+
+	if gen.AppName != "myapp" {
+		t.Errorf("expected AppName 'myapp', got '%s'", gen.AppName)
+	}
+	if gen.Namespace != "production" {
+		t.Errorf("expected Namespace 'production', got '%s'", gen.Namespace)
+	}
+	if gen.Labels["app.kubernetes.io/name"] != "myapp" {
+		t.Error("expected app.kubernetes.io/name label to be set")
+	}
+}
+
+func TestGenerateDeployment(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:          "api",
+		Image:         "vaultaire:latest",
+		Replicas:      3,
+		Port:          8080,
+		CPURequest:    "100m",
+		CPULimit:      "500m",
+		MemoryRequest: "128Mi",
+		MemoryLimit:   "512Mi",
+		HealthPath:    "/health",
+	})
+	if err != nil {
+		t.Fatalf("failed to generate deployment: %v", err)
+	}
+
+	if deployment.Kind != KindDeployment {
+		t.Errorf("expected kind Deployment, got %s", deployment.Kind)
+	}
+	if deployment.APIVersion != "apps/v1" {
+		t.Errorf("expected apiVersion apps/v1, got %s", deployment.APIVersion)
+	}
+	if deployment.Metadata.Name != "api" {
+		t.Errorf("expected name 'api', got '%s'", deployment.Metadata.Name)
+	}
+	if deployment.Metadata.Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", deployment.Metadata.Namespace)
+	}
+
+	spec, ok := deployment.Spec.(DeploymentSpec)
+	if !ok {
+		t.Fatal("spec is not DeploymentSpec")
+	}
+	if spec.Replicas != 3 {
+		t.Errorf("expected 3 replicas, got %d", spec.Replicas)
+	}
+}
+
+func TestGenerateDeploymentWithEnvVars(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:     "api",
+		Image:    "vaultaire:latest",
+		Replicas: 1,
+		Port:     8080,
+		EnvVars: map[string]string{
+			"LOG_LEVEL": "debug",
+			"ENV":       "test",
+		},
+		SecretEnvVars: map[string]string{
+			"DB_PASSWORD": "db-secrets:password",
+		},
+		ConfigMapEnvVars: map[string]string{
+			"CONFIG_PATH": "app-config:path",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to generate deployment: %v", err)
+	}
+
+	spec := deployment.Spec.(DeploymentSpec)
+	container := spec.Template.Spec.Containers[0]
+
+	// Check env vars are present
+	foundEnvVars := make(map[string]bool)
+	for _, env := range container.Env {
+		foundEnvVars[env.Name] = true
+	}
+
+	if !foundEnvVars["LOG_LEVEL"] {
+		t.Error("expected LOG_LEVEL env var")
+	}
+	if !foundEnvVars["DB_PASSWORD"] {
+		t.Error("expected DB_PASSWORD env var from secret")
+	}
+	if !foundEnvVars["CONFIG_PATH"] {
+		t.Error("expected CONFIG_PATH env var from configmap")
+	}
+}
+
+func TestGenerateDeploymentWithVolumes(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:     "api",
+		Image:    "vaultaire:latest",
+		Replicas: 1,
+		Port:     8080,
+		Volumes: []VolumeConfig{
+			{Name: "config", MountPath: "/etc/config", ConfigMap: "app-config", ReadOnly: true},
+			{Name: "secrets", MountPath: "/etc/secrets", Secret: "app-secrets", ReadOnly: true},
+			{Name: "data", MountPath: "/data", PVC: "app-data"},
+			{Name: "tmp", MountPath: "/tmp", EmptyDir: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to generate deployment: %v", err)
+	}
+
+	spec := deployment.Spec.(DeploymentSpec)
+	container := spec.Template.Spec.Containers[0]
+
+	if len(container.VolumeMounts) != 4 {
+		t.Errorf("expected 4 volume mounts, got %d", len(container.VolumeMounts))
+	}
+
+	volumes := spec.Template.Spec.Volumes
+	if len(volumes) != 4 {
+		t.Errorf("expected 4 volumes, got %d", len(volumes))
+	}
+
+	// Verify volume types
+	volumeTypes := make(map[string]string)
+	for _, v := range volumes {
+		switch {
+		case v.ConfigMap != nil:
+			volumeTypes[v.Name] = "configMap"
+		case v.Secret != nil:
+			volumeTypes[v.Name] = "secret"
+		case v.PersistentVolumeClaim != nil:
+			volumeTypes[v.Name] = "pvc"
+		case v.EmptyDir != nil:
+			volumeTypes[v.Name] = "emptyDir"
+		}
+	}
+
+	if volumeTypes["config"] != "configMap" {
+		t.Error("expected config volume to be configMap")
+	}
+	if volumeTypes["secrets"] != "secret" {
+		t.Error("expected secrets volume to be secret")
+	}
+	if volumeTypes["data"] != "pvc" {
+		t.Error("expected data volume to be pvc")
+	}
+	if volumeTypes["tmp"] != "emptyDir" {
+		t.Error("expected tmp volume to be emptyDir")
+	}
+}
+
+func TestGenerateService(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	svc := gen.GenerateService("api", 80, 8080, "ClusterIP")
+
+	if svc.Kind != KindService {
+		t.Errorf("expected kind Service, got %s", svc.Kind)
+	}
+	if svc.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1, got %s", svc.APIVersion)
+	}
+
+	spec, ok := svc.Spec.(ServiceSpec)
+	if !ok {
+		t.Fatal("spec is not ServiceSpec")
+	}
+	if spec.Type != "ClusterIP" {
+		t.Errorf("expected type ClusterIP, got %s", spec.Type)
+	}
+	if len(spec.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(spec.Ports))
+	}
+	if spec.Ports[0].Port != 80 {
+		t.Errorf("expected port 80, got %d", spec.Ports[0].Port)
+	}
+	if spec.Ports[0].TargetPort != 8080 {
+		t.Errorf("expected targetPort 8080, got %d", spec.Ports[0].TargetPort)
+	}
+}
+
+func TestGenerateServiceLoadBalancer(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	svc := gen.GenerateService("api", 443, 8443, "LoadBalancer")
+
+	spec := svc.Spec.(ServiceSpec)
+	if spec.Type != "LoadBalancer" {
+		t.Errorf("expected type LoadBalancer, got %s", spec.Type)
+	}
+}
+
+func TestGenerateConfigMap(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	cm := gen.GenerateConfigMap("app-config", map[string]string{
+		"config.yaml": "key: value",
+		"settings":    "debug=true",
+	})
+
+	if cm.Kind != KindConfigMap {
+		t.Errorf("expected kind ConfigMap, got %s", cm.Kind)
+	}
+	if cm.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1, got %s", cm.APIVersion)
+	}
+	if cm.Data["config.yaml"] != "key: value" {
+		t.Error("expected config.yaml data to be set")
+	}
+	if cm.Data["settings"] != "debug=true" {
+		t.Error("expected settings data to be set")
+	}
+}
+
+func TestGenerateSecret(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	secret := gen.GenerateSecret("db-secrets", map[string]string{
+		"username": "admin",
+		"password": "secret123",
+	}, "Opaque")
+
+	if secret.Kind != KindSecret {
+		t.Errorf("expected kind Secret, got %s", secret.Kind)
+	}
+	if secret.Type != "Opaque" {
+		t.Errorf("expected type Opaque, got %s", secret.Type)
+	}
+	if secret.StringData["username"] != "admin" {
+		t.Error("expected username to be set")
+	}
+}
+
+func TestGenerateServiceAccount(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	sa := gen.GenerateServiceAccount("vaultaire-sa")
+
+	if sa.Kind != KindServiceAccount {
+		t.Errorf("expected kind ServiceAccount, got %s", sa.Kind)
+	}
+	if sa.Metadata.Name != "vaultaire-sa" {
+		t.Errorf("expected name 'vaultaire-sa', got '%s'", sa.Metadata.Name)
+	}
+}
+
+func TestManifestToYAML(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+	svc := gen.GenerateService("api", 80, 8080, "ClusterIP")
+
+	yaml, err := svc.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "apiVersion: v1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+	if !strings.Contains(yaml, "kind: Service") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "name: api") {
+		t.Error("expected YAML to contain name")
+	}
+}
+
+func TestManifestSetToYAML(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	ms := &ManifestSet{}
+	ms.Add(gen.GenerateServiceAccount("vaultaire"))
+	ms.Add(gen.GenerateConfigMap("config", map[string]string{"key": "value"}))
+	ms.Add(gen.GenerateService("api", 80, 8080, "ClusterIP"))
+
+	yaml, err := ms.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert manifest set to YAML: %v", err)
+	}
+
+	// Count document separators
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 3 {
+		t.Errorf("expected 3 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestGenerateVaultaireManifests(t *testing.T) {
+	ms, err := GenerateVaultaireManifests("vaultaire", "vaultaire:v1.0.0", 3)
+	if err != nil {
+		t.Fatalf("failed to generate manifests: %v", err)
+	}
+
+	if len(ms.Manifests) < 4 {
+		t.Errorf("expected at least 4 manifests, got %d", len(ms.Manifests))
+	}
+
+	// Verify each manifest type exists
+	kinds := make(map[ManifestKind]int)
+	for _, m := range ms.Manifests {
+		kinds[m.Kind]++
+	}
+
+	if kinds[KindServiceAccount] != 1 {
+		t.Error("expected 1 ServiceAccount")
+	}
+	if kinds[KindConfigMap] != 1 {
+		t.Error("expected 1 ConfigMap")
+	}
+	if kinds[KindSecret] != 1 {
+		t.Error("expected 1 Secret")
+	}
+	if kinds[KindDeployment] != 1 {
+		t.Error("expected 1 Deployment")
+	}
+	if kinds[KindService] != 1 {
+		t.Error("expected 1 Service")
+	}
+}
+
+func TestDeploymentSecurityContext(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:     "api",
+		Image:    "vaultaire:latest",
+		Replicas: 1,
+		Port:     8080,
+	})
+	if err != nil {
+		t.Fatalf("failed to generate deployment: %v", err)
+	}
+
+	spec := deployment.Spec.(DeploymentSpec)
+	container := spec.Template.Spec.Containers[0]
+
+	// Verify container security context
+	if container.SecurityContext == nil {
+		t.Fatal("expected container security context")
+	}
+	if container.SecurityContext.RunAsNonRoot == nil || !*container.SecurityContext.RunAsNonRoot {
+		t.Error("expected runAsNonRoot to be true")
+	}
+	if container.SecurityContext.ReadOnlyRootFilesystem == nil || !*container.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("expected readOnlyRootFilesystem to be true")
+	}
+	if container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+		t.Error("expected allowPrivilegeEscalation to be false")
+	}
+	if container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Drop) == 0 {
+		t.Error("expected capabilities to drop ALL")
+	}
+
+	// Verify pod security context
+	podSecurity := spec.Template.Spec.SecurityContext
+	if podSecurity == nil {
+		t.Fatal("expected pod security context")
+	}
+	if podSecurity.RunAsNonRoot == nil || !*podSecurity.RunAsNonRoot {
+		t.Error("expected pod runAsNonRoot to be true")
+	}
+}
+
+func TestDeploymentProbes(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+
+	deployment, err := gen.GenerateDeployment(DeploymentConfig{
+		Name:       "api",
+		Image:      "vaultaire:latest",
+		Replicas:   1,
+		Port:       8080,
+		HealthPath: "/healthz",
+		HealthPort: 8081,
+	})
+	if err != nil {
+		t.Fatalf("failed to generate deployment: %v", err)
+	}
+
+	spec := deployment.Spec.(DeploymentSpec)
+	container := spec.Template.Spec.Containers[0]
+
+	if container.LivenessProbe == nil {
+		t.Fatal("expected liveness probe")
+	}
+	if container.LivenessProbe.HTTPGet.Path != "/healthz" {
+		t.Errorf("expected liveness path '/healthz', got '%s'", container.LivenessProbe.HTTPGet.Path)
+	}
+	if container.LivenessProbe.HTTPGet.Port != 8081 {
+		t.Errorf("expected liveness port 8081, got %d", container.LivenessProbe.HTTPGet.Port)
+	}
+
+	if container.ReadinessProbe == nil {
+		t.Fatal("expected readiness probe")
+	}
+	if container.ReadinessProbe.HTTPGet.Path != "/healthz" {
+		t.Errorf("expected readiness path '/healthz', got '%s'", container.ReadinessProbe.HTTPGet.Path)
+	}
+}
+
+func TestManifestLabelsAndAnnotations(t *testing.T) {
+	gen := NewManifestGenerator("vaultaire", "default")
+	gen.WithLabels(map[string]string{
+		"environment": "production",
+		"team":        "platform",
+	})
+	gen.WithAnnotations(map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "8080",
+	})
+
+	svc := gen.GenerateService("api", 80, 8080, "ClusterIP")
+
+	if svc.Metadata.Labels["environment"] != "production" {
+		t.Error("expected environment label")
+	}
+	if svc.Metadata.Labels["team"] != "platform" {
+		t.Error("expected team label")
+	}
+	if svc.Metadata.Annotations["prometheus.io/scrape"] != "true" {
+		t.Error("expected prometheus scrape annotation")
+	}
+}
+
+func TestManifestYAMLValidity(t *testing.T) {
+	ms, err := GenerateVaultaireManifests("vaultaire", "vaultaire:latest", 1)
+	if err != nil {
+		t.Fatalf("failed to generate manifests: %v", err)
+	}
+
+	yamlContent, err := ms.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	// Try to parse each document
+	docs := strings.Split(yamlContent, "---")
+	for i, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+
+		var parsed map[string]interface{}
+		if err := yaml.Unmarshal([]byte(doc), &parsed); err != nil {
+			t.Errorf("document %d is not valid YAML: %v", i, err)
+		}
+
+		// Verify required fields
+		if _, ok := parsed["apiVersion"]; !ok {
+			t.Errorf("document %d missing apiVersion", i)
+		}
+		if _, ok := parsed["kind"]; !ok {
+			t.Errorf("document %d missing kind", i)
+		}
+		if _, ok := parsed["metadata"]; !ok {
+			t.Errorf("document %d missing metadata", i)
+		}
+	}
+}
+
+func TestWithLabels(t *testing.T) {
+	gen := NewManifestGenerator("app", "ns")
+	gen.WithLabels(map[string]string{"env": "prod"})
+
+	if gen.Labels["env"] != "prod" {
+		t.Error("expected env label to be set")
+	}
+	// Original labels should still exist
+	if gen.Labels["app.kubernetes.io/name"] != "app" {
+		t.Error("expected original label to persist")
+	}
+}
+
+func TestWithAnnotations(t *testing.T) {
+	gen := NewManifestGenerator("app", "ns")
+	gen.WithAnnotations(map[string]string{"note": "test"})
+
+	if gen.Annotations["note"] != "test" {
+		t.Error("expected annotation to be set")
+	}
+}
+
+func TestManifestTemplate(t *testing.T) {
+	tmpl, err := NewManifestTemplate("test", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+data:
+  key: {{ .Value }}
+`)
+	if err != nil {
+		t.Fatalf("failed to create template: %v", err)
+	}
+
+	result, err := tmpl.Execute(map[string]string{
+		"Name":      "my-config",
+		"Namespace": "default",
+		"Value":     "test-value",
+	})
+	if err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	if !strings.Contains(result, "name: my-config") {
+		t.Error("expected name in result")
+	}
+	if !strings.Contains(result, "key: test-value") {
+		t.Error("expected value in result")
+	}
+}
+
+func TestCopyLabels(t *testing.T) {
+	original := map[string]string{"a": "1", "b": "2"}
+	copied := copyLabels(original)
+
+	// Modify copy
+	copied["c"] = "3"
+
+	// Original should be unchanged
+	if _, ok := original["c"]; ok {
+		t.Error("original should not be modified")
+	}
+}
+
+func TestBoolPtr(t *testing.T) {
+	truePtr := boolPtr(true)
+	falsePtr := boolPtr(false)
+
+	if !*truePtr {
+		t.Error("expected true")
+	}
+	if *falsePtr {
+		t.Error("expected false")
+	}
+}
+
+func TestWithDefault(t *testing.T) {
+	if withDefault("", "default") != "default" {
+		t.Error("expected default value")
+	}
+	if withDefault("custom", "default") != "custom" {
+		t.Error("expected custom value")
+	}
+}
+
+func TestGeneratedAt(t *testing.T) {
+	result := GeneratedAt()
+	if !strings.HasPrefix(result, "# Generated by Vaultaire at") {
+		t.Error("expected generated comment")
+	}
+}

--- a/internal/k8s/netpol.go
+++ b/internal/k8s/netpol.go
@@ -1,0 +1,536 @@
+// internal/k8s/netpol.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NetworkPolicyManager manages Kubernetes NetworkPolicy resources
+type NetworkPolicyManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewNetworkPolicyManager creates a new NetworkPolicy manager
+func NewNetworkPolicyManager(namespace string) *NetworkPolicyManager {
+	return &NetworkPolicyManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// NetworkPolicyConfig configures a NetworkPolicy
+type NetworkPolicyConfig struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Pod selector - which pods this policy applies to
+	PodSelector map[string]string
+
+	// Policy types
+	PolicyTypes []PolicyType
+
+	// Ingress rules
+	Ingress []NetworkPolicyIngressRule
+
+	// Egress rules
+	Egress []NetworkPolicyEgressRule
+}
+
+// PolicyType defines the type of network policy
+type PolicyType string
+
+const (
+	PolicyTypeIngress PolicyType = "Ingress"
+	PolicyTypeEgress  PolicyType = "Egress"
+)
+
+// NetworkPolicyIngressRule defines an ingress rule
+type NetworkPolicyIngressRule struct {
+	From  []NetworkPolicyPeer
+	Ports []NetworkPolicyPort
+}
+
+// NetworkPolicyEgressRule defines an egress rule
+type NetworkPolicyEgressRule struct {
+	To    []NetworkPolicyPeer
+	Ports []NetworkPolicyPort
+}
+
+// NetworkPolicyPeer defines a peer for network policy
+type NetworkPolicyPeer struct {
+	PodSelector       map[string]string
+	NamespaceSelector map[string]string
+	IPBlock           *IPBlock
+}
+
+// IPBlock defines an IP block
+type IPBlock struct {
+	CIDR   string
+	Except []string
+}
+
+// NetworkPolicyPort defines a port for network policy
+type NetworkPolicyPort struct {
+	Protocol string // TCP, UDP, SCTP
+	Port     string // Can be number or named port
+	EndPort  int32  // For port ranges
+}
+
+// NetworkPolicyResource represents a NetworkPolicy
+type NetworkPolicyResource struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   ManifestMetadata  `yaml:"metadata"`
+	Spec       NetworkPolicySpec `yaml:"spec"`
+}
+
+// NetworkPolicySpec defines NetworkPolicy specification
+type NetworkPolicySpec struct {
+	PodSelector NetworkPolicyLabelSelector `yaml:"podSelector"`
+	PolicyTypes []string                   `yaml:"policyTypes,omitempty"`
+	Ingress     []NetworkPolicyIngressSpec `yaml:"ingress,omitempty"`
+	Egress      []NetworkPolicyEgressSpec  `yaml:"egress,omitempty"`
+}
+
+// NetworkPolicyLabelSelector for pod selection
+type NetworkPolicyLabelSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels,omitempty"`
+}
+
+// NetworkPolicyIngressSpec for spec
+type NetworkPolicyIngressSpec struct {
+	From  []NetworkPolicyPeerSpec `yaml:"from,omitempty"`
+	Ports []NetworkPolicyPortSpec `yaml:"ports,omitempty"`
+}
+
+// NetworkPolicyEgressSpec for spec
+type NetworkPolicyEgressSpec struct {
+	To    []NetworkPolicyPeerSpec `yaml:"to,omitempty"`
+	Ports []NetworkPolicyPortSpec `yaml:"ports,omitempty"`
+}
+
+// NetworkPolicyPeerSpec for spec
+type NetworkPolicyPeerSpec struct {
+	PodSelector       *NetworkPolicyLabelSelector `yaml:"podSelector,omitempty"`
+	NamespaceSelector *NetworkPolicyLabelSelector `yaml:"namespaceSelector,omitempty"`
+	IPBlock           *IPBlockSpec                `yaml:"ipBlock,omitempty"`
+}
+
+// IPBlockSpec for spec
+type IPBlockSpec struct {
+	CIDR   string   `yaml:"cidr"`
+	Except []string `yaml:"except,omitempty"`
+}
+
+// NetworkPolicyPortSpec for spec
+type NetworkPolicyPortSpec struct {
+	Protocol string `yaml:"protocol,omitempty"`
+	Port     any    `yaml:"port,omitempty"`
+	EndPort  *int32 `yaml:"endPort,omitempty"`
+}
+
+// GenerateNetworkPolicy creates a NetworkPolicy resource
+func (npm *NetworkPolicyManager) GenerateNetworkPolicy(config NetworkPolicyConfig) *NetworkPolicyResource {
+	if config.Namespace == "" {
+		config.Namespace = npm.namespace
+	}
+
+	labels := copyStringMap(npm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	np := &NetworkPolicyResource{
+		APIVersion: "networking.k8s.io/v1",
+		Kind:       "NetworkPolicy",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: NetworkPolicySpec{
+			PodSelector: NetworkPolicyLabelSelector{
+				MatchLabels: config.PodSelector,
+			},
+		},
+	}
+
+	// Policy types
+	for _, pt := range config.PolicyTypes {
+		np.Spec.PolicyTypes = append(np.Spec.PolicyTypes, string(pt))
+	}
+
+	// Ingress rules
+	for _, rule := range config.Ingress {
+		ingressSpec := NetworkPolicyIngressSpec{}
+
+		for _, from := range rule.From {
+			peer := convertPeer(from)
+			ingressSpec.From = append(ingressSpec.From, peer)
+		}
+
+		for _, port := range rule.Ports {
+			portSpec := convertPort(port)
+			ingressSpec.Ports = append(ingressSpec.Ports, portSpec)
+		}
+
+		np.Spec.Ingress = append(np.Spec.Ingress, ingressSpec)
+	}
+
+	// Egress rules
+	for _, rule := range config.Egress {
+		egressSpec := NetworkPolicyEgressSpec{}
+
+		for _, to := range rule.To {
+			peer := convertPeer(to)
+			egressSpec.To = append(egressSpec.To, peer)
+		}
+
+		for _, port := range rule.Ports {
+			portSpec := convertPort(port)
+			egressSpec.Ports = append(egressSpec.Ports, portSpec)
+		}
+
+		np.Spec.Egress = append(np.Spec.Egress, egressSpec)
+	}
+
+	return np
+}
+
+func convertPeer(peer NetworkPolicyPeer) NetworkPolicyPeerSpec {
+	spec := NetworkPolicyPeerSpec{}
+
+	if len(peer.PodSelector) > 0 {
+		spec.PodSelector = &NetworkPolicyLabelSelector{
+			MatchLabels: peer.PodSelector,
+		}
+	}
+
+	if len(peer.NamespaceSelector) > 0 {
+		spec.NamespaceSelector = &NetworkPolicyLabelSelector{
+			MatchLabels: peer.NamespaceSelector,
+		}
+	}
+
+	if peer.IPBlock != nil {
+		spec.IPBlock = &IPBlockSpec{
+			CIDR:   peer.IPBlock.CIDR,
+			Except: peer.IPBlock.Except,
+		}
+	}
+
+	return spec
+}
+
+func convertPort(port NetworkPolicyPort) NetworkPolicyPortSpec {
+	spec := NetworkPolicyPortSpec{
+		Protocol: port.Protocol,
+	}
+
+	// Try to parse as int, otherwise use string (named port)
+	if port.Port != "" {
+		var portNum int
+		if _, err := fmt.Sscanf(port.Port, "%d", &portNum); err == nil {
+			spec.Port = portNum
+		} else {
+			spec.Port = port.Port
+		}
+	}
+
+	if port.EndPort > 0 {
+		spec.EndPort = &port.EndPort
+	}
+
+	return spec
+}
+
+// ToYAML converts NetworkPolicy to YAML
+func (np *NetworkPolicyResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(np); err != nil {
+		return "", fmt.Errorf("failed to encode NetworkPolicy: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// NetworkPolicyBuilder provides a fluent interface for building NetworkPolicy
+type NetworkPolicyBuilder struct {
+	config NetworkPolicyConfig
+}
+
+// NewNetworkPolicyBuilder creates a new NetworkPolicy builder
+func NewNetworkPolicyBuilder(name, namespace string) *NetworkPolicyBuilder {
+	return &NetworkPolicyBuilder{
+		config: NetworkPolicyConfig{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// ForPods sets the pod selector
+func (b *NetworkPolicyBuilder) ForPods(selector map[string]string) *NetworkPolicyBuilder {
+	b.config.PodSelector = selector
+	return b
+}
+
+// WithPolicyTypes sets policy types
+func (b *NetworkPolicyBuilder) WithPolicyTypes(types ...PolicyType) *NetworkPolicyBuilder {
+	b.config.PolicyTypes = types
+	return b
+}
+
+// AllowIngressFromPods allows ingress from pods matching selector
+func (b *NetworkPolicyBuilder) AllowIngressFromPods(selector map[string]string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyIngressRule{
+		From:  []NetworkPolicyPeer{{PodSelector: selector}},
+		Ports: ports,
+	}
+	b.config.Ingress = append(b.config.Ingress, rule)
+	return b
+}
+
+// AllowIngressFromNamespace allows ingress from a namespace
+func (b *NetworkPolicyBuilder) AllowIngressFromNamespace(nsSelector map[string]string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyIngressRule{
+		From:  []NetworkPolicyPeer{{NamespaceSelector: nsSelector}},
+		Ports: ports,
+	}
+	b.config.Ingress = append(b.config.Ingress, rule)
+	return b
+}
+
+// AllowIngressFromCIDR allows ingress from a CIDR block
+func (b *NetworkPolicyBuilder) AllowIngressFromCIDR(cidr string, except []string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyIngressRule{
+		From:  []NetworkPolicyPeer{{IPBlock: &IPBlock{CIDR: cidr, Except: except}}},
+		Ports: ports,
+	}
+	b.config.Ingress = append(b.config.Ingress, rule)
+	return b
+}
+
+// AllowAllIngress allows all ingress traffic
+func (b *NetworkPolicyBuilder) AllowAllIngress() *NetworkPolicyBuilder {
+	b.config.Ingress = append(b.config.Ingress, NetworkPolicyIngressRule{})
+	return b
+}
+
+// AllowEgressToPods allows egress to pods matching selector
+func (b *NetworkPolicyBuilder) AllowEgressToPods(selector map[string]string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyEgressRule{
+		To:    []NetworkPolicyPeer{{PodSelector: selector}},
+		Ports: ports,
+	}
+	b.config.Egress = append(b.config.Egress, rule)
+	return b
+}
+
+// AllowEgressToNamespace allows egress to a namespace
+func (b *NetworkPolicyBuilder) AllowEgressToNamespace(nsSelector map[string]string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyEgressRule{
+		To:    []NetworkPolicyPeer{{NamespaceSelector: nsSelector}},
+		Ports: ports,
+	}
+	b.config.Egress = append(b.config.Egress, rule)
+	return b
+}
+
+// AllowEgressToCIDR allows egress to a CIDR block
+func (b *NetworkPolicyBuilder) AllowEgressToCIDR(cidr string, except []string, ports ...NetworkPolicyPort) *NetworkPolicyBuilder {
+	rule := NetworkPolicyEgressRule{
+		To:    []NetworkPolicyPeer{{IPBlock: &IPBlock{CIDR: cidr, Except: except}}},
+		Ports: ports,
+	}
+	b.config.Egress = append(b.config.Egress, rule)
+	return b
+}
+
+// AllowDNS allows egress DNS (UDP/TCP 53)
+func (b *NetworkPolicyBuilder) AllowDNS() *NetworkPolicyBuilder {
+	rule := NetworkPolicyEgressRule{
+		Ports: []NetworkPolicyPort{
+			{Protocol: "UDP", Port: "53"},
+			{Protocol: "TCP", Port: "53"},
+		},
+	}
+	b.config.Egress = append(b.config.Egress, rule)
+	return b
+}
+
+// AllowAllEgress allows all egress traffic
+func (b *NetworkPolicyBuilder) AllowAllEgress() *NetworkPolicyBuilder {
+	b.config.Egress = append(b.config.Egress, NetworkPolicyEgressRule{})
+	return b
+}
+
+// DenyAllIngress denies all ingress (empty ingress with Ingress policy type)
+func (b *NetworkPolicyBuilder) DenyAllIngress() *NetworkPolicyBuilder {
+	b.config.PolicyTypes = append(b.config.PolicyTypes, PolicyTypeIngress)
+	// No ingress rules = deny all
+	return b
+}
+
+// DenyAllEgress denies all egress (empty egress with Egress policy type)
+func (b *NetworkPolicyBuilder) DenyAllEgress() *NetworkPolicyBuilder {
+	b.config.PolicyTypes = append(b.config.PolicyTypes, PolicyTypeEgress)
+	// No egress rules = deny all
+	return b
+}
+
+// WithAnnotation adds an annotation
+func (b *NetworkPolicyBuilder) WithAnnotation(key, value string) *NetworkPolicyBuilder {
+	if b.config.Annotations == nil {
+		b.config.Annotations = make(map[string]string)
+	}
+	b.config.Annotations[key] = value
+	return b
+}
+
+// WithLabel adds a label
+func (b *NetworkPolicyBuilder) WithLabel(key, value string) *NetworkPolicyBuilder {
+	if b.config.Labels == nil {
+		b.config.Labels = make(map[string]string)
+	}
+	b.config.Labels[key] = value
+	return b
+}
+
+// Build creates the NetworkPolicy resource
+func (b *NetworkPolicyBuilder) Build() *NetworkPolicyResource {
+	npm := NewNetworkPolicyManager(b.config.Namespace)
+	return npm.GenerateNetworkPolicy(b.config)
+}
+
+// TCP creates a TCP port
+func TCP(port string) NetworkPolicyPort {
+	return NetworkPolicyPort{Protocol: "TCP", Port: port}
+}
+
+// UDP creates a UDP port
+func UDP(port string) NetworkPolicyPort {
+	return NetworkPolicyPort{Protocol: "UDP", Port: port}
+}
+
+// PortRange creates a port range
+func PortRange(protocol, startPort string, endPort int32) NetworkPolicyPort {
+	return NetworkPolicyPort{Protocol: protocol, Port: startPort, EndPort: endPort}
+}
+
+// GenerateDefaultDenyIngress creates a default deny ingress policy
+func GenerateDefaultDenyIngress(namespace string) *NetworkPolicyResource {
+	return NewNetworkPolicyBuilder("default-deny-ingress", namespace).
+		ForPods(map[string]string{}).
+		WithPolicyTypes(PolicyTypeIngress).
+		Build()
+}
+
+// GenerateDefaultDenyEgress creates a default deny egress policy
+func GenerateDefaultDenyEgress(namespace string) *NetworkPolicyResource {
+	return NewNetworkPolicyBuilder("default-deny-egress", namespace).
+		ForPods(map[string]string{}).
+		WithPolicyTypes(PolicyTypeEgress).
+		Build()
+}
+
+// GenerateDefaultDenyAll creates a default deny all policy
+func GenerateDefaultDenyAll(namespace string) *NetworkPolicyResource {
+	return NewNetworkPolicyBuilder("default-deny-all", namespace).
+		ForPods(map[string]string{}).
+		WithPolicyTypes(PolicyTypeIngress, PolicyTypeEgress).
+		Build()
+}
+
+// GenerateVaultaireNetworkPolicies creates NetworkPolicies for Vaultaire
+func GenerateVaultaireNetworkPolicies(namespace string) []*NetworkPolicyResource {
+	policies := []*NetworkPolicyResource{}
+
+	// Default deny all ingress
+	policies = append(policies, GenerateDefaultDenyIngress(namespace))
+
+	// Allow API server to receive traffic
+	apiPolicy := NewNetworkPolicyBuilder("allow-api-ingress", namespace).
+		ForPods(map[string]string{"app": "vaultaire-api"}).
+		WithPolicyTypes(PolicyTypeIngress).
+		AllowIngressFromNamespace(
+			map[string]string{"kubernetes.io/metadata.name": "ingress-nginx"},
+			TCP("8080"),
+		).
+		AllowIngressFromPods(
+			map[string]string{"app": "vaultaire-worker"},
+			TCP("8080"),
+		).
+		Build()
+	policies = append(policies, apiPolicy)
+
+	// Allow workers to communicate with API and external services
+	workerPolicy := NewNetworkPolicyBuilder("allow-worker-egress", namespace).
+		ForPods(map[string]string{"app": "vaultaire-worker"}).
+		WithPolicyTypes(PolicyTypeEgress).
+		AllowDNS().
+		AllowEgressToPods(
+			map[string]string{"app": "vaultaire-api"},
+			TCP("8080"),
+		).
+		AllowEgressToCIDR("0.0.0.0/0", []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
+			TCP("443"),
+		).
+		Build()
+	policies = append(policies, workerPolicy)
+
+	// Allow metrics scraping from monitoring namespace
+	metricsPolicy := NewNetworkPolicyBuilder("allow-metrics-scrape", namespace).
+		ForPods(map[string]string{}).
+		WithPolicyTypes(PolicyTypeIngress).
+		AllowIngressFromNamespace(
+			map[string]string{"kubernetes.io/metadata.name": "monitoring"},
+			TCP("9090"),
+		).
+		Build()
+	policies = append(policies, metricsPolicy)
+
+	// Allow internal pod-to-pod communication within namespace
+	internalPolicy := NewNetworkPolicyBuilder("allow-internal", namespace).
+		ForPods(map[string]string{}).
+		WithPolicyTypes(PolicyTypeIngress).
+		AllowIngressFromPods(map[string]string{}).
+		Build()
+	policies = append(policies, internalPolicy)
+
+	return policies
+}
+
+// NetworkPolicySet represents a collection of NetworkPolicy resources
+type NetworkPolicySet struct {
+	Policies []*NetworkPolicyResource
+}
+
+// Add adds a NetworkPolicy to the set
+func (s *NetworkPolicySet) Add(np *NetworkPolicyResource) {
+	s.Policies = append(s.Policies, np)
+}
+
+// ToYAML converts all NetworkPolicies to multi-document YAML
+func (s *NetworkPolicySet) ToYAML() (string, error) {
+	var parts []string
+	for _, np := range s.Policies {
+		yaml, err := np.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+	return strings.Join(parts, "---\n"), nil
+}

--- a/internal/k8s/netpol_test.go
+++ b/internal/k8s/netpol_test.go
@@ -1,0 +1,452 @@
+// internal/k8s/netpol_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewNetworkPolicyManager(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	if npm.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", npm.namespace)
+	}
+}
+
+func TestGenerateNetworkPolicy(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		PodSelector: map[string]string{"app": "test"},
+		PolicyTypes: []PolicyType{PolicyTypeIngress},
+		Ingress: []NetworkPolicyIngressRule{
+			{
+				From: []NetworkPolicyPeer{
+					{PodSelector: map[string]string{"role": "frontend"}},
+				},
+				Ports: []NetworkPolicyPort{
+					{Protocol: "TCP", Port: "8080"},
+				},
+			},
+		},
+	})
+
+	if np.Kind != "NetworkPolicy" {
+		t.Errorf("expected kind NetworkPolicy, got %s", np.Kind)
+	}
+	if np.APIVersion != "networking.k8s.io/v1" {
+		t.Errorf("expected apiVersion networking.k8s.io/v1, got %s", np.APIVersion)
+	}
+	if np.Spec.PodSelector.MatchLabels["app"] != "test" {
+		t.Error("expected pod selector app=test")
+	}
+}
+
+func TestGenerateNetworkPolicyWithEgress(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-egress",
+		PodSelector: map[string]string{"app": "test"},
+		PolicyTypes: []PolicyType{PolicyTypeEgress},
+		Egress: []NetworkPolicyEgressRule{
+			{
+				To: []NetworkPolicyPeer{
+					{IPBlock: &IPBlock{CIDR: "10.0.0.0/8"}},
+				},
+				Ports: []NetworkPolicyPort{
+					{Protocol: "TCP", Port: "443"},
+				},
+			},
+		},
+	})
+
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("expected 1 egress rule, got %d", len(np.Spec.Egress))
+	}
+	if np.Spec.Egress[0].To[0].IPBlock.CIDR != "10.0.0.0/8" {
+		t.Error("expected CIDR 10.0.0.0/8")
+	}
+}
+
+func TestNetworkPolicyWithIPBlockExcept(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-ipblock",
+		PodSelector: map[string]string{},
+		PolicyTypes: []PolicyType{PolicyTypeEgress},
+		Egress: []NetworkPolicyEgressRule{
+			{
+				To: []NetworkPolicyPeer{
+					{IPBlock: &IPBlock{
+						CIDR:   "0.0.0.0/0",
+						Except: []string{"10.0.0.0/8", "192.168.0.0/16"},
+					}},
+				},
+			},
+		},
+	})
+
+	if len(np.Spec.Egress[0].To[0].IPBlock.Except) != 2 {
+		t.Errorf("expected 2 except blocks, got %d", len(np.Spec.Egress[0].To[0].IPBlock.Except))
+	}
+}
+
+func TestNetworkPolicyToYAML(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		PodSelector: map[string]string{"app": "test"},
+		PolicyTypes: []PolicyType{PolicyTypeIngress},
+	})
+
+	yaml, err := np.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: NetworkPolicy") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "networking.k8s.io/v1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestNetworkPolicyBuilder(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithPolicyTypes(PolicyTypeIngress, PolicyTypeEgress).
+		AllowIngressFromPods(map[string]string{"role": "frontend"}, TCP("8080")).
+		AllowEgressToPods(map[string]string{"role": "backend"}, TCP("5432")).
+		Build()
+
+	if np.Metadata.Name != "test" {
+		t.Errorf("expected name 'test', got '%s'", np.Metadata.Name)
+	}
+	if len(np.Spec.PolicyTypes) != 2 {
+		t.Error("expected 2 policy types")
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Error("expected 1 ingress rule")
+	}
+	if len(np.Spec.Egress) != 1 {
+		t.Error("expected 1 egress rule")
+	}
+}
+
+func TestNetworkPolicyBuilderAllowDNS(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithPolicyTypes(PolicyTypeEgress).
+		AllowDNS().
+		Build()
+
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("expected 1 egress rule, got %d", len(np.Spec.Egress))
+	}
+	if len(np.Spec.Egress[0].Ports) != 2 {
+		t.Error("expected 2 DNS ports (UDP and TCP)")
+	}
+}
+
+func TestNetworkPolicyBuilderFromNamespace(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithPolicyTypes(PolicyTypeIngress).
+		AllowIngressFromNamespace(map[string]string{"name": "frontend"}, TCP("8080")).
+		Build()
+
+	if np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["name"] != "frontend" {
+		t.Error("expected namespace selector")
+	}
+}
+
+func TestNetworkPolicyBuilderFromCIDR(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithPolicyTypes(PolicyTypeIngress).
+		AllowIngressFromCIDR("10.0.0.0/8", nil, TCP("8080")).
+		Build()
+
+	if np.Spec.Ingress[0].From[0].IPBlock.CIDR != "10.0.0.0/8" {
+		t.Error("expected CIDR block")
+	}
+}
+
+func TestNetworkPolicyBuilderAllowAll(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithPolicyTypes(PolicyTypeIngress, PolicyTypeEgress).
+		AllowAllIngress().
+		AllowAllEgress().
+		Build()
+
+	if len(np.Spec.Ingress) != 1 {
+		t.Error("expected 1 ingress rule (allow all)")
+	}
+	if len(np.Spec.Egress) != 1 {
+		t.Error("expected 1 egress rule (allow all)")
+	}
+}
+
+func TestNetworkPolicyBuilderDenyAll(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{}).
+		DenyAllIngress().
+		DenyAllEgress().
+		Build()
+
+	if len(np.Spec.PolicyTypes) != 2 {
+		t.Error("expected 2 policy types")
+	}
+	if len(np.Spec.Ingress) != 0 {
+		t.Error("expected no ingress rules (deny all)")
+	}
+	if len(np.Spec.Egress) != 0 {
+		t.Error("expected no egress rules (deny all)")
+	}
+}
+
+func TestTCPPort(t *testing.T) {
+	port := TCP("8080")
+
+	if port.Protocol != "TCP" {
+		t.Errorf("expected TCP protocol, got %s", port.Protocol)
+	}
+	if port.Port != "8080" {
+		t.Errorf("expected port 8080, got %s", port.Port)
+	}
+}
+
+func TestUDPPort(t *testing.T) {
+	port := UDP("53")
+
+	if port.Protocol != "UDP" {
+		t.Errorf("expected UDP protocol, got %s", port.Protocol)
+	}
+}
+
+func TestPortRange(t *testing.T) {
+	port := PortRange("TCP", "8000", 9000)
+
+	if port.Protocol != "TCP" {
+		t.Error("expected TCP protocol")
+	}
+	if port.Port != "8000" {
+		t.Error("expected start port 8000")
+	}
+	if port.EndPort != 9000 {
+		t.Error("expected end port 9000")
+	}
+}
+
+func TestGenerateDefaultDenyIngress(t *testing.T) {
+	np := GenerateDefaultDenyIngress("default")
+
+	if np.Metadata.Name != "default-deny-ingress" {
+		t.Errorf("expected name 'default-deny-ingress', got '%s'", np.Metadata.Name)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != "Ingress" {
+		t.Error("expected Ingress policy type")
+	}
+	if len(np.Spec.Ingress) != 0 {
+		t.Error("expected no ingress rules")
+	}
+}
+
+func TestGenerateDefaultDenyEgress(t *testing.T) {
+	np := GenerateDefaultDenyEgress("default")
+
+	if np.Metadata.Name != "default-deny-egress" {
+		t.Errorf("expected name 'default-deny-egress', got '%s'", np.Metadata.Name)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != "Egress" {
+		t.Error("expected Egress policy type")
+	}
+}
+
+func TestGenerateDefaultDenyAll(t *testing.T) {
+	np := GenerateDefaultDenyAll("default")
+
+	if np.Metadata.Name != "default-deny-all" {
+		t.Errorf("expected name 'default-deny-all', got '%s'", np.Metadata.Name)
+	}
+	if len(np.Spec.PolicyTypes) != 2 {
+		t.Error("expected 2 policy types")
+	}
+}
+
+func TestGenerateVaultaireNetworkPolicies(t *testing.T) {
+	policies := GenerateVaultaireNetworkPolicies("vaultaire")
+
+	if len(policies) < 4 {
+		t.Errorf("expected at least 4 policies, got %d", len(policies))
+	}
+
+	names := make(map[string]bool)
+	for _, p := range policies {
+		names[p.Metadata.Name] = true
+	}
+
+	expectedPolicies := []string{
+		"default-deny-ingress",
+		"allow-api-ingress",
+		"allow-worker-egress",
+		"allow-metrics-scrape",
+	}
+
+	for _, name := range expectedPolicies {
+		if !names[name] {
+			t.Errorf("expected policy '%s'", name)
+		}
+	}
+}
+
+func TestNetworkPolicySet(t *testing.T) {
+	set := &NetworkPolicySet{}
+	set.Add(GenerateDefaultDenyIngress("default"))
+	set.Add(GenerateDefaultDenyEgress("default"))
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 2 {
+		t.Errorf("expected 2 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestNetworkPolicyNamespaceDefault(t *testing.T) {
+	npm := NewNetworkPolicyManager("production")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		PodSelector: map[string]string{},
+	})
+
+	if np.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", np.Metadata.Namespace)
+	}
+}
+
+func TestNetworkPolicyNamespaceOverride(t *testing.T) {
+	npm := NewNetworkPolicyManager("production")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		Namespace:   "staging",
+		PodSelector: map[string]string{},
+	})
+
+	if np.Metadata.Namespace != "staging" {
+		t.Errorf("expected namespace 'staging', got '%s'", np.Metadata.Namespace)
+	}
+}
+
+func TestNetworkPolicyWithNamedPort(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		PodSelector: map[string]string{},
+		PolicyTypes: []PolicyType{PolicyTypeIngress},
+		Ingress: []NetworkPolicyIngressRule{
+			{
+				Ports: []NetworkPolicyPort{
+					{Protocol: "TCP", Port: "http"},
+				},
+			},
+		},
+	})
+
+	// Named port should be preserved as string
+	if np.Spec.Ingress[0].Ports[0].Port != "http" {
+		t.Errorf("expected named port 'http', got %v", np.Spec.Ingress[0].Ports[0].Port)
+	}
+}
+
+func TestNetworkPolicyWithPortRange(t *testing.T) {
+	npm := NewNetworkPolicyManager("default")
+
+	np := npm.GenerateNetworkPolicy(NetworkPolicyConfig{
+		Name:        "test-policy",
+		PodSelector: map[string]string{},
+		PolicyTypes: []PolicyType{PolicyTypeIngress},
+		Ingress: []NetworkPolicyIngressRule{
+			{
+				Ports: []NetworkPolicyPort{
+					{Protocol: "TCP", Port: "8000", EndPort: 9000},
+				},
+			},
+		},
+	})
+
+	if np.Spec.Ingress[0].Ports[0].EndPort == nil {
+		t.Fatal("expected end port")
+	}
+	if *np.Spec.Ingress[0].Ports[0].EndPort != 9000 {
+		t.Errorf("expected end port 9000, got %d", *np.Spec.Ingress[0].Ports[0].EndPort)
+	}
+}
+
+func TestNetworkPolicyBuilderWithLabels(t *testing.T) {
+	np := NewNetworkPolicyBuilder("test", "default").
+		ForPods(map[string]string{"app": "web"}).
+		WithLabel("env", "prod").
+		WithAnnotation("description", "test policy").
+		Build()
+
+	if np.Metadata.Labels["env"] != "prod" {
+		t.Error("expected env label")
+	}
+	if np.Metadata.Annotations["description"] != "test policy" {
+		t.Error("expected description annotation")
+	}
+}
+
+func TestConvertPeerPodSelector(t *testing.T) {
+	peer := NetworkPolicyPeer{
+		PodSelector: map[string]string{"app": "frontend"},
+	}
+
+	spec := convertPeer(peer)
+
+	if spec.PodSelector == nil {
+		t.Fatal("expected pod selector")
+	}
+	if spec.PodSelector.MatchLabels["app"] != "frontend" {
+		t.Error("expected app=frontend")
+	}
+}
+
+func TestConvertPeerNamespaceSelector(t *testing.T) {
+	peer := NetworkPolicyPeer{
+		NamespaceSelector: map[string]string{"name": "monitoring"},
+	}
+
+	spec := convertPeer(peer)
+
+	if spec.NamespaceSelector == nil {
+		t.Fatal("expected namespace selector")
+	}
+	if spec.NamespaceSelector.MatchLabels["name"] != "monitoring" {
+		t.Error("expected name=monitoring")
+	}
+}
+
+func TestConvertPortNumeric(t *testing.T) {
+	port := NetworkPolicyPort{Protocol: "TCP", Port: "8080"}
+	spec := convertPort(port)
+
+	// Numeric port should be converted to int
+	if spec.Port != 8080 {
+		t.Errorf("expected port 8080, got %v", spec.Port)
+	}
+}

--- a/internal/k8s/observability.go
+++ b/internal/k8s/observability.go
@@ -1,0 +1,707 @@
+// internal/k8s/observability.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigMapManifest represents a ConfigMap for dashboards
+type ConfigMapManifest struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   ManifestMetadata  `yaml:"metadata"`
+	Data       map[string]string `yaml:"data,omitempty"`
+}
+
+// ToYAML converts ConfigMap to YAML
+func (cm *ConfigMapManifest) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(cm); err != nil {
+		return "", fmt.Errorf("failed to encode ConfigMap: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ObservabilityManager manages observability resources
+type ObservabilityManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewObservabilityManager creates a new observability manager
+func NewObservabilityManager(namespace string) *ObservabilityManager {
+	return &ObservabilityManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// ServiceMonitorCfg configures a Prometheus ServiceMonitor (renamed to avoid conflict)
+type ServiceMonitorCfg struct {
+	Name              string
+	Namespace         string
+	Labels            map[string]string
+	Annotations       map[string]string
+	Selector          map[string]string
+	NamespaceSelector *NamespaceSelector
+	Endpoints         []MonitorEndpoint
+	JobLabel          string
+	TargetLabels      []string
+	PodTargetLabels   []string
+	SampleLimit       int
+}
+
+// NamespaceSelector defines namespace selection
+type NamespaceSelector struct {
+	Any        bool
+	MatchNames []string
+}
+
+// MonitorEndpoint defines a scrape endpoint (renamed to avoid conflict)
+type MonitorEndpoint struct {
+	Port              string
+	Path              string
+	Interval          string
+	ScrapeTimeout     string
+	Scheme            string
+	TLSConfig         *MonitorTLSConfig
+	BearerTokenFile   string
+	BasicAuth         *MonitorBasicAuth
+	MetricRelabelings []RelabelConfig
+	Relabelings       []RelabelConfig
+	HonorLabels       bool
+	HonorTimestamps   *bool
+}
+
+// MonitorTLSConfig defines TLS settings
+type MonitorTLSConfig struct {
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	ServerName         string
+	InsecureSkipVerify bool
+}
+
+// MonitorBasicAuth defines basic auth settings
+type MonitorBasicAuth struct {
+	Username SecretKeySelector
+	Password SecretKeySelector
+}
+
+// SecretKeySelector references a secret key
+type SecretKeySelector struct {
+	Name string
+	Key  string
+}
+
+// RelabelConfig defines metric relabeling
+type RelabelConfig struct {
+	SourceLabels []string
+	Separator    string
+	TargetLabel  string
+	Regex        string
+	Modulus      int
+	Replacement  string
+	Action       string // replace, keep, drop, hashmod, labelmap, labeldrop, labelkeep
+}
+
+// ServiceMonitorResource represents a ServiceMonitor
+type ServiceMonitorResource struct {
+	APIVersion string             `yaml:"apiVersion"`
+	Kind       string             `yaml:"kind"`
+	Metadata   ManifestMetadata   `yaml:"metadata"`
+	Spec       ServiceMonitorSpec `yaml:"spec"`
+}
+
+// ServiceMonitorSpec defines ServiceMonitor specification
+type ServiceMonitorSpec struct {
+	Selector          LabelSelectorSpec      `yaml:"selector"`
+	NamespaceSelector *NamespaceSelectorSpec `yaml:"namespaceSelector,omitempty"`
+	Endpoints         []EndpointSpec         `yaml:"endpoints"`
+	JobLabel          string                 `yaml:"jobLabel,omitempty"`
+	TargetLabels      []string               `yaml:"targetLabels,omitempty"`
+	PodTargetLabels   []string               `yaml:"podTargetLabels,omitempty"`
+	SampleLimit       int                    `yaml:"sampleLimit,omitempty"`
+}
+
+// LabelSelectorSpec for ServiceMonitor
+type LabelSelectorSpec struct {
+	MatchLabels map[string]string `yaml:"matchLabels,omitempty"`
+}
+
+// NamespaceSelectorSpec for ServiceMonitor
+type NamespaceSelectorSpec struct {
+	Any        bool     `yaml:"any,omitempty"`
+	MatchNames []string `yaml:"matchNames,omitempty"`
+}
+
+// EndpointSpec for ServiceMonitor
+type EndpointSpec struct {
+	Port              string              `yaml:"port,omitempty"`
+	Path              string              `yaml:"path,omitempty"`
+	Interval          string              `yaml:"interval,omitempty"`
+	ScrapeTimeout     string              `yaml:"scrapeTimeout,omitempty"`
+	Scheme            string              `yaml:"scheme,omitempty"`
+	TLSConfig         *TLSConfigSpec      `yaml:"tlsConfig,omitempty"`
+	BearerTokenFile   string              `yaml:"bearerTokenFile,omitempty"`
+	BasicAuth         *BasicAuthSpec      `yaml:"basicAuth,omitempty"`
+	MetricRelabelings []RelabelConfigSpec `yaml:"metricRelabelings,omitempty"`
+	Relabelings       []RelabelConfigSpec `yaml:"relabelings,omitempty"`
+	HonorLabels       bool                `yaml:"honorLabels,omitempty"`
+	HonorTimestamps   *bool               `yaml:"honorTimestamps,omitempty"`
+}
+
+// TLSConfigSpec for ServiceMonitor
+type TLSConfigSpec struct {
+	CAFile             string `yaml:"caFile,omitempty"`
+	CertFile           string `yaml:"certFile,omitempty"`
+	KeyFile            string `yaml:"keyFile,omitempty"`
+	ServerName         string `yaml:"serverName,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify,omitempty"`
+}
+
+// BasicAuthSpec for ServiceMonitor
+type BasicAuthSpec struct {
+	Username SecretKeySelectorSpec `yaml:"username"`
+	Password SecretKeySelectorSpec `yaml:"password"`
+}
+
+// SecretKeySelectorSpec for ServiceMonitor
+type SecretKeySelectorSpec struct {
+	Name string `yaml:"name"`
+	Key  string `yaml:"key"`
+}
+
+// RelabelConfigSpec for ServiceMonitor
+type RelabelConfigSpec struct {
+	SourceLabels []string `yaml:"sourceLabels,omitempty"`
+	Separator    string   `yaml:"separator,omitempty"`
+	TargetLabel  string   `yaml:"targetLabel,omitempty"`
+	Regex        string   `yaml:"regex,omitempty"`
+	Modulus      int      `yaml:"modulus,omitempty"`
+	Replacement  string   `yaml:"replacement,omitempty"`
+	Action       string   `yaml:"action,omitempty"`
+}
+
+// GenerateServiceMonitor creates a ServiceMonitor resource
+func (om *ObservabilityManager) GenerateServiceMonitor(config ServiceMonitorCfg) *ServiceMonitorResource {
+	if config.Namespace == "" {
+		config.Namespace = om.namespace
+	}
+
+	labels := copyStringMap(om.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	sm := &ServiceMonitorResource{
+		APIVersion: "monitoring.coreos.com/v1",
+		Kind:       "ServiceMonitor",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: ServiceMonitorSpec{
+			Selector: LabelSelectorSpec{
+				MatchLabels: config.Selector,
+			},
+			JobLabel:        config.JobLabel,
+			TargetLabels:    config.TargetLabels,
+			PodTargetLabels: config.PodTargetLabels,
+			SampleLimit:     config.SampleLimit,
+		},
+	}
+
+	if config.NamespaceSelector != nil {
+		sm.Spec.NamespaceSelector = &NamespaceSelectorSpec{
+			Any:        config.NamespaceSelector.Any,
+			MatchNames: config.NamespaceSelector.MatchNames,
+		}
+	}
+
+	for _, ep := range config.Endpoints {
+		epSpec := EndpointSpec{
+			Port:            ep.Port,
+			Path:            ep.Path,
+			Interval:        ep.Interval,
+			ScrapeTimeout:   ep.ScrapeTimeout,
+			Scheme:          ep.Scheme,
+			BearerTokenFile: ep.BearerTokenFile,
+			HonorLabels:     ep.HonorLabels,
+			HonorTimestamps: ep.HonorTimestamps,
+		}
+
+		if ep.TLSConfig != nil {
+			epSpec.TLSConfig = &TLSConfigSpec{
+				CAFile:             ep.TLSConfig.CAFile,
+				CertFile:           ep.TLSConfig.CertFile,
+				KeyFile:            ep.TLSConfig.KeyFile,
+				ServerName:         ep.TLSConfig.ServerName,
+				InsecureSkipVerify: ep.TLSConfig.InsecureSkipVerify,
+			}
+		}
+
+		if ep.BasicAuth != nil {
+			epSpec.BasicAuth = &BasicAuthSpec{
+				Username: SecretKeySelectorSpec{Name: ep.BasicAuth.Username.Name, Key: ep.BasicAuth.Username.Key},
+				Password: SecretKeySelectorSpec{Name: ep.BasicAuth.Password.Name, Key: ep.BasicAuth.Password.Key},
+			}
+		}
+
+		for _, r := range ep.MetricRelabelings {
+			epSpec.MetricRelabelings = append(epSpec.MetricRelabelings, RelabelConfigSpec(r))
+		}
+
+		for _, r := range ep.Relabelings {
+			epSpec.Relabelings = append(epSpec.Relabelings, RelabelConfigSpec(r))
+		}
+
+		sm.Spec.Endpoints = append(sm.Spec.Endpoints, epSpec)
+	}
+
+	return sm
+}
+
+// ToYAML converts ServiceMonitor to YAML
+func (sm *ServiceMonitorResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(sm); err != nil {
+		return "", fmt.Errorf("failed to encode ServiceMonitor: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// PodMonitorCfg configures a Prometheus PodMonitor
+type PodMonitorCfg struct {
+	Name                string
+	Namespace           string
+	Labels              map[string]string
+	Annotations         map[string]string
+	Selector            map[string]string
+	NamespaceSelector   *NamespaceSelector
+	PodMetricsEndpoints []PodMetricsEndpoint
+	JobLabel            string
+	PodTargetLabels     []string
+	SampleLimit         int
+}
+
+// PodMetricsEndpoint defines a pod metrics endpoint
+type PodMetricsEndpoint struct {
+	Port            string
+	Path            string
+	Interval        string
+	ScrapeTimeout   string
+	Scheme          string
+	HonorLabels     bool
+	HonorTimestamps *bool
+}
+
+// PodMonitorResource represents a PodMonitor
+type PodMonitorResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       PodMonitorSpec   `yaml:"spec"`
+}
+
+// PodMonitorSpec defines PodMonitor specification
+type PodMonitorSpec struct {
+	Selector            LabelSelectorSpec        `yaml:"selector"`
+	NamespaceSelector   *NamespaceSelectorSpec   `yaml:"namespaceSelector,omitempty"`
+	PodMetricsEndpoints []PodMetricsEndpointSpec `yaml:"podMetricsEndpoints"`
+	JobLabel            string                   `yaml:"jobLabel,omitempty"`
+	PodTargetLabels     []string                 `yaml:"podTargetLabels,omitempty"`
+	SampleLimit         int                      `yaml:"sampleLimit,omitempty"`
+}
+
+// PodMetricsEndpointSpec for PodMonitor
+type PodMetricsEndpointSpec struct {
+	Port            string `yaml:"port,omitempty"`
+	Path            string `yaml:"path,omitempty"`
+	Interval        string `yaml:"interval,omitempty"`
+	ScrapeTimeout   string `yaml:"scrapeTimeout,omitempty"`
+	Scheme          string `yaml:"scheme,omitempty"`
+	HonorLabels     bool   `yaml:"honorLabels,omitempty"`
+	HonorTimestamps *bool  `yaml:"honorTimestamps,omitempty"`
+}
+
+// GeneratePodMonitor creates a PodMonitor resource
+func (om *ObservabilityManager) GeneratePodMonitor(config PodMonitorCfg) *PodMonitorResource {
+	if config.Namespace == "" {
+		config.Namespace = om.namespace
+	}
+
+	labels := copyStringMap(om.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	pm := &PodMonitorResource{
+		APIVersion: "monitoring.coreos.com/v1",
+		Kind:       "PodMonitor",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: PodMonitorSpec{
+			Selector: LabelSelectorSpec{
+				MatchLabels: config.Selector,
+			},
+			JobLabel:        config.JobLabel,
+			PodTargetLabels: config.PodTargetLabels,
+			SampleLimit:     config.SampleLimit,
+		},
+	}
+
+	if config.NamespaceSelector != nil {
+		pm.Spec.NamespaceSelector = &NamespaceSelectorSpec{
+			Any:        config.NamespaceSelector.Any,
+			MatchNames: config.NamespaceSelector.MatchNames,
+		}
+	}
+
+	for _, ep := range config.PodMetricsEndpoints {
+		pm.Spec.PodMetricsEndpoints = append(pm.Spec.PodMetricsEndpoints, PodMetricsEndpointSpec(ep))
+	}
+
+	return pm
+}
+
+// ToYAML converts PodMonitor to YAML
+func (pm *PodMonitorResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(pm); err != nil {
+		return "", fmt.Errorf("failed to encode PodMonitor: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// PrometheusRuleCfg configures a PrometheusRule
+type PrometheusRuleCfg struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Groups      []RuleGroup
+}
+
+// RuleGroup defines a group of rules
+type RuleGroup struct {
+	Name     string
+	Interval string
+	Rules    []Rule
+}
+
+// Rule defines an alerting or recording rule
+type Rule struct {
+	Record      string // Recording rule name
+	Alert       string // Alert name
+	Expr        string // PromQL expression
+	For         string // Alert duration
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// PrometheusRuleResource represents a PrometheusRule
+type PrometheusRuleResource struct {
+	APIVersion string             `yaml:"apiVersion"`
+	Kind       string             `yaml:"kind"`
+	Metadata   ManifestMetadata   `yaml:"metadata"`
+	Spec       PrometheusRuleSpec `yaml:"spec"`
+}
+
+// PrometheusRuleSpec defines PrometheusRule specification
+type PrometheusRuleSpec struct {
+	Groups []RuleGroupSpec `yaml:"groups"`
+}
+
+// RuleGroupSpec for PrometheusRule
+type RuleGroupSpec struct {
+	Name     string     `yaml:"name"`
+	Interval string     `yaml:"interval,omitempty"`
+	Rules    []RuleSpec `yaml:"rules"`
+}
+
+// RuleSpec for PrometheusRule
+type RuleSpec struct {
+	Record      string            `yaml:"record,omitempty"`
+	Alert       string            `yaml:"alert,omitempty"`
+	Expr        string            `yaml:"expr"`
+	For         string            `yaml:"for,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// GeneratePrometheusRule creates a PrometheusRule resource
+func (om *ObservabilityManager) GeneratePrometheusRule(config PrometheusRuleCfg) *PrometheusRuleResource {
+	if config.Namespace == "" {
+		config.Namespace = om.namespace
+	}
+
+	labels := copyStringMap(om.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	pr := &PrometheusRuleResource{
+		APIVersion: "monitoring.coreos.com/v1",
+		Kind:       "PrometheusRule",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: PrometheusRuleSpec{},
+	}
+
+	for _, g := range config.Groups {
+		groupSpec := RuleGroupSpec{
+			Name:     g.Name,
+			Interval: g.Interval,
+		}
+		for _, r := range g.Rules {
+			groupSpec.Rules = append(groupSpec.Rules, RuleSpec(r))
+		}
+		pr.Spec.Groups = append(pr.Spec.Groups, groupSpec)
+	}
+
+	return pr
+}
+
+// ToYAML converts PrometheusRule to YAML
+func (pr *PrometheusRuleResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(pr); err != nil {
+		return "", fmt.Errorf("failed to encode PrometheusRule: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// GrafanaDashboardCfg configures a Grafana Dashboard ConfigMap
+type GrafanaDashboardCfg struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Folder      string
+	JSON        string
+}
+
+// GenerateGrafanaDashboard creates a ConfigMap for Grafana dashboard
+func (om *ObservabilityManager) GenerateGrafanaDashboard(config GrafanaDashboardCfg) *ConfigMapManifest {
+	if config.Namespace == "" {
+		config.Namespace = om.namespace
+	}
+
+	labels := copyStringMap(om.labels)
+	labels["grafana_dashboard"] = "1"
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	annotations := make(map[string]string)
+	for k, v := range config.Annotations {
+		annotations[k] = v
+	}
+	if config.Folder != "" {
+		annotations["grafana_folder"] = config.Folder
+	}
+
+	return &ConfigMapManifest{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: map[string]string{
+			config.Name + ".json": config.JSON,
+		},
+	}
+}
+
+// GenerateVaultaireObservability creates observability resources for Vaultaire
+func GenerateVaultaireObservability(namespace string) (*ServiceMonitorResource, *PrometheusRuleResource) {
+	om := NewObservabilityManager(namespace)
+
+	// ServiceMonitor for API server
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "vaultaire-api",
+		Selector: map[string]string{"app": "vaultaire-api"},
+		Endpoints: []MonitorEndpoint{
+			{
+				Port:     "metrics",
+				Path:     "/metrics",
+				Interval: "30s",
+			},
+		},
+		TargetLabels: []string{"app", "version"},
+	})
+
+	// Alerting rules
+	pr := om.GeneratePrometheusRule(PrometheusRuleCfg{
+		Name: "vaultaire-alerts",
+		Labels: map[string]string{
+			"prometheus": "vaultaire",
+			"role":       "alert-rules",
+		},
+		Groups: []RuleGroup{
+			{
+				Name: "vaultaire.rules",
+				Rules: []Rule{
+					{
+						Alert: "VaultaireAPIHighErrorRate",
+						Expr:  `sum(rate(http_requests_total{job="vaultaire-api",status=~"5.."}[5m])) / sum(rate(http_requests_total{job="vaultaire-api"}[5m])) > 0.05`,
+						For:   "5m",
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+						Annotations: map[string]string{
+							"summary":     "High error rate on Vaultaire API",
+							"description": "Error rate is {{ $value | humanizePercentage }} over the last 5 minutes",
+						},
+					},
+					{
+						Alert: "VaultaireAPIPodDown",
+						Expr:  `up{job="vaultaire-api"} == 0`,
+						For:   "1m",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+						Annotations: map[string]string{
+							"summary":     "Vaultaire API pod is down",
+							"description": "Pod {{ $labels.pod }} has been down for more than 1 minute",
+						},
+					},
+					{
+						Alert: "VaultaireHighMemoryUsage",
+						Expr:  `container_memory_usage_bytes{container="vaultaire-api"} / container_spec_memory_limit_bytes{container="vaultaire-api"} > 0.9`,
+						For:   "5m",
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+						Annotations: map[string]string{
+							"summary":     "High memory usage on Vaultaire API",
+							"description": "Memory usage is above 90% for pod {{ $labels.pod }}",
+						},
+					},
+					{
+						Alert: "VaultaireHighCPUUsage",
+						Expr:  `rate(container_cpu_usage_seconds_total{container="vaultaire-api"}[5m]) > 0.9`,
+						For:   "5m",
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+						Annotations: map[string]string{
+							"summary":     "High CPU usage on Vaultaire API",
+							"description": "CPU usage is above 90% for pod {{ $labels.pod }}",
+						},
+					},
+					{
+						Alert: "VaultaireStorageQuotaExceeded",
+						Expr:  `vaultaire_storage_used_bytes / vaultaire_storage_quota_bytes > 0.95`,
+						For:   "10m",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+						Annotations: map[string]string{
+							"summary":     "Storage quota nearly exceeded",
+							"description": "Storage usage is {{ $value | humanizePercentage }} of quota",
+						},
+					},
+				},
+			},
+			{
+				Name: "vaultaire.slo",
+				Rules: []Rule{
+					{
+						Record: "vaultaire:http_request_duration_seconds:p99",
+						Expr:   `histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job="vaultaire-api"}[5m])) by (le))`,
+					},
+					{
+						Record: "vaultaire:http_request_duration_seconds:p95",
+						Expr:   `histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="vaultaire-api"}[5m])) by (le))`,
+					},
+					{
+						Record: "vaultaire:http_request_duration_seconds:p50",
+						Expr:   `histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job="vaultaire-api"}[5m])) by (le))`,
+					},
+					{
+						Record: "vaultaire:availability:ratio_rate5m",
+						Expr:   `sum(rate(http_requests_total{job="vaultaire-api",status!~"5.."}[5m])) / sum(rate(http_requests_total{job="vaultaire-api"}[5m]))`,
+					},
+				},
+			},
+		},
+	})
+
+	return sm, pr
+}
+
+// ObservabilitySet represents a collection of observability resources
+type ObservabilitySet struct {
+	ServiceMonitors []*ServiceMonitorResource
+	PodMonitors     []*PodMonitorResource
+	PrometheusRules []*PrometheusRuleResource
+	Dashboards      []*ConfigMapManifest
+}
+
+// ToYAML converts all resources to multi-document YAML
+func (s *ObservabilitySet) ToYAML() (string, error) {
+	var parts []string
+
+	for _, sm := range s.ServiceMonitors {
+		yaml, err := sm.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, pm := range s.PodMonitors {
+		yaml, err := pm.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, pr := range s.PrometheusRules {
+		yaml, err := pr.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, d := range s.Dashboards {
+		yaml, err := d.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	return strings.Join(parts, "---\n"), nil
+}

--- a/internal/k8s/observability_test.go
+++ b/internal/k8s/observability_test.go
@@ -1,0 +1,506 @@
+// internal/k8s/observability_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewObservabilityManager(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	if om.namespace != "monitoring" {
+		t.Errorf("expected namespace 'monitoring', got '%s'", om.namespace)
+	}
+}
+
+func TestGenerateServiceMonitor(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{
+			{
+				Port:     "metrics",
+				Path:     "/metrics",
+				Interval: "30s",
+			},
+		},
+	})
+
+	if sm.Kind != "ServiceMonitor" {
+		t.Errorf("expected kind ServiceMonitor, got %s", sm.Kind)
+	}
+	if sm.APIVersion != "monitoring.coreos.com/v1" {
+		t.Errorf("expected apiVersion monitoring.coreos.com/v1, got %s", sm.APIVersion)
+	}
+	if sm.Spec.Selector.MatchLabels["app"] != "test" {
+		t.Error("expected selector app=test")
+	}
+	if len(sm.Spec.Endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(sm.Spec.Endpoints))
+	}
+	if sm.Spec.Endpoints[0].Port != "metrics" {
+		t.Error("expected port metrics")
+	}
+}
+
+func TestGenerateServiceMonitorWithNamespaceSelector(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		NamespaceSelector: &NamespaceSelector{
+			MatchNames: []string{"app-ns-1", "app-ns-2"},
+		},
+		Endpoints: []MonitorEndpoint{
+			{Port: "metrics"},
+		},
+	})
+
+	if sm.Spec.NamespaceSelector == nil {
+		t.Fatal("expected namespace selector")
+	}
+	if len(sm.Spec.NamespaceSelector.MatchNames) != 2 {
+		t.Error("expected 2 namespace matches")
+	}
+}
+
+func TestGenerateServiceMonitorAnyNamespace(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		NamespaceSelector: &NamespaceSelector{
+			Any: true,
+		},
+		Endpoints: []MonitorEndpoint{
+			{Port: "metrics"},
+		},
+	})
+
+	if sm.Spec.NamespaceSelector == nil || !sm.Spec.NamespaceSelector.Any {
+		t.Error("expected any namespace selector")
+	}
+}
+
+func TestGenerateServiceMonitorWithTLS(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{
+			{
+				Port:   "metrics",
+				Scheme: "https",
+				TLSConfig: &MonitorTLSConfig{
+					CAFile:     "/etc/prometheus/ca.crt",
+					ServerName: "test-service.default.svc",
+				},
+			},
+		},
+	})
+
+	if sm.Spec.Endpoints[0].Scheme != "https" {
+		t.Error("expected https scheme")
+	}
+	if sm.Spec.Endpoints[0].TLSConfig == nil {
+		t.Fatal("expected TLS config")
+	}
+	if sm.Spec.Endpoints[0].TLSConfig.CAFile != "/etc/prometheus/ca.crt" {
+		t.Error("expected CA file")
+	}
+}
+
+func TestGenerateServiceMonitorWithBasicAuth(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{
+			{
+				Port: "metrics",
+				BasicAuth: &MonitorBasicAuth{
+					Username: SecretKeySelector{Name: "metrics-auth", Key: "username"},
+					Password: SecretKeySelector{Name: "metrics-auth", Key: "password"},
+				},
+			},
+		},
+	})
+
+	if sm.Spec.Endpoints[0].BasicAuth == nil {
+		t.Fatal("expected basic auth")
+	}
+	if sm.Spec.Endpoints[0].BasicAuth.Username.Name != "metrics-auth" {
+		t.Error("expected username secret name")
+	}
+}
+
+func TestGenerateServiceMonitorWithRelabeling(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{
+			{
+				Port: "metrics",
+				MetricRelabelings: []RelabelConfig{
+					{
+						SourceLabels: []string{"__name__"},
+						Regex:        "expensive_metric.*",
+						Action:       "drop",
+					},
+				},
+			},
+		},
+	})
+
+	if len(sm.Spec.Endpoints[0].MetricRelabelings) != 1 {
+		t.Fatal("expected 1 metric relabeling")
+	}
+	if sm.Spec.Endpoints[0].MetricRelabelings[0].Action != "drop" {
+		t.Error("expected drop action")
+	}
+}
+
+func TestServiceMonitorToYAML(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:     "test-monitor",
+		Selector: map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{
+			{Port: "metrics"},
+		},
+	})
+
+	yaml, err := sm.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: ServiceMonitor") {
+		t.Error("expected YAML to contain kind")
+	}
+	if !strings.Contains(yaml, "monitoring.coreos.com/v1") {
+		t.Error("expected YAML to contain apiVersion")
+	}
+}
+
+func TestGeneratePodMonitor(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pm := om.GeneratePodMonitor(PodMonitorCfg{
+		Name:     "test-pod-monitor",
+		Selector: map[string]string{"app": "test"},
+		PodMetricsEndpoints: []PodMetricsEndpoint{
+			{
+				Port:     "metrics",
+				Path:     "/metrics",
+				Interval: "30s",
+			},
+		},
+	})
+
+	if pm.Kind != "PodMonitor" {
+		t.Errorf("expected kind PodMonitor, got %s", pm.Kind)
+	}
+	if len(pm.Spec.PodMetricsEndpoints) != 1 {
+		t.Error("expected 1 pod metrics endpoint")
+	}
+}
+
+func TestPodMonitorToYAML(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pm := om.GeneratePodMonitor(PodMonitorCfg{
+		Name:     "test-pod-monitor",
+		Selector: map[string]string{"app": "test"},
+		PodMetricsEndpoints: []PodMetricsEndpoint{
+			{Port: "metrics"},
+		},
+	})
+
+	yaml, err := pm.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: PodMonitor") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGeneratePrometheusRule(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pr := om.GeneratePrometheusRule(PrometheusRuleCfg{
+		Name: "test-rules",
+		Groups: []RuleGroup{
+			{
+				Name: "test.rules",
+				Rules: []Rule{
+					{
+						Alert: "TestAlert",
+						Expr:  "up == 0",
+						For:   "5m",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+						Annotations: map[string]string{
+							"summary": "Test alert fired",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if pr.Kind != "PrometheusRule" {
+		t.Errorf("expected kind PrometheusRule, got %s", pr.Kind)
+	}
+	if len(pr.Spec.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(pr.Spec.Groups))
+	}
+	if pr.Spec.Groups[0].Name != "test.rules" {
+		t.Error("expected group name test.rules")
+	}
+	if len(pr.Spec.Groups[0].Rules) != 1 {
+		t.Error("expected 1 rule")
+	}
+}
+
+func TestGeneratePrometheusRuleRecording(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pr := om.GeneratePrometheusRule(PrometheusRuleCfg{
+		Name: "test-recording-rules",
+		Groups: []RuleGroup{
+			{
+				Name:     "test.recording",
+				Interval: "30s",
+				Rules: []Rule{
+					{
+						Record: "job:http_requests:rate5m",
+						Expr:   "sum(rate(http_requests_total[5m])) by (job)",
+					},
+				},
+			},
+		},
+	})
+
+	if pr.Spec.Groups[0].Rules[0].Record != "job:http_requests:rate5m" {
+		t.Error("expected recording rule name")
+	}
+	if pr.Spec.Groups[0].Rules[0].Alert != "" {
+		t.Error("recording rule should not have alert")
+	}
+}
+
+func TestPrometheusRuleToYAML(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pr := om.GeneratePrometheusRule(PrometheusRuleCfg{
+		Name: "test-rules",
+		Groups: []RuleGroup{
+			{
+				Name:  "test.rules",
+				Rules: []Rule{{Alert: "Test", Expr: "up == 0"}},
+			},
+		},
+	})
+
+	yaml, err := pr.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: PrometheusRule") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGenerateGrafanaDashboard(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	dashboardJSON := `{"title": "Test Dashboard", "panels": []}`
+
+	cm := om.GenerateGrafanaDashboard(GrafanaDashboardCfg{
+		Name:   "test-dashboard",
+		Folder: "Vaultaire",
+		JSON:   dashboardJSON,
+	})
+
+	if cm.Kind != "ConfigMap" {
+		t.Errorf("expected kind ConfigMap, got %s", cm.Kind)
+	}
+	if cm.Metadata.Labels["grafana_dashboard"] != "1" {
+		t.Error("expected grafana_dashboard label")
+	}
+	if cm.Metadata.Annotations["grafana_folder"] != "Vaultaire" {
+		t.Error("expected grafana_folder annotation")
+	}
+	if cm.Data["test-dashboard.json"] != dashboardJSON {
+		t.Error("expected dashboard JSON")
+	}
+}
+
+func TestGenerateVaultaireObservability(t *testing.T) {
+	sm, pr := GenerateVaultaireObservability("vaultaire")
+
+	if sm.Metadata.Name != "vaultaire-api" {
+		t.Errorf("expected ServiceMonitor name 'vaultaire-api', got '%s'", sm.Metadata.Name)
+	}
+	if pr.Metadata.Name != "vaultaire-alerts" {
+		t.Errorf("expected PrometheusRule name 'vaultaire-alerts', got '%s'", pr.Metadata.Name)
+	}
+
+	// Check that we have alert rules
+	var hasAlertRules bool
+	var hasRecordingRules bool
+	for _, g := range pr.Spec.Groups {
+		for _, r := range g.Rules {
+			if r.Alert != "" {
+				hasAlertRules = true
+			}
+			if r.Record != "" {
+				hasRecordingRules = true
+			}
+		}
+	}
+
+	if !hasAlertRules {
+		t.Error("expected alert rules")
+	}
+	if !hasRecordingRules {
+		t.Error("expected recording rules")
+	}
+}
+
+func TestObservabilitySet(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	set := &ObservabilitySet{
+		ServiceMonitors: []*ServiceMonitorResource{
+			om.GenerateServiceMonitor(ServiceMonitorCfg{
+				Name:      "sm-1",
+				Selector:  map[string]string{"app": "test"},
+				Endpoints: []MonitorEndpoint{{Port: "metrics"}},
+			}),
+		},
+		PodMonitors: []*PodMonitorResource{
+			om.GeneratePodMonitor(PodMonitorCfg{
+				Name:                "pm-1",
+				Selector:            map[string]string{"app": "test"},
+				PodMetricsEndpoints: []PodMetricsEndpoint{{Port: "metrics"}},
+			}),
+		},
+		PrometheusRules: []*PrometheusRuleResource{
+			om.GeneratePrometheusRule(PrometheusRuleCfg{
+				Name:   "pr-1",
+				Groups: []RuleGroup{{Name: "test", Rules: []Rule{{Alert: "Test", Expr: "up==0"}}}},
+			}),
+		},
+	}
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 3 {
+		t.Errorf("expected 3 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestServiceMonitorNamespaceDefault(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:      "test-monitor",
+		Selector:  map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{{Port: "metrics"}},
+	})
+
+	if sm.Metadata.Namespace != "monitoring" {
+		t.Errorf("expected namespace 'monitoring', got '%s'", sm.Metadata.Namespace)
+	}
+}
+
+func TestServiceMonitorNamespaceOverride(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:      "test-monitor",
+		Namespace: "custom",
+		Selector:  map[string]string{"app": "test"},
+		Endpoints: []MonitorEndpoint{{Port: "metrics"}},
+	})
+
+	if sm.Metadata.Namespace != "custom" {
+		t.Errorf("expected namespace 'custom', got '%s'", sm.Metadata.Namespace)
+	}
+}
+
+func TestServiceMonitorJobLabel(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:         "test-monitor",
+		Selector:     map[string]string{"app": "test"},
+		Endpoints:    []MonitorEndpoint{{Port: "metrics"}},
+		JobLabel:     "app",
+		TargetLabels: []string{"version", "environment"},
+	})
+
+	if sm.Spec.JobLabel != "app" {
+		t.Error("expected jobLabel")
+	}
+	if len(sm.Spec.TargetLabels) != 2 {
+		t.Error("expected 2 target labels")
+	}
+}
+
+func TestServiceMonitorSampleLimit(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	sm := om.GenerateServiceMonitor(ServiceMonitorCfg{
+		Name:        "test-monitor",
+		Selector:    map[string]string{"app": "test"},
+		Endpoints:   []MonitorEndpoint{{Port: "metrics"}},
+		SampleLimit: 10000,
+	})
+
+	if sm.Spec.SampleLimit != 10000 {
+		t.Errorf("expected sampleLimit 10000, got %d", sm.Spec.SampleLimit)
+	}
+}
+
+func TestPrometheusRuleMultipleGroups(t *testing.T) {
+	om := NewObservabilityManager("monitoring")
+
+	pr := om.GeneratePrometheusRule(PrometheusRuleCfg{
+		Name: "multi-group-rules",
+		Groups: []RuleGroup{
+			{
+				Name:  "alerts",
+				Rules: []Rule{{Alert: "Alert1", Expr: "up == 0"}},
+			},
+			{
+				Name:  "recording",
+				Rules: []Rule{{Record: "metric:rate5m", Expr: "rate(metric[5m])"}},
+			},
+		},
+	})
+
+	if len(pr.Spec.Groups) != 2 {
+		t.Errorf("expected 2 groups, got %d", len(pr.Spec.Groups))
+	}
+}

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -1,0 +1,579 @@
+// internal/k8s/resources.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ResourceManager manages Kubernetes resource configurations
+type ResourceManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewResourceManager creates a new resource manager
+func NewResourceManager(namespace string) *ResourceManager {
+	return &ResourceManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// ResourceQuantities defines resource quantities (extended from base)
+type ResourceQuantities struct {
+	CPU              string `yaml:"cpu,omitempty"`
+	Memory           string `yaml:"memory,omitempty"`
+	EphemeralStorage string `yaml:"ephemeral-storage,omitempty"`
+	// Extended resources
+	NvidiaGPU    string `yaml:"nvidia.com/gpu,omitempty"`
+	AMDGPU       string `yaml:"amd.com/gpu,omitempty"`
+	HugePages2Mi string `yaml:"hugepages-2Mi,omitempty"`
+	HugePages1Gi string `yaml:"hugepages-1Gi,omitempty"`
+}
+
+// LimitRangeConfig configures a LimitRange
+type LimitRangeConfig struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Limits      []LimitRangeItem
+}
+
+// LimitRangeItem defines a limit range item
+type LimitRangeItem struct {
+	Type                 string             // Container, Pod, PersistentVolumeClaim
+	Default              ResourceQuantities // Default limits
+	DefaultRequest       ResourceQuantities // Default requests
+	Max                  ResourceQuantities // Maximum allowed
+	Min                  ResourceQuantities // Minimum required
+	MaxLimitRequestRatio ResourceQuantities // Max limit/request ratio
+}
+
+// LimitRangeResource represents a LimitRange
+type LimitRangeResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Spec       LimitRangeSpec   `yaml:"spec"`
+}
+
+// LimitRangeSpec defines LimitRange specification
+type LimitRangeSpec struct {
+	Limits []LimitRangeItemSpec `yaml:"limits"`
+}
+
+// LimitRangeItemSpec defines a limit range item in spec
+type LimitRangeItemSpec struct {
+	Type                 string            `yaml:"type"`
+	Default              map[string]string `yaml:"default,omitempty"`
+	DefaultRequest       map[string]string `yaml:"defaultRequest,omitempty"`
+	Max                  map[string]string `yaml:"max,omitempty"`
+	Min                  map[string]string `yaml:"min,omitempty"`
+	MaxLimitRequestRatio map[string]string `yaml:"maxLimitRequestRatio,omitempty"`
+}
+
+// GenerateLimitRange creates a LimitRange resource
+func (rm *ResourceManager) GenerateLimitRange(config LimitRangeConfig) *LimitRangeResource {
+	if config.Namespace == "" {
+		config.Namespace = rm.namespace
+	}
+
+	labels := copyStringMap(rm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	limits := make([]LimitRangeItemSpec, 0, len(config.Limits))
+	for _, l := range config.Limits {
+		item := LimitRangeItemSpec{
+			Type:                 l.Type,
+			Default:              resourceQuantitiesToMap(l.Default),
+			DefaultRequest:       resourceQuantitiesToMap(l.DefaultRequest),
+			Max:                  resourceQuantitiesToMap(l.Max),
+			Min:                  resourceQuantitiesToMap(l.Min),
+			MaxLimitRequestRatio: resourceQuantitiesToMap(l.MaxLimitRequestRatio),
+		}
+		limits = append(limits, item)
+	}
+
+	return &LimitRangeResource{
+		APIVersion: "v1",
+		Kind:       "LimitRange",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: LimitRangeSpec{
+			Limits: limits,
+		},
+	}
+}
+
+// ToYAML converts LimitRange to YAML
+func (lr *LimitRangeResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(lr); err != nil {
+		return "", fmt.Errorf("failed to encode LimitRange: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ResourceQuotaConfig configures a ResourceQuota
+type ResourceQuotaConfig struct {
+	Name          string
+	Namespace     string
+	Labels        map[string]string
+	Annotations   map[string]string
+	Hard          ResourceQuotaSpec
+	Scopes        []string
+	ScopeSelector *ScopeSelector
+}
+
+// ResourceQuotaSpec defines quota limits
+type ResourceQuotaSpec struct {
+	// Compute resources
+	CPU              string
+	Memory           string
+	EphemeralStorage string
+
+	// Storage resources
+	RequestsStorage        string
+	PersistentVolumeClaims string
+	StorageClassName       map[string]string // per storage class
+
+	// Object counts
+	Pods                   string
+	Services               string
+	Secrets                string
+	ConfigMaps             string
+	ReplicationControllers string
+	ResourceQuotas         string
+	ServicesLoadBalancers  string
+	ServicesNodePorts      string
+
+	// Requests and Limits
+	RequestsCPU    string
+	RequestsMemory string
+	LimitsCPU      string
+	LimitsMemory   string
+
+	// Extended resources
+	RequestsNvidiaGPU string
+	LimitsNvidiaGPU   string
+}
+
+// ScopeSelector for quota scope selection
+type ScopeSelector struct {
+	MatchExpressions []ScopeSelectorRequirement
+}
+
+// ScopeSelectorRequirement defines a scope requirement
+type ScopeSelectorRequirement struct {
+	ScopeName string
+	Operator  string // In, NotIn, Exists, DoesNotExist
+	Values    []string
+}
+
+// ResourceQuotaResource represents a ResourceQuota
+type ResourceQuotaResource struct {
+	APIVersion string             `yaml:"apiVersion"`
+	Kind       string             `yaml:"kind"`
+	Metadata   ManifestMetadata   `yaml:"metadata"`
+	Spec       ResourceQuotaRSpec `yaml:"spec"`
+}
+
+// ResourceQuotaRSpec defines ResourceQuota specification
+type ResourceQuotaRSpec struct {
+	Hard          map[string]string  `yaml:"hard"`
+	Scopes        []string           `yaml:"scopes,omitempty"`
+	ScopeSelector *ScopeSelectorSpec `yaml:"scopeSelector,omitempty"`
+}
+
+// ScopeSelectorSpec for ResourceQuota spec
+type ScopeSelectorSpec struct {
+	MatchExpressions []ScopeSelectorRequirementSpec `yaml:"matchExpressions"`
+}
+
+// ScopeSelectorRequirementSpec for ResourceQuota spec
+type ScopeSelectorRequirementSpec struct {
+	ScopeName string   `yaml:"scopeName"`
+	Operator  string   `yaml:"operator"`
+	Values    []string `yaml:"values,omitempty"`
+}
+
+// GenerateResourceQuota creates a ResourceQuota resource
+func (rm *ResourceManager) GenerateResourceQuota(config ResourceQuotaConfig) *ResourceQuotaResource {
+	if config.Namespace == "" {
+		config.Namespace = rm.namespace
+	}
+
+	labels := copyStringMap(rm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	hard := make(map[string]string)
+
+	// Compute resources
+	if config.Hard.CPU != "" {
+		hard["cpu"] = config.Hard.CPU
+	}
+	if config.Hard.Memory != "" {
+		hard["memory"] = config.Hard.Memory
+	}
+	if config.Hard.EphemeralStorage != "" {
+		hard["ephemeral-storage"] = config.Hard.EphemeralStorage
+	}
+
+	// Requests and limits
+	if config.Hard.RequestsCPU != "" {
+		hard["requests.cpu"] = config.Hard.RequestsCPU
+	}
+	if config.Hard.RequestsMemory != "" {
+		hard["requests.memory"] = config.Hard.RequestsMemory
+	}
+	if config.Hard.LimitsCPU != "" {
+		hard["limits.cpu"] = config.Hard.LimitsCPU
+	}
+	if config.Hard.LimitsMemory != "" {
+		hard["limits.memory"] = config.Hard.LimitsMemory
+	}
+
+	// Storage
+	if config.Hard.RequestsStorage != "" {
+		hard["requests.storage"] = config.Hard.RequestsStorage
+	}
+	if config.Hard.PersistentVolumeClaims != "" {
+		hard["persistentvolumeclaims"] = config.Hard.PersistentVolumeClaims
+	}
+	for sc, quota := range config.Hard.StorageClassName {
+		hard[fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", sc)] = quota
+	}
+
+	// Object counts
+	if config.Hard.Pods != "" {
+		hard["pods"] = config.Hard.Pods
+	}
+	if config.Hard.Services != "" {
+		hard["services"] = config.Hard.Services
+	}
+	if config.Hard.Secrets != "" {
+		hard["secrets"] = config.Hard.Secrets
+	}
+	if config.Hard.ConfigMaps != "" {
+		hard["configmaps"] = config.Hard.ConfigMaps
+	}
+	if config.Hard.ReplicationControllers != "" {
+		hard["replicationcontrollers"] = config.Hard.ReplicationControllers
+	}
+	if config.Hard.ResourceQuotas != "" {
+		hard["resourcequotas"] = config.Hard.ResourceQuotas
+	}
+	if config.Hard.ServicesLoadBalancers != "" {
+		hard["services.loadbalancers"] = config.Hard.ServicesLoadBalancers
+	}
+	if config.Hard.ServicesNodePorts != "" {
+		hard["services.nodeports"] = config.Hard.ServicesNodePorts
+	}
+
+	// Extended resources
+	if config.Hard.RequestsNvidiaGPU != "" {
+		hard["requests.nvidia.com/gpu"] = config.Hard.RequestsNvidiaGPU
+	}
+	if config.Hard.LimitsNvidiaGPU != "" {
+		hard["limits.nvidia.com/gpu"] = config.Hard.LimitsNvidiaGPU
+	}
+
+	rq := &ResourceQuotaResource{
+		APIVersion: "v1",
+		Kind:       "ResourceQuota",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Spec: ResourceQuotaRSpec{
+			Hard:   hard,
+			Scopes: config.Scopes,
+		},
+	}
+
+	if config.ScopeSelector != nil {
+		rq.Spec.ScopeSelector = &ScopeSelectorSpec{
+			MatchExpressions: make([]ScopeSelectorRequirementSpec, 0, len(config.ScopeSelector.MatchExpressions)),
+		}
+		for _, me := range config.ScopeSelector.MatchExpressions {
+			rq.Spec.ScopeSelector.MatchExpressions = append(rq.Spec.ScopeSelector.MatchExpressions, ScopeSelectorRequirementSpec(me))
+		}
+	}
+
+	return rq
+}
+
+// ToYAML converts ResourceQuota to YAML
+func (rq *ResourceQuotaResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(rq); err != nil {
+		return "", fmt.Errorf("failed to encode ResourceQuota: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// PriorityClassConfig configures a PriorityClass
+type PriorityClassConfig struct {
+	Name             string
+	Labels           map[string]string
+	Annotations      map[string]string
+	Value            int32
+	GlobalDefault    bool
+	PreemptionPolicy string // Never, PreemptLowerPriority
+	Description      string
+}
+
+// PriorityClassResource represents a PriorityClass
+type PriorityClassResource struct {
+	APIVersion       string           `yaml:"apiVersion"`
+	Kind             string           `yaml:"kind"`
+	Metadata         ManifestMetadata `yaml:"metadata"`
+	Value            int32            `yaml:"value"`
+	GlobalDefault    bool             `yaml:"globalDefault,omitempty"`
+	PreemptionPolicy string           `yaml:"preemptionPolicy,omitempty"`
+	Description      string           `yaml:"description,omitempty"`
+}
+
+// GeneratePriorityClass creates a PriorityClass resource
+func (rm *ResourceManager) GeneratePriorityClass(config PriorityClassConfig) *PriorityClassResource {
+	labels := copyStringMap(rm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	return &PriorityClassResource{
+		APIVersion: "scheduling.k8s.io/v1",
+		Kind:       "PriorityClass",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Value:            config.Value,
+		GlobalDefault:    config.GlobalDefault,
+		PreemptionPolicy: config.PreemptionPolicy,
+		Description:      config.Description,
+	}
+}
+
+// ToYAML converts PriorityClass to YAML
+func (pc *PriorityClassResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(pc); err != nil {
+		return "", fmt.Errorf("failed to encode PriorityClass: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ResourceProfile defines a standard resource profile
+type ResourceProfile struct {
+	Name        string
+	Description string
+	Requests    map[string]string
+	Limits      map[string]string
+}
+
+// StandardResourceProfiles returns common resource profiles
+func StandardResourceProfiles() map[string]ResourceProfile {
+	return map[string]ResourceProfile{
+		"tiny": {
+			Name:        "tiny",
+			Description: "Minimal resources for lightweight containers",
+			Requests:    map[string]string{"cpu": "10m", "memory": "32Mi"},
+			Limits:      map[string]string{"cpu": "100m", "memory": "128Mi"},
+		},
+		"small": {
+			Name:        "small",
+			Description: "Small workload resources",
+			Requests:    map[string]string{"cpu": "100m", "memory": "128Mi"},
+			Limits:      map[string]string{"cpu": "500m", "memory": "512Mi"},
+		},
+		"medium": {
+			Name:        "medium",
+			Description: "Medium workload resources",
+			Requests:    map[string]string{"cpu": "250m", "memory": "256Mi"},
+			Limits:      map[string]string{"cpu": "1", "memory": "1Gi"},
+		},
+		"large": {
+			Name:        "large",
+			Description: "Large workload resources",
+			Requests:    map[string]string{"cpu": "500m", "memory": "512Mi"},
+			Limits:      map[string]string{"cpu": "2", "memory": "2Gi"},
+		},
+		"xlarge": {
+			Name:        "xlarge",
+			Description: "Extra large workload resources",
+			Requests:    map[string]string{"cpu": "1", "memory": "1Gi"},
+			Limits:      map[string]string{"cpu": "4", "memory": "4Gi"},
+		},
+		"memory-optimized": {
+			Name:        "memory-optimized",
+			Description: "Memory-intensive workloads",
+			Requests:    map[string]string{"cpu": "250m", "memory": "2Gi"},
+			Limits:      map[string]string{"cpu": "1", "memory": "8Gi"},
+		},
+		"cpu-optimized": {
+			Name:        "cpu-optimized",
+			Description: "CPU-intensive workloads",
+			Requests:    map[string]string{"cpu": "2", "memory": "512Mi"},
+			Limits:      map[string]string{"cpu": "8", "memory": "2Gi"},
+		},
+		"gpu": {
+			Name:        "gpu",
+			Description: "GPU workloads",
+			Requests:    map[string]string{"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "1"},
+			Limits:      map[string]string{"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
+		},
+	}
+}
+
+// GetResourceProfile returns a resource profile by name
+func GetResourceProfile(name string) (ResourceProfile, bool) {
+	profiles := StandardResourceProfiles()
+	profile, ok := profiles[name]
+	return profile, ok
+}
+
+// resourceQuantitiesToMap converts ResourceQuantities to map
+func resourceQuantitiesToMap(rq ResourceQuantities) map[string]string {
+	m := make(map[string]string)
+	if rq.CPU != "" {
+		m["cpu"] = rq.CPU
+	}
+	if rq.Memory != "" {
+		m["memory"] = rq.Memory
+	}
+	if rq.EphemeralStorage != "" {
+		m["ephemeral-storage"] = rq.EphemeralStorage
+	}
+	if rq.NvidiaGPU != "" {
+		m["nvidia.com/gpu"] = rq.NvidiaGPU
+	}
+	if rq.AMDGPU != "" {
+		m["amd.com/gpu"] = rq.AMDGPU
+	}
+	if rq.HugePages2Mi != "" {
+		m["hugepages-2Mi"] = rq.HugePages2Mi
+	}
+	if rq.HugePages1Gi != "" {
+		m["hugepages-1Gi"] = rq.HugePages1Gi
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// GenerateVaultaireLimitRange creates a LimitRange for Vaultaire namespace
+func GenerateVaultaireLimitRange(namespace string) *LimitRangeResource {
+	rm := NewResourceManager(namespace)
+
+	return rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "vaultaire-limits",
+		Limits: []LimitRangeItem{
+			{
+				Type: "Container",
+				Default: ResourceQuantities{
+					CPU:    "500m",
+					Memory: "512Mi",
+				},
+				DefaultRequest: ResourceQuantities{
+					CPU:    "100m",
+					Memory: "128Mi",
+				},
+				Max: ResourceQuantities{
+					CPU:    "4",
+					Memory: "8Gi",
+				},
+				Min: ResourceQuantities{
+					CPU:    "10m",
+					Memory: "16Mi",
+				},
+			},
+			{
+				Type: "PersistentVolumeClaim",
+				Max: ResourceQuantities{
+					EphemeralStorage: "100Gi",
+				},
+				Min: ResourceQuantities{
+					EphemeralStorage: "1Gi",
+				},
+			},
+		},
+	})
+}
+
+// GenerateVaultaireResourceQuota creates a ResourceQuota for Vaultaire namespace
+func GenerateVaultaireResourceQuota(namespace string) *ResourceQuotaResource {
+	rm := NewResourceManager(namespace)
+
+	return rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "vaultaire-quota",
+		Hard: ResourceQuotaSpec{
+			RequestsCPU:            "20",
+			RequestsMemory:         "40Gi",
+			LimitsCPU:              "40",
+			LimitsMemory:           "80Gi",
+			Pods:                   "100",
+			Services:               "20",
+			Secrets:                "100",
+			ConfigMaps:             "100",
+			PersistentVolumeClaims: "20",
+			RequestsStorage:        "500Gi",
+		},
+	})
+}
+
+// GenerateVaultairePriorityClasses creates PriorityClasses for Vaultaire
+func GenerateVaultairePriorityClasses() []*PriorityClassResource {
+	rm := NewResourceManager("")
+
+	return []*PriorityClassResource{
+		rm.GeneratePriorityClass(PriorityClassConfig{
+			Name:             "vaultaire-critical",
+			Value:            1000000,
+			PreemptionPolicy: "PreemptLowerPriority",
+			Description:      "Critical Vaultaire components that must always run",
+		}),
+		rm.GeneratePriorityClass(PriorityClassConfig{
+			Name:             "vaultaire-high",
+			Value:            100000,
+			PreemptionPolicy: "PreemptLowerPriority",
+			Description:      "High priority Vaultaire workloads",
+		}),
+		rm.GeneratePriorityClass(PriorityClassConfig{
+			Name:             "vaultaire-normal",
+			Value:            10000,
+			PreemptionPolicy: "PreemptLowerPriority",
+			Description:      "Normal priority Vaultaire workloads",
+		}),
+		rm.GeneratePriorityClass(PriorityClassConfig{
+			Name:             "vaultaire-low",
+			Value:            1000,
+			PreemptionPolicy: "Never",
+			Description:      "Low priority Vaultaire workloads (batch jobs)",
+		}),
+	}
+}

--- a/internal/k8s/resources_test.go
+++ b/internal/k8s/resources_test.go
@@ -1,0 +1,429 @@
+// internal/k8s/resources_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewResourceManager(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	if rm.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", rm.namespace)
+	}
+}
+
+func TestGenerateLimitRange(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	lr := rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "test-limits",
+		Limits: []LimitRangeItem{
+			{
+				Type: "Container",
+				Default: ResourceQuantities{
+					CPU:    "500m",
+					Memory: "512Mi",
+				},
+				DefaultRequest: ResourceQuantities{
+					CPU:    "100m",
+					Memory: "128Mi",
+				},
+				Max: ResourceQuantities{
+					CPU:    "4",
+					Memory: "8Gi",
+				},
+				Min: ResourceQuantities{
+					CPU:    "10m",
+					Memory: "16Mi",
+				},
+			},
+		},
+	})
+
+	if lr.Kind != "LimitRange" {
+		t.Errorf("expected kind LimitRange, got %s", lr.Kind)
+	}
+	if lr.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1, got %s", lr.APIVersion)
+	}
+	if len(lr.Spec.Limits) != 1 {
+		t.Fatalf("expected 1 limit, got %d", len(lr.Spec.Limits))
+	}
+	if lr.Spec.Limits[0].Type != "Container" {
+		t.Error("expected type Container")
+	}
+	if lr.Spec.Limits[0].Default["cpu"] != "500m" {
+		t.Error("expected default cpu 500m")
+	}
+}
+
+func TestGenerateLimitRangeMultipleTypes(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	lr := rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "test-limits",
+		Limits: []LimitRangeItem{
+			{
+				Type:    "Container",
+				Default: ResourceQuantities{CPU: "500m", Memory: "512Mi"},
+			},
+			{
+				Type: "Pod",
+				Max:  ResourceQuantities{CPU: "8", Memory: "16Gi"},
+			},
+			{
+				Type: "PersistentVolumeClaim",
+				Max:  ResourceQuantities{EphemeralStorage: "100Gi"},
+			},
+		},
+	})
+
+	if len(lr.Spec.Limits) != 3 {
+		t.Errorf("expected 3 limits, got %d", len(lr.Spec.Limits))
+	}
+}
+
+func TestLimitRangeToYAML(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	lr := rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "test-limits",
+		Limits: []LimitRangeItem{
+			{
+				Type:    "Container",
+				Default: ResourceQuantities{CPU: "500m"},
+			},
+		},
+	})
+
+	yaml, err := lr.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: LimitRange") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGenerateResourceQuota(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "test-quota",
+		Hard: ResourceQuotaSpec{
+			RequestsCPU:    "10",
+			RequestsMemory: "20Gi",
+			LimitsCPU:      "20",
+			LimitsMemory:   "40Gi",
+			Pods:           "50",
+			Services:       "10",
+		},
+	})
+
+	if rq.Kind != "ResourceQuota" {
+		t.Errorf("expected kind ResourceQuota, got %s", rq.Kind)
+	}
+	if rq.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1, got %s", rq.APIVersion)
+	}
+	if rq.Spec.Hard["requests.cpu"] != "10" {
+		t.Error("expected requests.cpu 10")
+	}
+	if rq.Spec.Hard["pods"] != "50" {
+		t.Error("expected pods 50")
+	}
+}
+
+func TestGenerateResourceQuotaWithStorage(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "test-quota",
+		Hard: ResourceQuotaSpec{
+			RequestsStorage:        "100Gi",
+			PersistentVolumeClaims: "10",
+			StorageClassName: map[string]string{
+				"fast-ssd": "50Gi",
+				"standard": "100Gi",
+			},
+		},
+	})
+
+	if rq.Spec.Hard["requests.storage"] != "100Gi" {
+		t.Error("expected requests.storage 100Gi")
+	}
+	if rq.Spec.Hard["fast-ssd.storageclass.storage.k8s.io/requests.storage"] != "50Gi" {
+		t.Error("expected storage class quota")
+	}
+}
+
+func TestGenerateResourceQuotaWithScopes(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name:   "test-quota",
+		Scopes: []string{"BestEffort", "NotTerminating"},
+		Hard: ResourceQuotaSpec{
+			Pods: "10",
+		},
+	})
+
+	if len(rq.Spec.Scopes) != 2 {
+		t.Errorf("expected 2 scopes, got %d", len(rq.Spec.Scopes))
+	}
+}
+
+func TestGenerateResourceQuotaWithScopeSelector(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "test-quota",
+		ScopeSelector: &ScopeSelector{
+			MatchExpressions: []ScopeSelectorRequirement{
+				{
+					ScopeName: "PriorityClass",
+					Operator:  "In",
+					Values:    []string{"high", "medium"},
+				},
+			},
+		},
+		Hard: ResourceQuotaSpec{
+			Pods: "20",
+		},
+	})
+
+	if rq.Spec.ScopeSelector == nil {
+		t.Fatal("expected scope selector")
+	}
+	if len(rq.Spec.ScopeSelector.MatchExpressions) != 1 {
+		t.Error("expected 1 match expression")
+	}
+}
+
+func TestResourceQuotaToYAML(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "test-quota",
+		Hard: ResourceQuotaSpec{Pods: "50"},
+	})
+
+	yaml, err := rq.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: ResourceQuota") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGeneratePriorityClass(t *testing.T) {
+	rm := NewResourceManager("")
+
+	pc := rm.GeneratePriorityClass(PriorityClassConfig{
+		Name:             "high-priority",
+		Value:            100000,
+		GlobalDefault:    false,
+		PreemptionPolicy: "PreemptLowerPriority",
+		Description:      "High priority workloads",
+	})
+
+	if pc.Kind != "PriorityClass" {
+		t.Errorf("expected kind PriorityClass, got %s", pc.Kind)
+	}
+	if pc.APIVersion != "scheduling.k8s.io/v1" {
+		t.Errorf("expected apiVersion scheduling.k8s.io/v1, got %s", pc.APIVersion)
+	}
+	if pc.Value != 100000 {
+		t.Errorf("expected value 100000, got %d", pc.Value)
+	}
+	if pc.PreemptionPolicy != "PreemptLowerPriority" {
+		t.Error("expected preemptionPolicy PreemptLowerPriority")
+	}
+}
+
+func TestPriorityClassToYAML(t *testing.T) {
+	rm := NewResourceManager("")
+
+	pc := rm.GeneratePriorityClass(PriorityClassConfig{
+		Name:  "test-priority",
+		Value: 1000,
+	})
+
+	yaml, err := pc.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: PriorityClass") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestStandardResourceProfiles(t *testing.T) {
+	profiles := StandardResourceProfiles()
+
+	expectedProfiles := []string{"tiny", "small", "medium", "large", "xlarge", "memory-optimized", "cpu-optimized", "gpu"}
+
+	for _, name := range expectedProfiles {
+		if _, ok := profiles[name]; !ok {
+			t.Errorf("expected profile '%s' to exist", name)
+		}
+	}
+}
+
+func TestGetResourceProfile(t *testing.T) {
+	profile, ok := GetResourceProfile("medium")
+	if !ok {
+		t.Fatal("expected medium profile to exist")
+	}
+	if profile.Requests["cpu"] != "250m" {
+		t.Error("expected medium profile requests.cpu 250m")
+	}
+	if profile.Limits["memory"] != "1Gi" {
+		t.Error("expected medium profile limits.memory 1Gi")
+	}
+}
+
+func TestGetResourceProfileNotFound(t *testing.T) {
+	_, ok := GetResourceProfile("nonexistent")
+	if ok {
+		t.Error("expected profile to not exist")
+	}
+}
+
+func TestResourceQuantitiesToMap(t *testing.T) {
+	rq := ResourceQuantities{
+		CPU:       "500m",
+		Memory:    "512Mi",
+		NvidiaGPU: "1",
+	}
+
+	m := resourceQuantitiesToMap(rq)
+
+	if m["cpu"] != "500m" {
+		t.Error("expected cpu 500m")
+	}
+	if m["memory"] != "512Mi" {
+		t.Error("expected memory 512Mi")
+	}
+	if m["nvidia.com/gpu"] != "1" {
+		t.Error("expected nvidia.com/gpu 1")
+	}
+}
+
+func TestResourceQuantitiesToMapEmpty(t *testing.T) {
+	rq := ResourceQuantities{}
+	m := resourceQuantitiesToMap(rq)
+
+	if m != nil {
+		t.Error("expected nil map for empty quantities")
+	}
+}
+
+func TestGenerateVaultaireLimitRange(t *testing.T) {
+	lr := GenerateVaultaireLimitRange("vaultaire")
+
+	if lr.Metadata.Name != "vaultaire-limits" {
+		t.Errorf("expected name 'vaultaire-limits', got '%s'", lr.Metadata.Name)
+	}
+	if lr.Metadata.Namespace != "vaultaire" {
+		t.Errorf("expected namespace 'vaultaire', got '%s'", lr.Metadata.Namespace)
+	}
+	if len(lr.Spec.Limits) < 1 {
+		t.Error("expected at least 1 limit")
+	}
+}
+
+func TestGenerateVaultaireResourceQuota(t *testing.T) {
+	rq := GenerateVaultaireResourceQuota("vaultaire")
+
+	if rq.Metadata.Name != "vaultaire-quota" {
+		t.Errorf("expected name 'vaultaire-quota', got '%s'", rq.Metadata.Name)
+	}
+	if rq.Spec.Hard["pods"] != "100" {
+		t.Error("expected pods quota 100")
+	}
+	if rq.Spec.Hard["requests.cpu"] != "20" {
+		t.Error("expected requests.cpu quota 20")
+	}
+}
+
+func TestGenerateVaultairePriorityClasses(t *testing.T) {
+	pcs := GenerateVaultairePriorityClasses()
+
+	if len(pcs) != 4 {
+		t.Errorf("expected 4 priority classes, got %d", len(pcs))
+	}
+
+	names := make(map[string]bool)
+	for _, pc := range pcs {
+		names[pc.Metadata.Name] = true
+	}
+
+	expectedNames := []string{"vaultaire-critical", "vaultaire-high", "vaultaire-normal", "vaultaire-low"}
+	for _, name := range expectedNames {
+		if !names[name] {
+			t.Errorf("expected priority class '%s'", name)
+		}
+	}
+}
+
+func TestLimitRangeDefaultNamespace(t *testing.T) {
+	rm := NewResourceManager("production")
+
+	lr := rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "test-limits",
+		Limits: []LimitRangeItem{
+			{Type: "Container", Default: ResourceQuantities{CPU: "500m"}},
+		},
+	})
+
+	if lr.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", lr.Metadata.Namespace)
+	}
+}
+
+func TestResourceQuotaWithGPU(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	rq := rm.GenerateResourceQuota(ResourceQuotaConfig{
+		Name: "gpu-quota",
+		Hard: ResourceQuotaSpec{
+			RequestsNvidiaGPU: "4",
+			LimitsNvidiaGPU:   "8",
+		},
+	})
+
+	if rq.Spec.Hard["requests.nvidia.com/gpu"] != "4" {
+		t.Error("expected GPU requests quota")
+	}
+	if rq.Spec.Hard["limits.nvidia.com/gpu"] != "8" {
+		t.Error("expected GPU limits quota")
+	}
+}
+
+func TestLimitRangeWithMaxLimitRequestRatio(t *testing.T) {
+	rm := NewResourceManager("default")
+
+	lr := rm.GenerateLimitRange(LimitRangeConfig{
+		Name: "test-limits",
+		Limits: []LimitRangeItem{
+			{
+				Type: "Container",
+				MaxLimitRequestRatio: ResourceQuantities{
+					CPU:    "10",
+					Memory: "5",
+				},
+			},
+		},
+	})
+
+	if lr.Spec.Limits[0].MaxLimitRequestRatio["cpu"] != "10" {
+		t.Error("expected maxLimitRequestRatio cpu 10")
+	}
+}

--- a/internal/k8s/security.go
+++ b/internal/k8s/security.go
@@ -1,0 +1,570 @@
+// internal/k8s/security.go
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SecurityManager manages Kubernetes security resources
+type SecurityManager struct {
+	namespace string
+	labels    map[string]string
+}
+
+// NewSecurityManager creates a new security manager
+func NewSecurityManager(namespace string) *SecurityManager {
+	return &SecurityManager{
+		namespace: namespace,
+		labels: map[string]string{
+			"app.kubernetes.io/managed-by": "vaultaire",
+		},
+	}
+}
+
+// SecurityPodContext defines pod-level security settings (renamed to avoid conflict)
+type SecurityPodContext struct {
+	RunAsUser           *int64
+	RunAsGroup          *int64
+	RunAsNonRoot        *bool
+	FSGroup             *int64
+	FSGroupChangePolicy string // OnRootMismatch, Always
+	SupplementalGroups  []int64
+	Sysctls             []Sysctl
+	SeccompProfile      *SeccompProfile
+}
+
+// SecurityContainerContext defines container-level security settings
+type SecurityContainerContext struct {
+	RunAsUser                *int64
+	RunAsGroup               *int64
+	RunAsNonRoot             *bool
+	ReadOnlyRootFilesystem   *bool
+	AllowPrivilegeEscalation *bool
+	Privileged               *bool
+	Capabilities             *SecurityCapabilities
+	SeccompProfile           *SeccompProfile
+	SELinuxOptions           *SELinuxOptions
+	ProcMount                string // Default, Unmasked
+}
+
+// Sysctl defines a sysctl parameter
+type Sysctl struct {
+	Name  string
+	Value string
+}
+
+// SeccompProfile defines seccomp settings
+type SeccompProfile struct {
+	Type             string // Localhost, RuntimeDefault, Unconfined
+	LocalhostProfile string
+}
+
+// SecurityCapabilities defines Linux capabilities (renamed to avoid conflict)
+type SecurityCapabilities struct {
+	Add  []string
+	Drop []string
+}
+
+// SELinuxOptions defines SELinux settings
+type SELinuxOptions struct {
+	User  string
+	Role  string
+	Type  string
+	Level string
+}
+
+// RoleConfig configures a Role or ClusterRole
+type RoleConfig struct {
+	Name        string
+	Namespace   string // empty for ClusterRole
+	Labels      map[string]string
+	Annotations map[string]string
+	Rules       []PolicyRule
+}
+
+// PolicyRule defines a policy rule
+type PolicyRule struct {
+	APIGroups       []string
+	Resources       []string
+	ResourceNames   []string
+	Verbs           []string
+	NonResourceURLs []string
+}
+
+// RoleResource represents a Role
+type RoleResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	Rules      []PolicyRuleSpec `yaml:"rules"`
+}
+
+// PolicyRuleSpec for Role spec
+type PolicyRuleSpec struct {
+	APIGroups       []string `yaml:"apiGroups,omitempty"`
+	Resources       []string `yaml:"resources,omitempty"`
+	ResourceNames   []string `yaml:"resourceNames,omitempty"`
+	Verbs           []string `yaml:"verbs"`
+	NonResourceURLs []string `yaml:"nonResourceURLs,omitempty"`
+}
+
+// GenerateRole creates a Role resource
+func (sm *SecurityManager) GenerateRole(config RoleConfig) *RoleResource {
+	if config.Namespace == "" {
+		config.Namespace = sm.namespace
+	}
+
+	labels := copyStringMap(sm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	rules := make([]PolicyRuleSpec, 0, len(config.Rules))
+	for _, r := range config.Rules {
+		rules = append(rules, PolicyRuleSpec(r))
+	}
+
+	return &RoleResource{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "Role",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Rules: rules,
+	}
+}
+
+// GenerateClusterRole creates a ClusterRole resource
+func (sm *SecurityManager) GenerateClusterRole(config RoleConfig) *RoleResource {
+	labels := copyStringMap(sm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	rules := make([]PolicyRuleSpec, 0, len(config.Rules))
+	for _, r := range config.Rules {
+		rules = append(rules, PolicyRuleSpec(r))
+	}
+
+	return &RoleResource{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRole",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		Rules: rules,
+	}
+}
+
+// ToYAML converts Role to YAML
+func (r *RoleResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(r); err != nil {
+		return "", fmt.Errorf("failed to encode Role: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// RoleBindingConfig configures a RoleBinding or ClusterRoleBinding
+type RoleBindingConfig struct {
+	Name        string
+	Namespace   string // empty for ClusterRoleBinding
+	Labels      map[string]string
+	Annotations map[string]string
+	RoleRef     RoleRef
+	Subjects    []Subject
+}
+
+// RoleRef references a Role or ClusterRole
+type RoleRef struct {
+	APIGroup string
+	Kind     string // Role or ClusterRole
+	Name     string
+}
+
+// Subject defines who the binding applies to
+type Subject struct {
+	Kind      string // User, Group, ServiceAccount
+	Name      string
+	Namespace string // only for ServiceAccount
+	APIGroup  string // only for User/Group
+}
+
+// RoleBindingResource represents a RoleBinding
+type RoleBindingResource struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   ManifestMetadata `yaml:"metadata"`
+	RoleRef    RoleRefSpec      `yaml:"roleRef"`
+	Subjects   []SubjectSpec    `yaml:"subjects"`
+}
+
+// RoleRefSpec for RoleBinding spec
+type RoleRefSpec struct {
+	APIGroup string `yaml:"apiGroup"`
+	Kind     string `yaml:"kind"`
+	Name     string `yaml:"name"`
+}
+
+// SubjectSpec for RoleBinding spec
+type SubjectSpec struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace,omitempty"`
+	APIGroup  string `yaml:"apiGroup,omitempty"`
+}
+
+// GenerateRoleBinding creates a RoleBinding resource
+func (sm *SecurityManager) GenerateRoleBinding(config RoleBindingConfig) *RoleBindingResource {
+	if config.Namespace == "" {
+		config.Namespace = sm.namespace
+	}
+
+	labels := copyStringMap(sm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	subjects := make([]SubjectSpec, 0, len(config.Subjects))
+	for _, s := range config.Subjects {
+		subjects = append(subjects, SubjectSpec(s))
+	}
+
+	return &RoleBindingResource{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "RoleBinding",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		RoleRef: RoleRefSpec{
+			APIGroup: config.RoleRef.APIGroup,
+			Kind:     config.RoleRef.Kind,
+			Name:     config.RoleRef.Name,
+		},
+		Subjects: subjects,
+	}
+}
+
+// GenerateClusterRoleBinding creates a ClusterRoleBinding resource
+func (sm *SecurityManager) GenerateClusterRoleBinding(config RoleBindingConfig) *RoleBindingResource {
+	labels := copyStringMap(sm.labels)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+
+	subjects := make([]SubjectSpec, 0, len(config.Subjects))
+	for _, s := range config.Subjects {
+		subjects = append(subjects, SubjectSpec(s))
+	}
+
+	return &RoleBindingResource{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRoleBinding",
+		Metadata: ManifestMetadata{
+			Name:        config.Name,
+			Labels:      labels,
+			Annotations: config.Annotations,
+		},
+		RoleRef: RoleRefSpec{
+			APIGroup: config.RoleRef.APIGroup,
+			Kind:     config.RoleRef.Kind,
+			Name:     config.RoleRef.Name,
+		},
+		Subjects: subjects,
+	}
+}
+
+// ToYAML converts RoleBinding to YAML
+func (rb *RoleBindingResource) ToYAML() (string, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(rb); err != nil {
+		return "", fmt.Errorf("failed to encode RoleBinding: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// PodSecurityStandard defines Pod Security Standards levels
+type PodSecurityStandard string
+
+const (
+	PSSPrivileged PodSecurityStandard = "privileged"
+	PSSBaseline   PodSecurityStandard = "baseline"
+	PSSRestricted PodSecurityStandard = "restricted"
+)
+
+// PodSecurityMode defines Pod Security Standards enforcement mode
+type PodSecurityMode string
+
+const (
+	PSSModeEnforce PodSecurityMode = "enforce"
+	PSSModeAudit   PodSecurityMode = "audit"
+	PSSModeWarn    PodSecurityMode = "warn"
+)
+
+// GetPodSecurityLabels returns namespace labels for Pod Security Standards
+func GetPodSecurityLabels(level PodSecurityStandard, mode PodSecurityMode, version string) map[string]string {
+	if version == "" {
+		version = "latest"
+	}
+	return map[string]string{
+		fmt.Sprintf("pod-security.kubernetes.io/%s", mode):         string(level),
+		fmt.Sprintf("pod-security.kubernetes.io/%s-version", mode): version,
+	}
+}
+
+// RestrictedSecurityContext returns a restricted container security context
+func RestrictedSecurityContext() *SecurityContainerContext {
+	nonRoot := true
+	readOnly := true
+	noPrivEsc := false
+	privileged := false
+
+	return &SecurityContainerContext{
+		RunAsNonRoot:             &nonRoot,
+		ReadOnlyRootFilesystem:   &readOnly,
+		AllowPrivilegeEscalation: &noPrivEsc,
+		Privileged:               &privileged,
+		Capabilities: &SecurityCapabilities{
+			Drop: []string{"ALL"},
+		},
+		SeccompProfile: &SeccompProfile{
+			Type: "RuntimeDefault",
+		},
+	}
+}
+
+// BaselineSecurityContext returns a baseline container security context
+func BaselineSecurityContext() *SecurityContainerContext {
+	noPrivEsc := false
+	privileged := false
+
+	return &SecurityContainerContext{
+		AllowPrivilegeEscalation: &noPrivEsc,
+		Privileged:               &privileged,
+		Capabilities: &SecurityCapabilities{
+			Drop: []string{"ALL"},
+			Add:  []string{"NET_BIND_SERVICE"},
+		},
+	}
+}
+
+// ContainerSecurityContextSpec for manifest
+type ContainerSecurityContextSpec struct {
+	RunAsUser                *int64                    `yaml:"runAsUser,omitempty"`
+	RunAsGroup               *int64                    `yaml:"runAsGroup,omitempty"`
+	RunAsNonRoot             *bool                     `yaml:"runAsNonRoot,omitempty"`
+	ReadOnlyRootFilesystem   *bool                     `yaml:"readOnlyRootFilesystem,omitempty"`
+	AllowPrivilegeEscalation *bool                     `yaml:"allowPrivilegeEscalation,omitempty"`
+	Privileged               *bool                     `yaml:"privileged,omitempty"`
+	Capabilities             *SecurityCapabilitiesSpec `yaml:"capabilities,omitempty"`
+	SeccompProfile           *SeccompProfileSpec       `yaml:"seccompProfile,omitempty"`
+	SELinuxOptions           *SELinuxOptionsSpec       `yaml:"seLinuxOptions,omitempty"`
+	ProcMount                string                    `yaml:"procMount,omitempty"`
+}
+
+// SecurityPodContextSpec for manifest
+type SecurityPodContextSpec struct {
+	RunAsUser           *int64              `yaml:"runAsUser,omitempty"`
+	RunAsGroup          *int64              `yaml:"runAsGroup,omitempty"`
+	RunAsNonRoot        *bool               `yaml:"runAsNonRoot,omitempty"`
+	FSGroup             *int64              `yaml:"fsGroup,omitempty"`
+	FSGroupChangePolicy string              `yaml:"fsGroupChangePolicy,omitempty"`
+	SupplementalGroups  []int64             `yaml:"supplementalGroups,omitempty"`
+	Sysctls             []SysctlSpec        `yaml:"sysctls,omitempty"`
+	SeccompProfile      *SeccompProfileSpec `yaml:"seccompProfile,omitempty"`
+}
+
+// SecurityCapabilitiesSpec for manifest
+type SecurityCapabilitiesSpec struct {
+	Add  []string `yaml:"add,omitempty"`
+	Drop []string `yaml:"drop,omitempty"`
+}
+
+// SeccompProfileSpec for manifest
+type SeccompProfileSpec struct {
+	Type             string `yaml:"type"`
+	LocalhostProfile string `yaml:"localhostProfile,omitempty"`
+}
+
+// SELinuxOptionsSpec for manifest
+type SELinuxOptionsSpec struct {
+	User  string `yaml:"user,omitempty"`
+	Role  string `yaml:"role,omitempty"`
+	Type  string `yaml:"type,omitempty"`
+	Level string `yaml:"level,omitempty"`
+}
+
+// SysctlSpec for manifest
+type SysctlSpec struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+// ToSpec converts SecurityContainerContext to spec format
+func (csc *SecurityContainerContext) ToSpec() *ContainerSecurityContextSpec {
+	if csc == nil {
+		return nil
+	}
+
+	spec := &ContainerSecurityContextSpec{
+		RunAsUser:                csc.RunAsUser,
+		RunAsGroup:               csc.RunAsGroup,
+		RunAsNonRoot:             csc.RunAsNonRoot,
+		ReadOnlyRootFilesystem:   csc.ReadOnlyRootFilesystem,
+		AllowPrivilegeEscalation: csc.AllowPrivilegeEscalation,
+		Privileged:               csc.Privileged,
+		ProcMount:                csc.ProcMount,
+	}
+
+	if csc.Capabilities != nil {
+		spec.Capabilities = &SecurityCapabilitiesSpec{
+			Add:  csc.Capabilities.Add,
+			Drop: csc.Capabilities.Drop,
+		}
+	}
+
+	if csc.SeccompProfile != nil {
+		spec.SeccompProfile = &SeccompProfileSpec{
+			Type:             csc.SeccompProfile.Type,
+			LocalhostProfile: csc.SeccompProfile.LocalhostProfile,
+		}
+	}
+
+	if csc.SELinuxOptions != nil {
+		spec.SELinuxOptions = &SELinuxOptionsSpec{
+			User:  csc.SELinuxOptions.User,
+			Role:  csc.SELinuxOptions.Role,
+			Type:  csc.SELinuxOptions.Type,
+			Level: csc.SELinuxOptions.Level,
+		}
+	}
+
+	return spec
+}
+
+// ToSpec converts SecurityPodContext to spec format
+func (psc *SecurityPodContext) ToSpec() *SecurityPodContextSpec {
+	if psc == nil {
+		return nil
+	}
+
+	spec := &SecurityPodContextSpec{
+		RunAsUser:           psc.RunAsUser,
+		RunAsGroup:          psc.RunAsGroup,
+		RunAsNonRoot:        psc.RunAsNonRoot,
+		FSGroup:             psc.FSGroup,
+		FSGroupChangePolicy: psc.FSGroupChangePolicy,
+		SupplementalGroups:  psc.SupplementalGroups,
+	}
+
+	for _, s := range psc.Sysctls {
+		spec.Sysctls = append(spec.Sysctls, SysctlSpec(s))
+	}
+
+	if psc.SeccompProfile != nil {
+		spec.SeccompProfile = &SeccompProfileSpec{
+			Type:             psc.SeccompProfile.Type,
+			LocalhostProfile: psc.SeccompProfile.LocalhostProfile,
+		}
+	}
+
+	return spec
+}
+
+// GenerateVaultaireRBAC creates RBAC resources for Vaultaire
+func GenerateVaultaireRBAC(namespace string) ([]*RoleResource, []*RoleBindingResource) {
+	sm := NewSecurityManager(namespace)
+
+	roles := []*RoleResource{
+		// API server role
+		sm.GenerateRole(RoleConfig{
+			Name: "vaultaire-api",
+			Rules: []PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"configmaps", "secrets"}, Verbs: []string{"get", "list", "watch"}},
+				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+				{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
+			},
+		}),
+		// Worker role
+		sm.GenerateRole(RoleConfig{
+			Name: "vaultaire-worker",
+			Rules: []PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "list", "watch"}},
+				{APIGroups: []string{""}, Resources: []string{"persistentvolumeclaims"}, Verbs: []string{"get", "list", "watch", "create", "update", "delete"}},
+				{APIGroups: []string{"batch"}, Resources: []string{"jobs"}, Verbs: []string{"get", "list", "watch", "create", "delete"}},
+			},
+		}),
+	}
+
+	bindings := []*RoleBindingResource{
+		sm.GenerateRoleBinding(RoleBindingConfig{
+			Name: "vaultaire-api",
+			RoleRef: RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "vaultaire-api",
+			},
+			Subjects: []Subject{
+				{Kind: "ServiceAccount", Name: "vaultaire-api", Namespace: namespace},
+			},
+		}),
+		sm.GenerateRoleBinding(RoleBindingConfig{
+			Name: "vaultaire-worker",
+			RoleRef: RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "vaultaire-worker",
+			},
+			Subjects: []Subject{
+				{Kind: "ServiceAccount", Name: "vaultaire-worker", Namespace: namespace},
+			},
+		}),
+	}
+
+	return roles, bindings
+}
+
+// SecuritySet represents a collection of security resources
+type SecuritySet struct {
+	Roles        []*RoleResource
+	RoleBindings []*RoleBindingResource
+}
+
+// ToYAML converts all security resources to multi-document YAML
+func (s *SecuritySet) ToYAML() (string, error) {
+	var parts []string
+
+	for _, r := range s.Roles {
+		yaml, err := r.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	for _, rb := range s.RoleBindings {
+		yaml, err := rb.ToYAML()
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, yaml)
+	}
+
+	return strings.Join(parts, "---\n"), nil
+}

--- a/internal/k8s/security_test.go
+++ b/internal/k8s/security_test.go
@@ -1,0 +1,460 @@
+// internal/k8s/security_test.go
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSecurityManager(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	if sm.namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", sm.namespace)
+	}
+}
+
+func TestGenerateRole(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	role := sm.GenerateRole(RoleConfig{
+		Name: "test-role",
+		Rules: []PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	})
+
+	if role.Kind != "Role" {
+		t.Errorf("expected kind Role, got %s", role.Kind)
+	}
+	if role.APIVersion != "rbac.authorization.k8s.io/v1" {
+		t.Errorf("expected apiVersion rbac.authorization.k8s.io/v1, got %s", role.APIVersion)
+	}
+	if len(role.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(role.Rules))
+	}
+	if len(role.Rules[0].Verbs) != 3 {
+		t.Error("expected 3 verbs")
+	}
+}
+
+func TestGenerateClusterRole(t *testing.T) {
+	sm := NewSecurityManager("")
+
+	role := sm.GenerateClusterRole(RoleConfig{
+		Name: "test-cluster-role",
+		Rules: []PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	})
+
+	if role.Kind != "ClusterRole" {
+		t.Errorf("expected kind ClusterRole, got %s", role.Kind)
+	}
+	if role.Metadata.Namespace != "" {
+		t.Error("ClusterRole should not have namespace")
+	}
+}
+
+func TestGenerateRoleWithResourceNames(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	role := sm.GenerateRole(RoleConfig{
+		Name: "specific-secrets",
+		Rules: []PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				ResourceNames: []string{"db-password", "api-key"},
+				Verbs:         []string{"get"},
+			},
+		},
+	})
+
+	if len(role.Rules[0].ResourceNames) != 2 {
+		t.Error("expected 2 resource names")
+	}
+}
+
+func TestGenerateRoleWithNonResourceURLs(t *testing.T) {
+	sm := NewSecurityManager("")
+
+	role := sm.GenerateClusterRole(RoleConfig{
+		Name: "health-checker",
+		Rules: []PolicyRule{
+			{
+				NonResourceURLs: []string{"/healthz", "/readyz"},
+				Verbs:           []string{"get"},
+			},
+		},
+	})
+
+	if len(role.Rules[0].NonResourceURLs) != 2 {
+		t.Error("expected 2 non-resource URLs")
+	}
+}
+
+func TestRoleToYAML(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	role := sm.GenerateRole(RoleConfig{
+		Name:  "test-role",
+		Rules: []PolicyRule{{Verbs: []string{"get"}}},
+	})
+
+	yaml, err := role.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: Role") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGenerateRoleBinding(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	rb := sm.GenerateRoleBinding(RoleBindingConfig{
+		Name: "test-binding",
+		RoleRef: RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+		Subjects: []Subject{
+			{Kind: "ServiceAccount", Name: "test-sa", Namespace: "default"},
+		},
+	})
+
+	if rb.Kind != "RoleBinding" {
+		t.Errorf("expected kind RoleBinding, got %s", rb.Kind)
+	}
+	if rb.RoleRef.Name != "test-role" {
+		t.Error("expected role ref name")
+	}
+	if len(rb.Subjects) != 1 {
+		t.Error("expected 1 subject")
+	}
+}
+
+func TestGenerateClusterRoleBinding(t *testing.T) {
+	sm := NewSecurityManager("")
+
+	rb := sm.GenerateClusterRoleBinding(RoleBindingConfig{
+		Name: "test-cluster-binding",
+		RoleRef: RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "test-cluster-role",
+		},
+		Subjects: []Subject{
+			{Kind: "Group", Name: "developers", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	})
+
+	if rb.Kind != "ClusterRoleBinding" {
+		t.Errorf("expected kind ClusterRoleBinding, got %s", rb.Kind)
+	}
+}
+
+func TestGenerateRoleBindingMultipleSubjects(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	rb := sm.GenerateRoleBinding(RoleBindingConfig{
+		Name: "multi-subject",
+		RoleRef: RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+		Subjects: []Subject{
+			{Kind: "ServiceAccount", Name: "sa-1", Namespace: "default"},
+			{Kind: "ServiceAccount", Name: "sa-2", Namespace: "default"},
+			{Kind: "User", Name: "admin", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	})
+
+	if len(rb.Subjects) != 3 {
+		t.Errorf("expected 3 subjects, got %d", len(rb.Subjects))
+	}
+}
+
+func TestRoleBindingToYAML(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	rb := sm.GenerateRoleBinding(RoleBindingConfig{
+		Name: "test-binding",
+		RoleRef: RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+		Subjects: []Subject{
+			{Kind: "ServiceAccount", Name: "test-sa"},
+		},
+	})
+
+	yaml, err := rb.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	if !strings.Contains(yaml, "kind: RoleBinding") {
+		t.Error("expected YAML to contain kind")
+	}
+}
+
+func TestGetPodSecurityLabels(t *testing.T) {
+	labels := GetPodSecurityLabels(PSSRestricted, PSSModeEnforce, "v1.28")
+
+	if labels["pod-security.kubernetes.io/enforce"] != "restricted" {
+		t.Error("expected enforce label")
+	}
+	if labels["pod-security.kubernetes.io/enforce-version"] != "v1.28" {
+		t.Error("expected enforce-version label")
+	}
+}
+
+func TestGetPodSecurityLabelsDefaultVersion(t *testing.T) {
+	labels := GetPodSecurityLabels(PSSBaseline, PSSModeWarn, "")
+
+	if labels["pod-security.kubernetes.io/warn-version"] != "latest" {
+		t.Error("expected default version 'latest'")
+	}
+}
+
+func TestRestrictedSecurityContext(t *testing.T) {
+	ctx := RestrictedSecurityContext()
+
+	if ctx.RunAsNonRoot == nil || !*ctx.RunAsNonRoot {
+		t.Error("expected runAsNonRoot true")
+	}
+	if ctx.ReadOnlyRootFilesystem == nil || !*ctx.ReadOnlyRootFilesystem {
+		t.Error("expected readOnlyRootFilesystem true")
+	}
+	if ctx.AllowPrivilegeEscalation == nil || *ctx.AllowPrivilegeEscalation {
+		t.Error("expected allowPrivilegeEscalation false")
+	}
+	if ctx.Privileged == nil || *ctx.Privileged {
+		t.Error("expected privileged false")
+	}
+	if ctx.Capabilities == nil || len(ctx.Capabilities.Drop) != 1 || ctx.Capabilities.Drop[0] != "ALL" {
+		t.Error("expected capabilities drop ALL")
+	}
+	if ctx.SeccompProfile == nil || ctx.SeccompProfile.Type != "RuntimeDefault" {
+		t.Error("expected seccomp RuntimeDefault")
+	}
+}
+
+func TestBaselineSecurityContext(t *testing.T) {
+	ctx := BaselineSecurityContext()
+
+	if ctx.AllowPrivilegeEscalation == nil || *ctx.AllowPrivilegeEscalation {
+		t.Error("expected allowPrivilegeEscalation false")
+	}
+	if ctx.Capabilities == nil {
+		t.Fatal("expected capabilities")
+	}
+	if len(ctx.Capabilities.Add) != 1 || ctx.Capabilities.Add[0] != "NET_BIND_SERVICE" {
+		t.Error("expected NET_BIND_SERVICE capability")
+	}
+}
+
+func TestContainerSecurityContextToSpec(t *testing.T) {
+	ctx := RestrictedSecurityContext()
+	spec := ctx.ToSpec()
+
+	if spec == nil {
+		t.Fatal("expected spec")
+	}
+	if spec.RunAsNonRoot == nil || !*spec.RunAsNonRoot {
+		t.Error("expected runAsNonRoot in spec")
+	}
+	if spec.Capabilities == nil {
+		t.Error("expected capabilities in spec")
+	}
+	if spec.SeccompProfile == nil {
+		t.Error("expected seccompProfile in spec")
+	}
+}
+
+func TestContainerSecurityContextToSpecNil(t *testing.T) {
+	var ctx *SecurityContainerContext
+	spec := ctx.ToSpec()
+
+	if spec != nil {
+		t.Error("expected nil spec for nil context")
+	}
+}
+
+func TestPodSecurityContextToSpec(t *testing.T) {
+	runAsUser := int64(1000)
+	fsGroup := int64(2000)
+	nonRoot := true
+
+	ctx := &SecurityPodContext{
+		RunAsUser:    &runAsUser,
+		FSGroup:      &fsGroup,
+		RunAsNonRoot: &nonRoot,
+		Sysctls: []Sysctl{
+			{Name: "net.core.somaxconn", Value: "1024"},
+		},
+		SeccompProfile: &SeccompProfile{
+			Type: "RuntimeDefault",
+		},
+	}
+
+	spec := ctx.ToSpec()
+
+	if spec == nil {
+		t.Fatal("expected spec")
+	}
+	if *spec.RunAsUser != 1000 {
+		t.Error("expected runAsUser 1000")
+	}
+	if *spec.FSGroup != 2000 {
+		t.Error("expected fsGroup 2000")
+	}
+	if len(spec.Sysctls) != 1 {
+		t.Error("expected 1 sysctl")
+	}
+}
+
+func TestPodSecurityContextToSpecNil(t *testing.T) {
+	var ctx *SecurityPodContext
+	spec := ctx.ToSpec()
+
+	if spec != nil {
+		t.Error("expected nil spec for nil context")
+	}
+}
+
+func TestContainerSecurityContextWithSELinux(t *testing.T) {
+	ctx := &SecurityContainerContext{
+		SELinuxOptions: &SELinuxOptions{
+			User:  "system_u",
+			Role:  "system_r",
+			Type:  "container_t",
+			Level: "s0:c123,c456",
+		},
+	}
+
+	spec := ctx.ToSpec()
+
+	if spec.SELinuxOptions == nil {
+		t.Fatal("expected SELinux options")
+	}
+	if spec.SELinuxOptions.Type != "container_t" {
+		t.Error("expected SELinux type")
+	}
+}
+
+func TestGenerateVaultaireRBAC(t *testing.T) {
+	roles, bindings := GenerateVaultaireRBAC("vaultaire")
+
+	if len(roles) < 2 {
+		t.Errorf("expected at least 2 roles, got %d", len(roles))
+	}
+	if len(bindings) < 2 {
+		t.Errorf("expected at least 2 bindings, got %d", len(bindings))
+	}
+
+	roleNames := make(map[string]bool)
+	for _, r := range roles {
+		roleNames[r.Metadata.Name] = true
+	}
+
+	if !roleNames["vaultaire-api"] {
+		t.Error("expected vaultaire-api role")
+	}
+	if !roleNames["vaultaire-worker"] {
+		t.Error("expected vaultaire-worker role")
+	}
+}
+
+func TestSecuritySet(t *testing.T) {
+	sm := NewSecurityManager("default")
+
+	set := &SecuritySet{
+		Roles: []*RoleResource{
+			sm.GenerateRole(RoleConfig{Name: "role-1", Rules: []PolicyRule{{Verbs: []string{"get"}}}}),
+		},
+		RoleBindings: []*RoleBindingResource{
+			sm.GenerateRoleBinding(RoleBindingConfig{
+				Name:     "binding-1",
+				RoleRef:  RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "role-1"},
+				Subjects: []Subject{{Kind: "ServiceAccount", Name: "sa-1"}},
+			}),
+		},
+	}
+
+	yaml, err := set.ToYAML()
+	if err != nil {
+		t.Fatalf("failed to convert to YAML: %v", err)
+	}
+
+	docs := strings.Split(yaml, "---")
+	if len(docs) != 2 {
+		t.Errorf("expected 2 YAML documents, got %d", len(docs))
+	}
+}
+
+func TestRoleNamespaceDefault(t *testing.T) {
+	sm := NewSecurityManager("production")
+
+	role := sm.GenerateRole(RoleConfig{
+		Name:  "test-role",
+		Rules: []PolicyRule{{Verbs: []string{"get"}}},
+	})
+
+	if role.Metadata.Namespace != "production" {
+		t.Errorf("expected namespace 'production', got '%s'", role.Metadata.Namespace)
+	}
+}
+
+func TestRoleNamespaceOverride(t *testing.T) {
+	sm := NewSecurityManager("production")
+
+	role := sm.GenerateRole(RoleConfig{
+		Name:      "test-role",
+		Namespace: "staging",
+		Rules:     []PolicyRule{{Verbs: []string{"get"}}},
+	})
+
+	if role.Metadata.Namespace != "staging" {
+		t.Errorf("expected namespace 'staging', got '%s'", role.Metadata.Namespace)
+	}
+}
+
+func TestPodSecurityStandardConstants(t *testing.T) {
+	if PSSPrivileged != "privileged" {
+		t.Error("expected privileged constant")
+	}
+	if PSSBaseline != "baseline" {
+		t.Error("expected baseline constant")
+	}
+	if PSSRestricted != "restricted" {
+		t.Error("expected restricted constant")
+	}
+}
+
+func TestPodSecurityModeConstants(t *testing.T) {
+	if PSSModeEnforce != "enforce" {
+		t.Error("expected enforce constant")
+	}
+	if PSSModeAudit != "audit" {
+		t.Error("expected audit constant")
+	}
+	if PSSModeWarn != "warn" {
+		t.Error("expected warn constant")
+	}
+}


### PR DESCRIPTION
## Steps 411-420: Kubernetes Deployment Phase

### Step 411 - Kubernetes Manifests
- Deployment, Service, ConfigMap, Secret, ServiceAccount generators
- Multi-document YAML output with proper formatting

### Step 412 - Helm Charts
- Chart.yaml and values.yaml generation
- Template helpers (_helpers.tpl)

### Step 413 - ConfigMaps & Secrets
- ConfigSecretManager for lifecycle management
- Encryption and sealed secrets support

### Step 414 - Service Mesh (Istio)
- VirtualService, DestinationRule, Gateway, AuthorizationPolicy

### Step 415 - Ingress Configuration
- Multi-controller support (Nginx, Traefik, AWS ALB, GCP)

### Step 416 - Auto-scaling Policies
- HPA, VPA, PodDisruptionBudget

### Step 417 - Resource Limits
- LimitRange, ResourceQuota, PriorityClass

### Step 418 - Network Policies
- Ingress/egress rules, pod/namespace selectors, IP blocks

### Step 419 - Security Policies
- RBAC (Role, ClusterRole, bindings)
- Pod Security Standards helpers

### Step 420 - Observability Stack
- ServiceMonitor, PodMonitor, PrometheusRule
- Grafana dashboard ConfigMaps
- Vaultaire alerts and SLOs

**All tests passing.**