### PR TITLE
feat(dashboard): login + registration POST handlers [Phase 1.1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,18 +78,22 @@ Migrations are in `internal/database/migrations/`.
 ## Git Workflow
 
 ```bash
-git checkout -b step-XXX-feature-name   # Branch from main
+git checkout -b phase-X.Y-feature-name  # Branch from main
 # ... TDD cycle ...
-git commit -m "feat(scope): description [Step XXX]"
+git commit -m "feat(scope): description [Phase X]"
+git push origin phase-X.Y-feature-name
 gh pr create --base main
-gh pr merge --squash --delete-branch --admin
+# Wait for CI (build-and-test) to pass, then:
+gh pr merge --squash --delete-branch
 ```
 
-Commit format: `type(scope): description [Step NNN]` where type is feat/fix/refactor/test/docs.
+Commit format: `type(scope): description [Phase NNN]` where type is feat/fix/refactor/test/docs.
 
 Never include `Co-Authored-By` lines mentioning Claude or AI in commit messages.
 
 Branch protection: direct pushes to main are blocked; CI must pass before merge.
+
+**Never use `--admin` to bypass CI.** Wait for `build-and-test` to pass. If CI fails, fix the issue on the branch and push again.
 
 ## CI/CD
 

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -24,14 +24,25 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 
 ## Routes
 
-| Path | Auth | Purpose |
-|------|------|---------|
-| `/static/*` | none | CSS, JS assets |
-| `/login` | none | Login page |
-| `/register` | none | Registration page |
-| `/logout` | none | Clears session, redirects |
-| `/dashboard/*` | session | Customer dashboard |
-| `/admin/*` | session + admin role | Admin panel |
+| Path | Method | Auth | Purpose |
+|------|--------|------|---------|
+| `/static/*` | GET | none | CSS, JS assets |
+| `/login` | GET | none | Login page |
+| `/login` | POST | none | Validate credentials, create session, redirect to /dashboard |
+| `/register` | GET | none | Registration page |
+| `/register` | POST | none | Create user+tenant, create session, redirect to /dashboard |
+| `/logout` | GET | none | Delete session, clear cookie, redirect to /login |
+| `/dashboard/*` | GET | session | Customer dashboard |
+| `/admin/*` | GET | session + admin role | Admin panel |
+
+## Auth Flow
+
+1. User submits login/register form (POST)
+2. Handler validates credentials / creates account via `deps.Auth`
+3. On success: creates session in `deps.Sessions` with 24h TTL
+4. Sets `vaultaire_session` cookie
+5. Redirects to `/dashboard`
+6. On error: re-renders form with `.Error` message and preserved form values
 
 ## Templates
 

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -5,12 +5,15 @@ import (
 	"html/template"
 	"io/fs"
 	"net/http"
+	"time"
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 )
+
+const sessionTTL = 24 * time.Hour
 
 // Deps groups the dependencies the dashboard routes need.
 type Deps struct {
@@ -35,7 +38,9 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 
 	// --- Public auth routes ---
 	r.Get("/login", renderPage(baseTmpl, "login"))
+	r.Post("/login", handleLogin(baseTmpl, deps))
 	r.Get("/register", renderPage(baseTmpl, "register"))
+	r.Post("/register", handleRegister(baseTmpl, deps))
 	r.Get("/logout", handleLogout(deps.Sessions))
 
 	// --- Customer dashboard (session required) ---
@@ -76,6 +81,113 @@ func renderPage(base *template.Template, page string) http.HandlerFunc {
 	}
 }
 
+func handleLogin(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
+	errTmpl := template.Must(baseTmpl.Clone())
+	template.Must(errTmpl.Parse(pageContent("login")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := r.FormValue("email")
+		password := r.FormValue("password")
+
+		renderErr := func(msg string) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = errTmpl.ExecuteTemplate(w, "base", map[string]any{
+				"Error": msg,
+				"Email": email,
+				"Page":  "login",
+			})
+		}
+
+		valid, err := deps.Auth.ValidatePassword(r.Context(), email, password)
+		if err != nil || !valid {
+			renderErr("Invalid email or password.")
+			return
+		}
+
+		user, err := deps.Auth.GetUserByEmail(r.Context(), email)
+		if err != nil {
+			renderErr("Invalid email or password.")
+			return
+		}
+
+		// Determine role — default to "user" if the DB column isn't loaded yet.
+		role := "user"
+		if deps.DB != nil {
+			_ = deps.DB.QueryRowContext(r.Context(),
+				`SELECT role FROM users WHERE id = $1`, user.ID).Scan(&role)
+		}
+
+		token, err := deps.Sessions.Create(r.Context(), dashauth.SessionData{
+			UserID:   user.ID,
+			TenantID: user.TenantID,
+			Email:    user.Email,
+			Role:     role,
+		}, sessionTTL)
+		if err != nil {
+			deps.Logger.Error("create session", zap.Error(err))
+			renderErr("Something went wrong. Please try again.")
+			return
+		}
+
+		dashauth.SetSessionCookie(w, token, sessionTTL)
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+	}
+}
+
+func handleRegister(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
+	errTmpl := template.Must(baseTmpl.Clone())
+	template.Must(errTmpl.Parse(pageContent("register")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := r.FormValue("email")
+		password := r.FormValue("password")
+		company := r.FormValue("company")
+
+		renderErr := func(msg string) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = errTmpl.ExecuteTemplate(w, "base", map[string]any{
+				"Error":   msg,
+				"Email":   email,
+				"Company": company,
+				"Page":    "register",
+			})
+		}
+
+		if len(password) < 8 {
+			renderErr("Password must be at least 8 characters.")
+			return
+		}
+
+		user, _, _, err := deps.Auth.CreateUserWithTenant(r.Context(), email, password, company)
+		if err != nil {
+			if err.Error() == "user already exists" {
+				renderErr("An account with that email already exists.")
+			} else {
+				deps.Logger.Error("registration failed", zap.Error(err))
+				renderErr("Registration failed. Please try again.")
+			}
+			return
+		}
+
+		token, err := deps.Sessions.Create(r.Context(), dashauth.SessionData{
+			UserID:   user.ID,
+			TenantID: user.TenantID,
+			Email:    user.Email,
+			Role:     "user",
+		}, sessionTTL)
+		if err != nil {
+			deps.Logger.Error("create session after register", zap.Error(err))
+			renderErr("Account created but login failed. Please sign in.")
+			return
+		}
+
+		dashauth.SetSessionCookie(w, token, sessionTTL)
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+	}
+}
+
 func handleLogout(store dashauth.SessionStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if c, err := r.Cookie("vaultaire_session"); err == nil {
@@ -97,8 +209,9 @@ func pageContent(page string) string {
 			`<div class="auth-page"><div class="auth-card">` +
 			`<div class="auth-brand">stored.ge</div>` +
 			`<h1>Sign In</h1>` +
+			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
 			`<form method="POST" action="/login">` +
-			`<div class="form-group"><label>Email</label><input type="email" name="email" required></div>` +
+			`<div class="form-group"><label>Email</label><input type="email" name="email" value="{{.Email}}" required></div>` +
 			`<div class="form-group"><label>Password</label><input type="password" name="password" required></div>` +
 			`<button type="submit" class="btn btn-primary btn-block">Sign In</button>` +
 			`</form>` +
@@ -111,10 +224,11 @@ func pageContent(page string) string {
 			`<div class="auth-page"><div class="auth-card">` +
 			`<div class="auth-brand">stored.ge</div>` +
 			`<h1>Create Account</h1>` +
+			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
 			`<form method="POST" action="/register">` +
-			`<div class="form-group"><label>Email</label><input type="email" name="email" required></div>` +
+			`<div class="form-group"><label>Email</label><input type="email" name="email" value="{{.Email}}" required></div>` +
 			`<div class="form-group"><label>Password</label><input type="password" name="password" required minlength="8"></div>` +
-			`<div class="form-group"><label>Company</label><input type="text" name="company"></div>` +
+			`<div class="form-group"><label>Company</label><input type="text" name="company" value="{{.Company}}"></div>` +
 			`<button type="submit" class="btn btn-primary btn-block">Create Account</button>` +
 			`</form>` +
 			`<div class="auth-footer">Have an account? <a href="/login">Sign in</a></div>` +

--- a/internal/dashboard/router_test.go
+++ b/internal/dashboard/router_test.go
@@ -1,0 +1,211 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func setupTestRouter(t *testing.T) (chi.Router, *auth.AuthService, dashauth.SessionStore) {
+	t.Helper()
+	authSvc := auth.NewAuthService(nil, nil)
+	sessions := dashauth.NewMemoryStore()
+	r := chi.NewRouter()
+	RegisterRoutes(r, Deps{
+		Auth:     authSvc,
+		Sessions: sessions,
+		Logger:   zap.NewNop(),
+	})
+	return r, authSvc, sessions
+}
+
+func TestGetLogin(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+	req := httptest.NewRequest("GET", "/login", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Sign In")
+}
+
+func TestGetRegister(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+	req := httptest.NewRequest("GET", "/register", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Create Account")
+}
+
+func TestPostRegister(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	form := url.Values{
+		"email":    {"test@stored.ge"},
+		"password": {"securepass123"},
+		"company":  {"Test Corp"},
+	}
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Should redirect to /dashboard
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard", w.Header().Get("Location"))
+
+	// Should have a session cookie
+	cookies := w.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "vaultaire_session" {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie, "expected session cookie")
+	assert.NotEmpty(t, sessionCookie.Value)
+}
+
+func TestPostRegister_DuplicateEmail(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+
+	// Pre-register a user
+	_, _ = authSvc.CreateUser(context.Background(), "taken@stored.ge", "password123")
+
+	form := url.Values{
+		"email":    {"taken@stored.ge"},
+		"password": {"securepass123"},
+	}
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "already exists")
+}
+
+func TestPostRegister_ShortPassword(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	form := url.Values{
+		"email":    {"test@stored.ge"},
+		"password": {"short"},
+	}
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "at least 8 characters")
+}
+
+func TestPostLogin(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+
+	// Register a user first
+	_, _ = authSvc.CreateUser(context.Background(), "login@stored.ge", "securepass123")
+
+	form := url.Values{
+		"email":    {"login@stored.ge"},
+		"password": {"securepass123"},
+	}
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard", w.Header().Get("Location"))
+
+	// Should have session cookie
+	cookies := w.Result().Cookies()
+	var found bool
+	for _, c := range cookies {
+		if c.Name == "vaultaire_session" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected session cookie")
+}
+
+func TestPostLogin_BadPassword(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+
+	_, _ = authSvc.CreateUser(context.Background(), "login@stored.ge", "securepass123")
+
+	form := url.Values{
+		"email":    {"login@stored.ge"},
+		"password": {"wrongpassword"},
+	}
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid email or password")
+}
+
+func TestPostLogin_NoSuchUser(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	form := url.Values{
+		"email":    {"nobody@stored.ge"},
+		"password": {"whatever123"},
+	}
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid email or password")
+}
+
+func TestDashboard_RequiresSession(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestLogout(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	req := httptest.NewRequest("GET", "/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "vaultaire_session", Value: "anything"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestStaticAssets(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	req := httptest.NewRequest("GET", "/static/css/style.css", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "--primary")
+}


### PR DESCRIPTION
## Summary
- POST `/login`: validates credentials via `AuthService.ValidatePassword`, creates PostgreSQL session, sets `vaultaire_session` cookie, redirects to `/dashboard`
- POST `/register`: calls `CreateUserWithTenant`, creates session, auto-logs user in
- Error feedback: forms re-render with error messages and preserved field values
- Server-side password validation (min 8 chars)

## Test plan
- [x] `TestPostLogin` — successful login redirects + sets cookie
- [x] `TestPostLogin_BadPassword` — returns 401 with error message
- [x] `TestPostLogin_NoSuchUser` — returns 401
- [x] `TestPostRegister` — creates account, redirects, sets cookie
- [x] `TestPostRegister_DuplicateEmail` — returns 400 with "already exists"
- [x] `TestPostRegister_ShortPassword` — returns 400
- [x] `TestDashboard_RequiresSession` — unauthenticated redirects to /login
- [x] `TestLogout` — clears session
- [x] `TestStaticAssets` — CSS served from embedded FS
- [x] `golangci-lint` — 0 issues
- [ ] Deploy: register at stored.ge/register → redirects to dashboard