### PR TITLE
fix(security): add TODO markers on nosec annotations needing real fixes

### DIFF
--- a/cmd/vaultaire/main.go
+++ b/cmd/vaultaire/main.go
@@ -157,7 +157,7 @@ func main() {
 	if dataPath == "" {
 		dataPath = "/tmp/vaultaire-data"
 	}
-	if err := os.MkdirAll(dataPath, 0750); err != nil { // #nosec G703 — data directory from config
+	if err := os.MkdirAll(dataPath, 0750); err != nil { // #nosec G703 — TODO: sanitize DATA_PATH to prevent traversal
 		logger.Fatal("failed to create storage directory", zap.Error(err))
 	}
 	localDriver := drivers.NewLocalDriver(dataPath, logger)

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -104,7 +104,7 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 
 	// Create container directory
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
-	if err := os.MkdirAll(dirPath, 0755); err != nil { // #nosec G703 — bucket path validated by engine
+	if err := os.MkdirAll(dirPath, 0755); err != nil { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
 		s.logger.Error("Failed to create container", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
@@ -135,7 +135,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
 
 	// Check if bucket exists
-	if _, err := os.Stat(dirPath); os.IsNotExist(err) { // #nosec G703 — bucket path validated by engine
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
 		WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
 		return
 	}
@@ -163,7 +163,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Delete the bucket
-	if err := os.RemoveAll(dirPath); err != nil { // #nosec G703 — bucket path validated by engine
+	if err := os.RemoveAll(dirPath); err != nil { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
 		s.logger.Error("Failed to delete bucket", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return

--- a/internal/cache/backup.go
+++ b/internal/cache/backup.go
@@ -375,7 +375,7 @@ func (c *SSDCache) CreateEncryptedBackup(backupDir string, backupType BackupType
 
 	encrypted := gcm.Seal(nonce, nonce, data, nil)
 
-	if err := os.WriteFile(dataFile, encrypted, 0600); err != nil { // #nosec G703 — backup file path is internally constructed
+	if err := os.WriteFile(dataFile, encrypted, 0600); err != nil { // #nosec G703 — TODO: validate backup file path before write
 		return nil, err
 	}
 

--- a/internal/drivers/s3compat.go
+++ b/internal/drivers/s3compat.go
@@ -29,7 +29,7 @@ func NewS3CompatDriver(accessKey, secretKey string, logger *zap.Logger) (*S3Comp
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402 — required for backends with self-signed certs
+				InsecureSkipVerify: true, // #nosec G402 — TODO: make InsecureSkipVerify configurable per backend instead of hardcoded true
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
Updates 6 `#nosec` annotations to include TODO markers so the tech debt is visible in code:

- **G703 (path traversal)**: 4 annotations now say `TODO: add path sanitization` / `TODO: validate path` / `TODO: sanitize DATA_PATH`
- **G402 (InsecureSkipVerify)**: 1 annotation now says `TODO: make configurable per backend`

These are grep-able (`grep -rn 'TODO.*nosec'`) and will show up in any TODO scanner.

## Test plan
- [x] Pre-commit hooks pass