### PR TITLE
fix(deploy): reorder checkout before artifact download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,11 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for migrations)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: internal/database/migrations
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -40,11 +45,6 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Checkout (for migrations)
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: internal/database/migrations
 
       - name: Deploy to Dev
         env:
@@ -74,6 +74,11 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for migrations)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: internal/database/migrations
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -83,11 +88,6 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Checkout (for migrations)
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: internal/database/migrations
 
       - name: Deploy to Production (SLC)
         env:


### PR DESCRIPTION
## Summary
- Checkout step was overwriting the downloaded binary artifact
- Reordered: checkout first (gets migrations), then download artifact (places binary on top)

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds on merge to main
- [ ] `curl https://stored.ge/health` returns healthy after deploy