### PR TITLE
feat(dashboard,geyser): Phase 1.2-1.3 dashboard + Geyser tape integration

### DIFF
--- a/cmd/vaultaire/main.go
+++ b/cmd/vaultaire/main.go
@@ -141,6 +141,7 @@ func main() {
 		"s3":        0.023,
 		"onedrive":  0.0,
 		"local":     0.0,
+		"geyser":    0.00155, // $1.55/TB
 	})
 
 	eng.SetEgressCosts(map[string]float64{
@@ -149,6 +150,7 @@ func main() {
 		"quotaless": 0.01,
 		"onedrive":  0.02,
 		"local":     0.0,
+		"geyser":    0.0, // No egress fees
 	})
 
 	// Initialize storage drivers
@@ -207,16 +209,38 @@ func main() {
 		}
 	}
 
-	// 5. Set primary backend (auto-detect best available)
+	// 5. Add Geyser if credentials available
+	if accessKey := os.Getenv("GEYSER_ACCESS_KEY"); accessKey != "" {
+		secretKey := os.Getenv("GEYSER_SECRET_KEY")
+		bucket := os.Getenv("GEYSER_BUCKET")
+		if bucket == "" {
+			bucket = "stored3lib-632df558-9627-427b-ab86-9f3ff1eaafe9"
+		}
+		var geyserOpts []drivers.GeyserOption
+		if ep := os.Getenv("GEYSER_ENDPOINT"); ep != "" {
+			geyserOpts = append(geyserOpts, drivers.WithGeyserEndpoint(ep))
+		}
+		geyserDriver, err := drivers.NewGeyserDriver(accessKey, secretKey, bucket, "vaultaire", logger, geyserOpts...)
+		if err != nil {
+			logger.Warn("failed to create Geyser driver", zap.Error(err))
+		} else {
+			eng.AddDriver("geyser", geyserDriver)
+			logger.Info("geyser driver added (LTO-9 tape)", zap.String("bucket", bucket))
+		}
+	}
+
+	// 6. Set primary backend (auto-detect best available)
 	storageMode := os.Getenv("STORAGE_MODE")
 	if storageMode == "" {
-		// Auto-detect: prefer Quotaless > Lyve > S3 > local
+		// Auto-detect: prefer Quotaless > Lyve > S3 > Geyser > local
 		if os.Getenv("QUOTALESS_ACCESS_KEY") != "" {
 			storageMode = "quotaless"
 		} else if os.Getenv("LYVE_ACCESS_KEY") != "" {
 			storageMode = "lyve"
 		} else if os.Getenv("S3_ACCESS_KEY") != "" {
 			storageMode = "s3"
+		} else if os.Getenv("GEYSER_ACCESS_KEY") != "" {
+			storageMode = "geyser"
 		} else {
 			storageMode = "local"
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -284,11 +284,16 @@ func (s *Server) setupRoutes() {
 	// Dashboard routes must be registered BEFORE the S3 catch-all so that
 	// /login, /dashboard/*, /admin/*, and /static/* are matched first.
 	s.logger.Info("Registering dashboard routes")
+	dataPath := os.Getenv("DATA_PATH")
+	if dataPath == "" {
+		dataPath = "/tmp/vaultaire-data"
+	}
 	dashboard.RegisterRoutes(s.router, dashboard.Deps{
 		DB:       s.db,
 		Auth:     s.auth,
 		Sessions: s.sessionStore,
 		Logger:   s.logger,
+		DataPath: dataPath,
 	})
 
 	s.logger.Info("Registering S3 catch-all handler")

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -7,8 +7,9 @@ Web dashboard for stored.ge customers and admins. Uses htmx + Go templates, embe
 - **embed.go** — `//go:embed` bundles `templates/` and `static/` into the binary
 - **router.go** — `RegisterRoutes(r, deps)` mounts all dashboard routes on the chi router. Must be called BEFORE the S3 catch-all in `server.go`.
 - **auth/** — session management (PostgreSQL-backed `DBStore` or in-memory `MemoryStore`)
-- **handlers/** — HTTP handlers (Phase 1 fills these in)
+- **handlers/** — HTTP handlers (`overview.go` renders dashboard with real data from DB)
 - **templates/layouts/** — shared HTML layouts (`base.html`, `admin.html`)
+- **templates/customer/** — customer page templates (`dashboard.html` = overview)
 - **static/css/** — `style.css`
 - **static/js/** — `htmx.min.js` (v2.0.4, vendored)
 
@@ -32,7 +33,10 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/register` | GET | none | Registration page |
 | `/register` | POST | none | Create user+tenant, create session, redirect to /dashboard |
 | `/logout` | GET | none | Delete session, clear cookie, redirect to /login |
-| `/dashboard/*` | GET | session | Customer dashboard |
+| `/dashboard/` | GET | session | Overview: storage gauge, bandwidth, stats, activity |
+| `/dashboard/buckets` | GET | session | Bucket list with counts + sizes |
+| `/dashboard/buckets` | POST | session | Create new bucket (validates name, creates directory) |
+| `/dashboard/buckets/{name}` | GET | session | Object browser with prefix navigation |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow
@@ -46,4 +50,14 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 
 ## Templates
 
-Base layout defines blocks: `title`, `head`, `nav`, `content`. Pages override these blocks. Phase 1 will add per-page template files in `templates/auth/`, `templates/customer/`, `templates/admin/`.
+Base layout defines blocks: `title`, `head`, `nav`, `content`. Pages override these blocks. Customer page templates are in `templates/customer/`, parsed from embedded FS and combined with base layout in `RegisterRoutes`.
+
+## Dashboard Overview (Phase 1.2)
+
+`handlers/overview.go` queries DB directly (no QuotaManager interface needed — just `*sql.DB`):
+- Storage: `tenant_quotas` (used, limit, tier)
+- Bandwidth: `bandwidth_usage_daily` (current month ingress+egress)
+- Counts: `object_head_cache` (distinct buckets, total objects), `api_keys` (per user)
+- Activity: `quota_usage_events` (last 5, with operation, key, size, time)
+
+Gracefully degrades to zeros when DB is nil (tests, local dev without PostgreSQL).

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -1,0 +1,44 @@
+# internal/dashboard/handlers
+
+HTTP handlers for the stored.ge customer dashboard. Each handler receives a pre-parsed `*template.Template` (base layout + page content) and renders it with data from PostgreSQL.
+
+## Overview Handler (`overview.go`)
+
+`HandleOverview(tmpl, db, logger)` renders the main dashboard page:
+- Reads session from context via `dashauth.GetSession(r.Context())`
+- Queries 4 tables: `tenant_quotas`, `bandwidth_usage_daily`, `object_head_cache`, `api_keys`, `quota_usage_events`
+- Fails gracefully to zeros when DB is nil or tables are empty
+- Template: `templates/customer/dashboard.html`
+
+Helper functions: `formatBytes` (human-readable sizes), `relativeTime` (time ago), `absInt64`.
+
+## Bucket Browser (`buckets.go`)
+
+Three handlers:
+- `HandleBuckets(tmpl, db, dataPath, logger)` — lists buckets from `object_head_cache` (distinct buckets with counts/sizes)
+- `HandleCreateBucket(tmpl, db, dataPath, logger)` — validates S3-compatible name, creates directory at `{dataPath}/{name}`
+- `HandleBucketObjects(tmpl, db, logger)` — lists objects in a bucket with prefix-based "folder" navigation (uses chi URL param `{name}`)
+
+Bucket name validation: `^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$` + path traversal check.
+
+Shared helpers: `sessionData(sd, page)` builds the base template data map. `formatBytes` and `relativeTime` from `overview.go`.
+
+## Legacy Handlers
+
+Files like `dashboard.go`, `buckets.go`, `usage.go`, etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Phase 1.3+ will rewrite them to follow the `overview.go` pattern.
+
+## Pattern
+
+```go
+func HandleXxx(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        sd := dashauth.GetSession(r.Context())
+        data := map[string]any{ /* session fields + page data */ }
+        tmpl.ExecuteTemplate(w, "base", data)
+    }
+}
+```
+
+## Testing
+
+Tests use a minimal base template (no embedded FS) and inject session data directly into context. Run: `go test ./internal/dashboard/handlers/ -v`

--- a/internal/dashboard/handlers/buckets.go
+++ b/internal/dashboard/handlers/buckets.go
@@ -1,81 +1,307 @@
 package handlers
 
 import (
+	"context"
+	"database/sql"
 	"html/template"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
 )
 
-type BucketsHandler struct {
-	db interface{}
+// BucketRow is a single bucket for the bucket list template.
+type BucketRow struct {
+	Name            string
+	ObjectCount     int
+	TotalSize       int64
+	LastModified    time.Time
+	SizeFmt         string
+	LastModifiedFmt string
 }
 
-func NewBucketsHandler(db interface{}) *BucketsHandler {
-	return &BucketsHandler{db: db}
+// ObjectRow is a single object for the bucket browser template.
+type ObjectRow struct {
+	Key             string
+	Display         string
+	Size            int64
+	ContentType     string
+	LastModified    time.Time
+	SizeFmt         string
+	LastModifiedFmt string
 }
 
-func (h *BucketsHandler) ListBuckets(w http.ResponseWriter, r *http.Request) {
-	tmpl := `<!DOCTYPE html>
-<html>
-<head>
-    <title>S3 Buckets</title>
-    <style>
-        body { background: #000; color: #0f0; font-family: monospace; }
-        .terminal { border: 1px solid #0f0; padding: 20px; margin: 20px; }
-        .bucket { background: #111; padding: 10px; margin: 10px 0; }
-    </style>
-</head>
-<body>
-    <div class="terminal">
-        <h1>S3 Buckets</h1>
-        <div class="bucket">
-            test-bucket [Created: 2025-09-05]
-        </div>
-        <div class="bucket">
-            production-data [Created: 2025-09-01]
-        </div>
-        <button onclick="location.href='/dashboard/buckets/new'">Create New Bucket</button>
-    </div>
-</body>
-</html>`
+// PrefixRow is a common-prefix "folder" in the bucket browser.
+type PrefixRow struct {
+	FullPrefix string
+	Display    string
+}
 
-	t, _ := template.New("buckets").Parse(tmpl)
-	if err := t.Execute(w, nil); err != nil {
+var bucketNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$`)
+
+// HandleBuckets returns an http.HandlerFunc that lists all buckets for the
+// current tenant, with object counts and total sizes.
+func HandleBuckets(tmpl *template.Template, db *sql.DB, dataPath string, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "buckets")
+
+		if db != nil {
+			buckets := listBuckets(r.Context(), db, sd.TenantID)
+			data["Buckets"] = buckets
+			data["BucketCount"] = len(buckets)
+		} else {
+			data["Buckets"] = nil
+			data["BucketCount"] = 0
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render buckets", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleCreateBucket handles POST /dashboard/buckets to create a new bucket.
+func HandleCreateBucket(tmpl *template.Template, db *sql.DB, dataPath string, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "buckets")
+
+		name := strings.TrimSpace(r.FormValue("name"))
+		name = strings.ToLower(name)
+
+		// Validate bucket name (S3-compatible rules).
+		if !bucketNameRe.MatchString(name) {
+			data["CreateError"] = "Invalid bucket name. Use 3-63 lowercase letters, numbers, hyphens, or dots."
+			renderBucketList(w, tmpl, db, sd, data, logger)
+			return
+		}
+
+		// Prevent path traversal.
+		if strings.Contains(name, "..") {
+			data["CreateError"] = "Invalid bucket name."
+			renderBucketList(w, tmpl, db, sd, data, logger)
+			return
+		}
+
+		// Create the directory under the data path.
+		if dataPath != "" {
+			dirPath := filepath.Join(dataPath, name)
+			cleanPath := filepath.Clean(dirPath)
+			if !strings.HasPrefix(cleanPath, filepath.Clean(dataPath)) {
+				data["CreateError"] = "Invalid bucket name."
+				renderBucketList(w, tmpl, db, sd, data, logger)
+				return
+			}
+			if err := os.MkdirAll(cleanPath, 0750); err != nil {
+				logger.Error("create bucket directory", zap.Error(err))
+				data["CreateError"] = "Failed to create bucket."
+				renderBucketList(w, tmpl, db, sd, data, logger)
+				return
+			}
+		}
+
+		data["CreateSuccess"] = name
+		renderBucketList(w, tmpl, db, sd, data, logger)
+	}
+}
+
+// HandleBucketObjects returns an http.HandlerFunc that lists objects in a
+// specific bucket with prefix-based "folder" navigation.
+func HandleBucketObjects(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		bucketName := chi.URLParam(r, "name")
+		if bucketName == "" {
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			return
+		}
+
+		prefix := r.URL.Query().Get("prefix")
+
+		data := sessionData(sd, "buckets")
+		data["BucketName"] = bucketName
+		data["Prefix"] = prefix
+
+		if prefix != "" {
+			// Parent prefix: strip the last path component.
+			parts := strings.Split(strings.TrimSuffix(prefix, "/"), "/")
+			if len(parts) > 1 {
+				data["ParentPrefix"] = strings.Join(parts[:len(parts)-1], "/") + "/"
+			}
+			// else ParentPrefix is empty → goes back to bucket root
+		}
+
+		if db != nil {
+			populateBucketObjects(r.Context(), db, sd.TenantID, bucketName, prefix, data)
+		} else {
+			data["ObjectCount"] = 0
+			data["TotalSizeFmt"] = "0 B"
+			data["Objects"] = nil
+			data["Prefixes"] = nil
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render bucket objects", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func renderBucketList(w http.ResponseWriter, tmpl *template.Template, db *sql.DB, sd *dashauth.SessionData, data map[string]any, logger *zap.Logger) {
+	if db != nil {
+		buckets := listBuckets(context.Background(), db, sd.TenantID)
+		data["Buckets"] = buckets
+		data["BucketCount"] = len(buckets)
+	} else {
+		data["Buckets"] = nil
+		data["BucketCount"] = 0
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+		logger.Error("render bucket list", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }
 
-func (h *BucketsHandler) ShowCreateForm(w http.ResponseWriter, r *http.Request) {
-	tmpl := `<!DOCTYPE html>
-<html>
-<head>
-    <title>Create Bucket</title>
-    <style>
-        body { background: #000; color: #0f0; font-family: monospace; }
-        .terminal { border: 1px solid #0f0; padding: 20px; margin: 20px; }
-        input { background: #111; color: #0f0; border: 1px solid #0f0; padding: 5px; }
-    </style>
-</head>
-<body>
-    <div class="terminal">
-        <h1>Create Bucket</h1>
-        <form action="/dashboard/buckets/create" method="POST">
-            <label>Bucket Name:</label><br>
-            <input type="text" name="name" pattern="[a-z0-9-]+" required><br><br>
-            <button type="submit">Create</button>
-            <button type="button" onclick="location.href='/dashboard/buckets'">Cancel</button>
-        </form>
-    </div>
-</body>
-</html>`
-
-	t, _ := template.New("create").Parse(tmpl)
-	if err := t.Execute(w, nil); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+func listBuckets(ctx context.Context, db *sql.DB, tenantID string) []BucketRow {
+	rows, err := db.QueryContext(ctx,
+		`SELECT bucket,
+		        COUNT(*) AS object_count,
+		        COALESCE(SUM(size_bytes), 0) AS total_size,
+		        MAX(updated_at) AS last_modified
+		 FROM object_head_cache
+		 WHERE tenant_id = $1
+		 GROUP BY bucket
+		 ORDER BY bucket`, tenantID)
+	if err != nil {
+		return nil
 	}
+	defer func() { _ = rows.Close() }()
+
+	var buckets []BucketRow
+	for rows.Next() {
+		var b BucketRow
+		var lastMod time.Time
+		if err := rows.Scan(&b.Name, &b.ObjectCount, &b.TotalSize, &lastMod); err != nil {
+			continue
+		}
+		b.LastModified = lastMod
+		b.SizeFmt = formatBytes(b.TotalSize)
+		b.LastModifiedFmt = relativeTime(lastMod)
+		buckets = append(buckets, b)
+	}
+	return buckets
 }
 
-func (h *BucketsHandler) CreateBucket(w http.ResponseWriter, r *http.Request) {
-	// In a real implementation, this would create the bucket
-	// For now, just redirect back to the list
-	http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+func populateBucketObjects(ctx context.Context, db *sql.DB, tenantID, bucket, prefix string, data map[string]any) {
+	// Query all objects matching the prefix.
+	query := `SELECT object_key, size_bytes, content_type, updated_at
+		 FROM object_head_cache
+		 WHERE tenant_id = $1 AND bucket = $2`
+	args := []any{tenantID, bucket}
+
+	if prefix != "" {
+		query += ` AND object_key LIKE $3`
+		args = append(args, prefix+"%")
+	}
+	query += ` ORDER BY object_key`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		data["ObjectCount"] = 0
+		data["TotalSizeFmt"] = "0 B"
+		data["Objects"] = nil
+		data["Prefixes"] = nil
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	// Collect objects and extract common prefixes (simulated folder structure).
+	prefixSet := make(map[string]bool)
+	var objects []ObjectRow
+	var totalSize int64
+	var totalCount int
+
+	for rows.Next() {
+		var key, contentType string
+		var size int64
+		var lastMod time.Time
+		if err := rows.Scan(&key, &size, &contentType, &lastMod); err != nil {
+			continue
+		}
+		totalCount++
+		totalSize += size
+
+		// Strip the current prefix to get the relative key.
+		rel := strings.TrimPrefix(key, prefix)
+
+		// If the relative key contains a slash, it's in a "subfolder".
+		if idx := strings.Index(rel, "/"); idx >= 0 {
+			pfx := prefix + rel[:idx+1]
+			prefixSet[pfx] = true
+			continue
+		}
+
+		objects = append(objects, ObjectRow{
+			Key:             key,
+			Display:         rel,
+			Size:            size,
+			ContentType:     contentType,
+			LastModified:    lastMod,
+			SizeFmt:         formatBytes(size),
+			LastModifiedFmt: relativeTime(lastMod),
+		})
+	}
+
+	// Build sorted prefix list.
+	var prefixes []PrefixRow
+	for p := range prefixSet {
+		display := strings.TrimPrefix(p, prefix)
+		display = strings.TrimSuffix(display, "/")
+		prefixes = append(prefixes, PrefixRow{
+			FullPrefix: p,
+			Display:    display,
+		})
+	}
+
+	data["ObjectCount"] = totalCount
+	data["TotalSizeFmt"] = formatBytes(totalSize)
+	data["Objects"] = objects
+	data["Prefixes"] = prefixes
+}
+
+// sessionData builds the base template data map from session.
+func sessionData(sd *dashauth.SessionData, page string) map[string]any {
+	return map[string]any{
+		"Email":    sd.Email,
+		"Role":     sd.Role,
+		"UserID":   sd.UserID,
+		"TenantID": sd.TenantID,
+		"Page":     page,
+	}
 }

--- a/internal/dashboard/handlers/buckets_test.go
+++ b/internal/dashboard/handlers/buckets_test.go
@@ -1,56 +1,206 @@
 package handlers
 
 import (
+	"context"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
-func TestBucketsHandler(t *testing.T) {
-	t.Run("lists buckets", func(t *testing.T) {
-		handler := NewBucketsHandler(nil)
-		req := httptest.NewRequest("GET", "/dashboard/buckets", nil)
+func testBucketsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Buckets{{end}}` +
+			`{{define "content"}}` +
+			`<h1>Buckets</h1>` +
+			`<span class="count">{{.BucketCount}}</span>` +
+			`<span class="email">{{.Email}}</span>` +
+			`{{if .CreateError}}<span class="error">{{.CreateError}}</span>{{end}}` +
+			`{{if .CreateSuccess}}<span class="success">{{.CreateSuccess}}</span>{{end}}` +
+			`{{range .Buckets}}<span class="bucket">{{.Name}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func testBucketObjectsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Objects{{end}}` +
+			`{{define "content"}}` +
+			`<h1>{{.BucketName}}</h1>` +
+			`<span class="count">{{.ObjectCount}}</span>` +
+			`<span class="size">{{.TotalSizeFmt}}</span>` +
+			`{{range .Objects}}<span class="object">{{.Display}}</span>{{end}}` +
+			`{{range .Prefixes}}<span class="prefix">{{.Display}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func injectSession(req *http.Request) *http.Request {
+	sd := &dashauth.SessionData{
+		UserID:   "user-123",
+		TenantID: "tenant-456",
+		Email:    "test@stored.ge",
+		Role:     "user",
+	}
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	return req.WithContext(ctx)
+}
+
+func TestHandleBuckets_NoDB(t *testing.T) {
+	tmpl := testBucketsTemplate(t)
+	handler := HandleBuckets(tmpl, nil, "", zap.NewNop())
+
+	req := injectSession(httptest.NewRequest("GET", "/dashboard/buckets", nil))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Buckets")
+	assert.Contains(t, body, "test@stored.ge")
+	assert.Contains(t, body, `<span class="count">0</span>`)
+}
+
+func TestHandleBuckets_NoSession(t *testing.T) {
+	tmpl := testBucketsTemplate(t)
+	handler := HandleBuckets(tmpl, nil, "", zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleCreateBucket_NoDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpl := testBucketsTemplate(t)
+	handler := HandleCreateBucket(tmpl, nil, tmpDir, zap.NewNop())
+
+	form := url.Values{"name": {"my-test-bucket"}}
+	req := injectSession(httptest.NewRequest("POST", "/dashboard/buckets",
+		strings.NewReader(form.Encode())))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "my-test-bucket")
+
+	// Directory should have been created.
+	_, err := os.Stat(filepath.Join(tmpDir, "my-test-bucket"))
+	require.NoError(t, err)
+}
+
+func TestHandleCreateBucket_InvalidName(t *testing.T) {
+	tmpl := testBucketsTemplate(t)
+	handler := HandleCreateBucket(tmpl, nil, t.TempDir(), zap.NewNop())
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"AB", "Invalid bucket name"},        // too short + uppercase
+		{"a", "Invalid bucket name"},         // too short
+		{"../etc", "Invalid bucket name"},    // path traversal
+		{"My Bucket", "Invalid bucket name"}, // spaces + uppercase
+	}
+
+	for _, tt := range tests {
+		form := url.Values{"name": {tt.name}}
+		req := injectSession(httptest.NewRequest("POST", "/dashboard/buckets",
+			strings.NewReader(form.Encode())))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
 
-		handler.ListBuckets(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid bucket name", "name=%q", tt.name)
+	}
+}
 
-		if w.Code != http.StatusOK {
-			t.Errorf("expected 200, got %d", w.Code)
-		}
+func TestHandleBucketObjects_NoDB(t *testing.T) {
+	tmpl := testBucketObjectsTemplate(t)
+	handler := HandleBucketObjects(tmpl, nil, zap.NewNop())
 
-		body := w.Body.String()
-		if !strings.Contains(body, "S3 Buckets") {
-			t.Error("expected S3 Buckets title")
-		}
-	})
+	// chi requires a route context to extract URL params.
+	req := injectSession(httptest.NewRequest("GET", "/dashboard/buckets/my-bucket", nil))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "my-bucket")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	t.Run("shows create bucket form", func(t *testing.T) {
-		handler := NewBucketsHandler(nil)
-		req := httptest.NewRequest("GET", "/dashboard/buckets/new", nil)
-		w := httptest.NewRecorder()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
 
-		handler.ShowCreateForm(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "my-bucket")
+	assert.Contains(t, body, `<span class="count">0</span>`)
+	assert.Contains(t, body, `<span class="size">0 B</span>`)
+}
 
-		if w.Code != http.StatusOK {
-			t.Errorf("expected 200, got %d", w.Code)
-		}
+func TestHandleBucketObjects_NoSession(t *testing.T) {
+	tmpl := testBucketObjectsTemplate(t)
+	handler := HandleBucketObjects(tmpl, nil, zap.NewNop())
 
-		body := w.Body.String()
-		if !strings.Contains(body, "Create Bucket") {
-			t.Error("expected create bucket form")
-		}
-	})
+	req := httptest.NewRequest("GET", "/dashboard/buckets/my-bucket", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
 
-	t.Run("creates new bucket", func(t *testing.T) {
-		handler := NewBucketsHandler(nil)
-		req := httptest.NewRequest("POST", "/dashboard/buckets/create?name=test-bucket", nil)
-		w := httptest.NewRecorder()
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
 
-		handler.CreateBucket(w, req)
+func TestSessionData(t *testing.T) {
+	sd := &dashauth.SessionData{
+		UserID:   "u1",
+		TenantID: "t1",
+		Email:    "a@b.com",
+		Role:     "admin",
+	}
+	data := sessionData(sd, "test")
+	assert.Equal(t, "a@b.com", data["Email"])
+	assert.Equal(t, "admin", data["Role"])
+	assert.Equal(t, "test", data["Page"])
+}
 
-		if w.Code != http.StatusSeeOther {
-			t.Errorf("expected redirect 303, got %d", w.Code)
-		}
-	})
+func TestBucketNameRegex(t *testing.T) {
+	valid := []string{"my-bucket", "bucket123", "a.b.c", "abc"}
+	invalid := []string{"AB", "a", "my bucket", "-bucket", "bucket-", "..bad"}
+
+	for _, name := range valid {
+		assert.True(t, bucketNameRe.MatchString(name), "expected valid: %s", name)
+	}
+	for _, name := range invalid {
+		assert.False(t, bucketNameRe.MatchString(name), "expected invalid: %s", name)
+	}
+}
+
+// Ensure relativeTime and formatBytes still work (shared with overview).
+func TestBuckets_SharedHelpers(t *testing.T) {
+	assert.Equal(t, "1 KB", formatBytes(1024))
+	assert.Equal(t, "just now", relativeTime(time.Now()))
 }

--- a/internal/dashboard/handlers/overview.go
+++ b/internal/dashboard/handlers/overview.go
@@ -1,0 +1,249 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"math"
+	"net/http"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// ActivityRow is a single recent-activity row for the dashboard template.
+type ActivityRow struct {
+	Operation  string
+	ObjectKey  string
+	SizeFmt    string
+	TimeFmt    string
+	BadgeClass string
+}
+
+// HandleOverview returns an http.HandlerFunc that renders the dashboard
+// overview page with real data from PostgreSQL.
+func HandleOverview(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := map[string]any{
+			"Email":    sd.Email,
+			"Role":     sd.Role,
+			"UserID":   sd.UserID,
+			"TenantID": sd.TenantID,
+			"Page":     "dashboard",
+		}
+
+		ctx := r.Context()
+
+		if db != nil {
+			populateStorageUsage(ctx, db, sd.TenantID, data)
+			populateBandwidth(ctx, db, sd.TenantID, data)
+			populateCounts(ctx, db, sd.TenantID, sd.UserID, data)
+			populateActivity(ctx, db, sd.TenantID, data)
+		} else {
+			setDefaults(data)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render dashboard overview", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func populateStorageUsage(ctx context.Context, db *sql.DB, tenantID string, data map[string]any) {
+	var used, limit int64
+	var tier string
+
+	err := db.QueryRowContext(ctx,
+		`SELECT storage_used_bytes, storage_limit_bytes, tier
+		 FROM tenant_quotas WHERE tenant_id = $1`, tenantID).Scan(&used, &limit, &tier)
+	if err != nil {
+		data["StorageUsedFmt"] = "0 B"
+		data["StorageLimitFmt"] = "1 TB"
+		data["StoragePercent"] = 0
+		data["StorageBarClass"] = ""
+		data["Tier"] = "starter"
+		return
+	}
+
+	pct := 0
+	if limit > 0 {
+		pct = int(used * 100 / limit)
+	}
+
+	barClass := ""
+	if pct >= 90 {
+		barClass = "danger"
+	} else if pct >= 75 {
+		barClass = "warning"
+	}
+
+	data["StorageUsedFmt"] = formatBytes(used)
+	data["StorageLimitFmt"] = formatBytes(limit)
+	data["StoragePercent"] = pct
+	data["StorageBarClass"] = barClass
+	data["Tier"] = tier
+}
+
+func populateBandwidth(ctx context.Context, db *sql.DB, tenantID string, data map[string]any) {
+	var ingress, egress int64
+	err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(ingress_bytes), 0), COALESCE(SUM(egress_bytes), 0)
+		 FROM bandwidth_usage_daily
+		 WHERE tenant_id = $1 AND date >= date_trunc('month', CURRENT_DATE)`,
+		tenantID).Scan(&ingress, &egress)
+	if err != nil {
+		ingress, egress = 0, 0
+	}
+
+	data["IngressFmt"] = formatBytes(ingress)
+	data["EgressFmt"] = formatBytes(egress)
+	data["BandwidthTotalFmt"] = formatBytes(ingress + egress)
+}
+
+func populateCounts(ctx context.Context, db *sql.DB, tenantID, userID string, data map[string]any) {
+	var bucketCount, objectCount, apiKeyCount int
+
+	// Bucket count: distinct buckets in the head cache for this tenant.
+	_ = db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT bucket) FROM object_head_cache WHERE tenant_id = $1`,
+		tenantID).Scan(&bucketCount)
+
+	// Object count.
+	_ = db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM object_head_cache WHERE tenant_id = $1`,
+		tenantID).Scan(&objectCount)
+
+	// API key count.
+	_ = db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM api_keys WHERE user_id = $1`,
+		userID).Scan(&apiKeyCount)
+
+	data["BucketCount"] = bucketCount
+	data["ObjectCount"] = objectCount
+	data["APIKeyCount"] = apiKeyCount
+}
+
+func populateActivity(ctx context.Context, db *sql.DB, tenantID string, data map[string]any) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT operation, object_key, bytes_delta, timestamp
+		 FROM quota_usage_events
+		 WHERE tenant_id = $1
+		 ORDER BY timestamp DESC
+		 LIMIT 5`, tenantID)
+	if err != nil {
+		data["Activity"] = nil
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var activity []ActivityRow
+	for rows.Next() {
+		var op, key string
+		var delta int64
+		var ts time.Time
+		if err := rows.Scan(&op, &key, &delta, &ts); err != nil {
+			continue
+		}
+
+		badge := "default"
+		switch op {
+		case "PUT", "RESERVE":
+			badge = "success"
+		case "DELETE":
+			badge = "danger"
+		}
+
+		// Truncate long keys for display.
+		displayKey := key
+		if len(displayKey) > 60 {
+			displayKey = displayKey[:57] + "..."
+		}
+
+		activity = append(activity, ActivityRow{
+			Operation:  op,
+			ObjectKey:  displayKey,
+			SizeFmt:    formatBytes(absInt64(delta)),
+			TimeFmt:    relativeTime(ts),
+			BadgeClass: badge,
+		})
+	}
+	data["Activity"] = activity
+}
+
+func setDefaults(data map[string]any) {
+	data["StorageUsedFmt"] = "0 B"
+	data["StorageLimitFmt"] = "1 TB"
+	data["StoragePercent"] = 0
+	data["StorageBarClass"] = ""
+	data["Tier"] = "starter"
+	data["IngressFmt"] = "0 B"
+	data["EgressFmt"] = "0 B"
+	data["BandwidthTotalFmt"] = "0 B"
+	data["BucketCount"] = 0
+	data["ObjectCount"] = 0
+	data["APIKeyCount"] = 0
+	data["Activity"] = nil
+}
+
+// formatBytes returns a human-readable size string (e.g. "1.5 GB").
+func formatBytes(b int64) string {
+	if b == 0 {
+		return "0 B"
+	}
+	units := []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	i := int(math.Log(float64(b)) / math.Log(1024))
+	if i >= len(units) {
+		i = len(units) - 1
+	}
+	val := float64(b) / math.Pow(1024, float64(i))
+	if val == math.Trunc(val) {
+		return fmt.Sprintf("%.0f %s", val, units[i])
+	}
+	return fmt.Sprintf("%.1f %s", val, units[i])
+}
+
+func relativeTime(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if m == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", h)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		if days < 30 {
+			return fmt.Sprintf("%d days ago", days)
+		}
+		return t.Format("Jan 2, 2006")
+	}
+}
+
+func absInt64(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/dashboard/handlers/overview_test.go
+++ b/internal/dashboard/handlers/overview_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testOverviewTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	// Minimal base + content template for testing.
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Dashboard{{end}}` +
+			`{{define "content"}}` +
+			`<h1>Dashboard</h1>` +
+			`<span class="storage">{{.StorageUsedFmt}} of {{.StorageLimitFmt}}</span>` +
+			`<span class="bandwidth">{{.BandwidthTotalFmt}}</span>` +
+			`<span class="buckets">{{.BucketCount}}</span>` +
+			`<span class="objects">{{.ObjectCount}}</span>` +
+			`<span class="apikeys">{{.APIKeyCount}}</span>` +
+			`<span class="tier">{{.Tier}}</span>` +
+			`<span class="email">{{.Email}}</span>` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleOverview_NoDB(t *testing.T) {
+	tmpl := testOverviewTemplate(t)
+	handler := HandleOverview(tmpl, nil, zap.NewNop())
+
+	// Create a session and inject it into the request context.
+	store := dashauth.NewMemoryStore()
+	token, err := store.Create(context.Background(), dashauth.SessionData{
+		UserID:   "user-123",
+		TenantID: "tenant-456",
+		Email:    "test@stored.ge",
+		Role:     "user",
+	}, time.Hour)
+	require.NoError(t, err)
+
+	sd, err := store.Get(context.Background(), token)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Dashboard")
+	assert.Contains(t, body, "test@stored.ge")
+	// Default values when no DB.
+	assert.Contains(t, body, "0 B of 1 TB")
+	assert.Contains(t, body, "starter")
+}
+
+func TestHandleOverview_NoSession(t *testing.T) {
+	tmpl := testOverviewTemplate(t)
+	handler := HandleOverview(tmpl, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Should redirect to login.
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1 MB"},
+		{1073741824, "1 GB"},
+		{1099511627776, "1 TB"},
+		{5368709120, "5 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatBytes(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRelativeTime(t *testing.T) {
+	assert.Equal(t, "just now", relativeTime(time.Now()))
+	assert.Equal(t, "5 minutes ago", relativeTime(time.Now().Add(-5*time.Minute)))
+	assert.Equal(t, "1 hour ago", relativeTime(time.Now().Add(-1*time.Hour)))
+	assert.Equal(t, "3 hours ago", relativeTime(time.Now().Add(-3*time.Hour)))
+	assert.Equal(t, "2 days ago", relativeTime(time.Now().Add(-48*time.Hour)))
+}
+
+func TestAbsInt64(t *testing.T) {
+	assert.Equal(t, int64(5), absInt64(5))
+	assert.Equal(t, int64(5), absInt64(-5))
+	assert.Equal(t, int64(0), absInt64(0))
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 )
@@ -21,6 +22,7 @@ type Deps struct {
 	Auth     *auth.AuthService
 	Sessions dashauth.SessionStore
 	Logger   *zap.Logger
+	DataPath string // Local storage root for bucket creation.
 }
 
 // RegisterRoutes mounts the dashboard, auth, admin, and static-asset
@@ -46,7 +48,26 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
 		dr.Use(dashauth.RequireSession(deps.Sessions))
-		dr.Get("/", renderPage(baseTmpl, "dashboard"))
+
+		// Overview: parse the real template from embedded FS.
+		overviewTmpl := template.Must(baseTmpl.Clone())
+		template.Must(overviewTmpl.ParseFS(Templates,
+			"templates/customer/dashboard.html",
+		))
+		dr.Get("/", handlers.HandleOverview(overviewTmpl, deps.DB, deps.Logger))
+
+		// Bucket browser.
+		bucketsTmpl := template.Must(baseTmpl.Clone())
+		template.Must(bucketsTmpl.ParseFS(Templates,
+			"templates/customer/buckets.html",
+		))
+		bucketObjsTmpl := template.Must(baseTmpl.Clone())
+		template.Must(bucketObjsTmpl.ParseFS(Templates,
+			"templates/customer/bucket_objects.html",
+		))
+		dr.Get("/buckets", handlers.HandleBuckets(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
+		dr.Post("/buckets", handlers.HandleCreateBucket(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
+		dr.Get("/buckets/{name}", handlers.HandleBucketObjects(bucketObjsTmpl, deps.DB, deps.Logger))
 	})
 
 	// --- Admin (session + admin role required) ---
@@ -233,12 +254,6 @@ func pageContent(page string) string {
 			`</form>` +
 			`<div class="auth-footer">Have an account? <a href="/login">Sign in</a></div>` +
 			`</div></div>{{end}}`
-	case "dashboard":
-		return `{{define "title"}}Dashboard — stored.ge{{end}}` +
-			`{{define "content"}}` +
-			`<h1>Dashboard</h1>` +
-			`<p>Welcome, {{.Email}}. Your dashboard is coming in Phase 1.</p>` +
-			`{{end}}`
 	case "admin":
 		return `{{define "title"}}Admin — stored.ge{{end}}` +
 			`{{define "content"}}` +

--- a/internal/dashboard/router_test.go
+++ b/internal/dashboard/router_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
@@ -185,6 +186,98 @@ func TestDashboard_RequiresSession(t *testing.T) {
 
 	assert.Equal(t, http.StatusSeeOther, w.Code)
 	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestDashboard_RendersOverview(t *testing.T) {
+	r, authSvc, sessions := setupTestRouter(t)
+
+	// Register a user and create a session.
+	_, _ = authSvc.CreateUser(context.Background(), "dash@stored.ge", "securepass123")
+	user, _ := authSvc.GetUserByEmail(context.Background(), "dash@stored.ge")
+
+	token, err := sessions.Create(context.Background(), dashauth.SessionData{
+		UserID:   user.ID,
+		TenantID: "tenant-test",
+		Email:    user.Email,
+		Role:     "user",
+	}, 24*time.Hour)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	req.AddCookie(&http.Cookie{Name: "vaultaire_session", Value: token})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// Should render the real dashboard overview, not the old placeholder.
+	assert.Contains(t, body, "Dashboard")
+	assert.Contains(t, body, "dash@stored.ge")
+	assert.Contains(t, body, "Storage Used")
+	assert.Contains(t, body, "Bandwidth This Month")
+	assert.Contains(t, body, "Buckets")
+	assert.Contains(t, body, "API Keys")
+	assert.Contains(t, body, "starter") // Default tier when no DB
+}
+
+func TestBuckets_RequiresSession(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestBuckets_RendersList(t *testing.T) {
+	r, authSvc, sessions := setupTestRouter(t)
+
+	_, _ = authSvc.CreateUser(context.Background(), "buckets@stored.ge", "securepass123")
+	user, _ := authSvc.GetUserByEmail(context.Background(), "buckets@stored.ge")
+
+	token, err := sessions.Create(context.Background(), dashauth.SessionData{
+		UserID:   user.ID,
+		TenantID: "tenant-test",
+		Email:    user.Email,
+		Role:     "user",
+	}, 24*time.Hour)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets", nil)
+	req.AddCookie(&http.Cookie{Name: "vaultaire_session", Value: token})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Buckets")
+	assert.Contains(t, body, "buckets@stored.ge")
+}
+
+func TestBucketObjects_RendersBrowser(t *testing.T) {
+	r, authSvc, sessions := setupTestRouter(t)
+
+	_, _ = authSvc.CreateUser(context.Background(), "browse@stored.ge", "securepass123")
+	user, _ := authSvc.GetUserByEmail(context.Background(), "browse@stored.ge")
+
+	token, err := sessions.Create(context.Background(), dashauth.SessionData{
+		UserID:   user.ID,
+		TenantID: "tenant-test",
+		Email:    user.Email,
+		Role:     "user",
+	}, 24*time.Hour)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets/my-bucket", nil)
+	req.AddCookie(&http.Cookie{Name: "vaultaire_session", Value: token})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "my-bucket")
 }
 
 func TestLogout(t *testing.T) {

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -268,6 +268,59 @@ th {
     margin-top: 3rem;
 }
 
+/* Dashboard header */
+.dashboard-header { margin-bottom: 1.5rem; }
+.dashboard-header h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+
+/* Card detail line (sub-text below card value) */
+.card-detail { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.25rem; }
+.card-value-plan { text-transform: capitalize; }
+
+/* Badges */
+.badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.badge-success { background: #f0fdf4; color: var(--success); }
+.badge-danger { background: #fef2f2; color: var(--danger); }
+.badge-default { background: var(--bg); color: var(--text-muted); }
+
+/* Empty state */
+.empty-state { padding: 1.5rem 0; text-align: center; }
+
+/* Page header (title + action button side by side) */
+.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; }
+.page-header h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+
+/* Inline form row */
+.form-row { display: flex; align-items: flex-end; gap: 0.75rem; }
+.form-group-inline { flex: 1; }
+
+/* Breadcrumb */
+.breadcrumb { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 1rem; }
+.breadcrumb a { color: var(--primary); text-decoration: none; }
+
+/* Bucket link */
+.bucket-link { color: var(--primary); text-decoration: none; font-weight: 500; }
+.bucket-link:hover { text-decoration: underline; }
+
+/* Compact card (less padding) */
+.card-compact { padding: 0.75rem 1rem; }
+
+/* Hidden utility */
+.hidden { display: none; }
+
+/* Dashboard actions */
+.dashboard-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+
+/* Muted text */
+.text-muted { color: var(--text-muted); }
+
 /* HTMX indicator */
 .htmx-indicator { opacity: 0; transition: opacity 0.2s; }
 .htmx-request .htmx-indicator { opacity: 1; }

--- a/internal/dashboard/templates/customer/bucket_objects.html
+++ b/internal/dashboard/templates/customer/bucket_objects.html
@@ -1,0 +1,66 @@
+{{define "title"}}{{.BucketName}} — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>{{.BucketName}}</h1>
+        <p class="text-muted">{{.ObjectCount}} object{{if ne .ObjectCount 1}}s{{end}} &middot; {{.TotalSizeFmt}}</p>
+    </div>
+</div>
+
+<nav class="breadcrumb">
+    <a href="/dashboard/">Dashboard</a> /
+    <a href="/dashboard/buckets">Buckets</a> /
+    <strong>{{.BucketName}}</strong>
+</nav>
+
+{{if .Prefix}}
+<div class="card card-compact">
+    <a href="/dashboard/buckets/{{.BucketName}}{{if .ParentPrefix}}?prefix={{.ParentPrefix}}{{end}}"
+       class="btn btn-sm">&larr; Up one level</a>
+    <span class="text-muted" style="margin-left: 0.5rem;">{{.Prefix}}</span>
+</div>
+{{end}}
+
+{{if or .Prefixes .Objects}}
+<div class="table-wrap">
+    <table>
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Size</th>
+                <th>Type</th>
+                <th>Last Modified</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Prefixes}}
+            <tr>
+                <td>
+                    <a href="/dashboard/buckets/{{$.BucketName}}?prefix={{.FullPrefix}}" class="bucket-link">{{.Display}}/</a>
+                </td>
+                <td class="text-muted">—</td>
+                <td class="text-muted">prefix</td>
+                <td class="text-muted">—</td>
+            </tr>
+            {{end}}
+            {{range .Objects}}
+            <tr>
+                <td class="mono">{{.Display}}</td>
+                <td>{{.SizeFmt}}</td>
+                <td>{{.ContentType}}</td>
+                <td>{{.LastModifiedFmt}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="card">
+    <p class="text-muted empty-state">This bucket is empty.</p>
+</div>
+{{end}}
+
+<div class="dashboard-actions">
+    <a href="/dashboard/buckets" class="btn">Back to Buckets</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/customer/buckets.html
+++ b/internal/dashboard/templates/customer/buckets.html
@@ -1,0 +1,62 @@
+{{define "title"}}Buckets — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>Buckets</h1>
+        <p class="text-muted">{{.BucketCount}} bucket{{if ne .BucketCount 1}}s{{end}}</p>
+    </div>
+    <button class="btn btn-primary" onclick="document.getElementById('create-form').classList.toggle('hidden')">
+        Create Bucket
+    </button>
+</div>
+
+<div id="create-form" class="card hidden">
+    <form method="POST" action="/dashboard/buckets">
+        <div class="form-row">
+            <div class="form-group form-group-inline">
+                <label>Bucket Name</label>
+                <input type="text" name="name" pattern="[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]" required
+                       placeholder="my-bucket" title="Lowercase letters, numbers, hyphens, and dots. 3-63 characters.">
+            </div>
+            <button type="submit" class="btn btn-primary">Create</button>
+        </div>
+        {{if .CreateError}}<div class="alert alert-error">{{.CreateError}}</div>{{end}}
+        {{if .CreateSuccess}}<div class="alert alert-success">Bucket "{{.CreateSuccess}}" created.</div>{{end}}
+    </form>
+</div>
+
+{{if .Buckets}}
+<div class="table-wrap">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Objects</th>
+                <th>Size</th>
+                <th>Last Modified</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Buckets}}
+            <tr>
+                <td><a href="/dashboard/buckets/{{.Name}}" class="bucket-link">{{.Name}}</a></td>
+                <td>{{.ObjectCount}}</td>
+                <td>{{.SizeFmt}}</td>
+                <td>{{.LastModifiedFmt}}</td>
+                <td><a href="/dashboard/buckets/{{.Name}}" class="btn btn-sm">Browse</a></td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="card">
+    <p class="text-muted empty-state">No buckets yet. Create one above or upload via the S3 API.</p>
+</div>
+{{end}}
+
+<div class="dashboard-actions">
+    <a href="/dashboard/" class="btn">Back to Dashboard</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/customer/dashboard.html
+++ b/internal/dashboard/templates/customer/dashboard.html
@@ -1,0 +1,74 @@
+{{define "title"}}Dashboard — stored.ge{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Dashboard</h1>
+    <p class="text-muted">Welcome back, {{.Email}}</p>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Storage Used</div>
+        <div class="card-value">{{.StorageUsedFmt}}</div>
+        <div class="usage-bar">
+            <div class="usage-bar-fill {{.StorageBarClass}}" style="width: {{.StoragePercent}}%"></div>
+        </div>
+        <div class="card-detail">{{.StoragePercent}}% of {{.StorageLimitFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Bandwidth This Month</div>
+        <div class="card-value">{{.BandwidthTotalFmt}}</div>
+        <div class="card-detail">{{.IngressFmt}} in / {{.EgressFmt}} out</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Buckets</div>
+        <div class="card-value">{{.BucketCount}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Objects</div>
+        <div class="card-value">{{.ObjectCount}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">API Keys</div>
+        <div class="card-value">{{.APIKeyCount}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Plan</div>
+        <div class="card-value card-value-plan">{{.Tier}}</div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Recent Activity</div>
+    {{if .Activity}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Operation</th>
+                    <th>Object</th>
+                    <th>Size</th>
+                    <th>Time</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Activity}}
+                <tr>
+                    <td><span class="badge badge-{{.BadgeClass}}">{{.Operation}}</span></td>
+                    <td class="mono">{{.ObjectKey}}</td>
+                    <td>{{.SizeFmt}}</td>
+                    <td>{{.TimeFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted empty-state">No activity yet. Upload your first object to get started.</p>
+    {{end}}
+</div>
+
+<div class="dashboard-actions">
+    <a href="/dashboard/buckets" class="btn btn-primary">Browse Buckets</a>
+    <a href="/dashboard/apikeys" class="btn">Manage API Keys</a>
+</div>
+{{end}}

--- a/internal/drivers/geyser.go
+++ b/internal/drivers/geyser.go
@@ -1,36 +1,86 @@
 // internal/drivers/geyser.go
+//
+// Geyser storage driver for Spectra Logic Vail (LTO-9 tape).
+//
+// Key constraint: Vail requires Content-Length on every PUT (HTTP 411
+// otherwise). The engine wraps bodies in TeeReader chains that strip
+// length info, so we must materialise the data before uploading.
+//
+// For objects <= spillThreshold (64 MB) we buffer in RAM.
+// For larger objects we spill to a temp file on disk.
 package drivers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/FairForge/vaultaire/internal/common"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.uber.org/zap"
 )
 
+const (
+	// spillThreshold is the maximum size buffered in RAM. Objects larger
+	// than this are spilled to a temporary file to avoid OOM on GB+
+	// archive uploads.
+	spillThreshold = 64 << 20 // 64 MB
+)
+
+// GeyserDriver implements the engine.Driver interface for Geyser's
+// S3-compatible tape storage (Spectra Logic Vail).
 type GeyserDriver struct {
 	client   *s3.Client
 	bucket   string
 	tenantID string
 	logger   *zap.Logger
+	endpoint string
 }
 
-func NewGeyserDriver(accessKey, secretKey, bucket, tenantID string, logger *zap.Logger) (*GeyserDriver, error) {
-	endpoint := "https://la1.geyserdata.com"
+// GeyserOption configures a GeyserDriver.
+type GeyserOption func(*geyserOpts)
+
+type geyserOpts struct {
+	endpoint string
+}
+
+// WithGeyserEndpoint overrides the default LA endpoint.
+// Use "https://lon1.geyserdata.com" for London.
+func WithGeyserEndpoint(ep string) GeyserOption {
+	return func(o *geyserOpts) { o.endpoint = ep }
+}
+
+func NewGeyserDriver(accessKey, secretKey, bucket, tenantID string, logger *zap.Logger, options ...GeyserOption) (*GeyserDriver, error) {
+	opts := &geyserOpts{
+		endpoint: "https://la1.geyserdata.com",
+	}
+	for _, o := range options {
+		o(opts)
+	}
+
+	// Tape operations can be slow — use generous timeouts.
+	httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(t *http.Transport) {
+		t.ResponseHeaderTimeout = 5 * time.Minute
+		t.MaxIdleConnsPerHost = 10
+		t.IdleConnTimeout = 90 * time.Second
+	})
 
 	cfg, err := config.LoadDefaultConfig(context.Background(),
 		config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
 		),
-		config.WithRegion("us-west-2"), // Geyser uses us-west-2
+		config.WithRegion("us-west-2"),
+		config.WithHTTPClient(httpClient),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -38,12 +88,13 @@ func NewGeyserDriver(accessKey, secretKey, bucket, tenantID string, logger *zap.
 
 	return &GeyserDriver{
 		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
-			o.BaseEndpoint = aws.String(endpoint)
+			o.BaseEndpoint = aws.String(opts.endpoint)
 			o.UsePathStyle = true // Geyser requires path-style
 		}),
 		bucket:   bucket,
 		tenantID: tenantID,
 		logger:   logger,
+		endpoint: opts.endpoint,
 	}, nil
 }
 
@@ -78,21 +129,76 @@ func (d *GeyserDriver) Put(ctx context.Context, container, artifact string, data
 	tenantID := d.getTenantID(ctx)
 	key := d.buildKey(tenantID, container, artifact)
 
+	// Geyser's Spectra Vail gateway requires Content-Length on every PUT
+	// (HTTP 411 otherwise). We materialise the data to know the size.
+	body, contentLength, cleanup, err := materialize(data)
+	if err != nil {
+		return fmt.Errorf("geyser buffer %s: %w", key, err)
+	}
+	defer cleanup()
+
 	d.logger.Debug("geyser put",
 		zap.String("tenant_id", tenantID),
 		zap.String("bucket", d.bucket),
 		zap.String("key", key),
+		zap.Int64("size", contentLength),
 	)
 
-	_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(d.bucket),
-		Key:    aws.String(key),
-		Body:   data,
+	_, err = d.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(d.bucket),
+		Key:           aws.String(key),
+		Body:          body,
+		ContentLength: &contentLength,
 	})
 	if err != nil {
 		return fmt.Errorf("geyser put %s: %w", key, err)
 	}
 	return nil
+}
+
+// materialize reads the entire body to determine its length (required by
+// Geyser/Spectra Vail). Small objects (<=64 MB) are buffered in RAM;
+// larger objects are spilled to a temp file to avoid OOM.
+func materialize(data io.Reader) (body io.ReadSeeker, size int64, cleanup func(), err error) {
+	buf := &bytes.Buffer{}
+	n, err := io.CopyN(buf, data, spillThreshold+1)
+	if err != nil && err != io.EOF {
+		return nil, 0, func() {}, fmt.Errorf("reading body: %w", err)
+	}
+
+	if n <= spillThreshold {
+		// Fits in memory.
+		return bytes.NewReader(buf.Bytes()), n, func() {}, nil
+	}
+
+	// Large object — spill to temp file.
+	f, err := os.CreateTemp("", "geyser-put-*")
+	if err != nil {
+		return nil, 0, func() {}, fmt.Errorf("create temp file: %w", err)
+	}
+	cleanupFn := func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}
+
+	// Write what we already buffered, then stream the rest.
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		cleanupFn()
+		return nil, 0, func() {}, fmt.Errorf("write temp: %w", err)
+	}
+	written, err := io.Copy(f, data)
+	if err != nil {
+		cleanupFn()
+		return nil, 0, func() {}, fmt.Errorf("spill to disk: %w", err)
+	}
+	total := n + written
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		cleanupFn()
+		return nil, 0, func() {}, fmt.Errorf("seek temp: %w", err)
+	}
+
+	return f, total, cleanupFn, nil
 }
 
 func (d *GeyserDriver) Delete(ctx context.Context, container, artifact string) error {

--- a/internal/usage/quota_manager.go
+++ b/internal/usage/quota_manager.go
@@ -208,6 +208,7 @@ func (m *QuotaManager) GetTier(ctx context.Context, tenantID string) (string, er
 func (m *QuotaManager) UpdateTier(ctx context.Context, tenantID, newTier string) error {
 	limits := map[string]int64{
 		"starter":      1099511627776,   // 1TB
+		"vault18":      19791209299968,  // 18TB (pack size)
 		"professional": 10995116277760,  // 10TB
 		"enterprise":   109951162777600, // 100TB
 	}


### PR DESCRIPTION
## Summary

- **Phase 1.2**: Dashboard overview with real-time stats from 5 DB tables (storage, bandwidth, buckets, objects, API keys, recent activity)
- **Phase 1.3**: Bucket browser — list, create (S3-compatible name validation), object navigation with prefix-based folders
- **Geyser LTO-9 tape**: Fixed Content-Length bug, spill-to-disk for large files, 5-min timeout, configurable endpoint (LA/London), wired into main.go
- **Vault18 tier**: 18TB pack tier added to quota manager

### Benchmark Results (all backends tested this session)

| Backend | Upload | Download | Cost/TB | Integrity |
|---------|--------|----------|---------|-----------|
| Geyser LA (tape) | 7.3 MB/s | 5.9 MB/s | $1.55 | 5/5 PASS |
| Lyve US-Central-2 | 32.89 MB/s | 8.19 MB/s | $6.38 | 5/5 PASS |
| Lyve US-West-1 | 28.82 MB/s | 5.34 MB/s | $6.38 | 5/5 PASS |
| Lyve EU-West-1 | 5.81 MB/s | 2.89 MB/s | $6.38 | 5/5 PASS |
| Lyve Singapore | 4.66 MB/s | 4.71 MB/s | $6.38 | PASS |
| OneDrive fleet (2 tenants) | 14.18 MB/s | — | $0 | 0 errors |

## Test plan

- [x] `make build` — compiles clean
- [x] `make lint` — 0 issues
- [x] `go test -short -race ./internal/dashboard/...` — all pass
- [x] `go test -short -race ./internal/drivers/...` — all pass
- [x] `go test -short -race ./internal/usage/...` — all pass
- [x] Geyser smoke test: PUT/GET/LIST/DELETE + SHA256 integrity
- [x] Vaultaire→Geyser full stack: S3 operations through engine
- [x] All 6 benchmark workloads against Geyser (tape, largefile, smallfiles, integrity, mixed, soak via tape)
- [x] Lyve Cloud benchmarked across 5 regions
- [x] OneDrive fleet benchmark (2/3 tenants — tenant-2 secret expired)