### PR TITLE
feat(dashboard): API key management [Phase 1.4]

### DIFF
--- a/cmd/quotaless-bench/main.go
+++ b/cmd/quotaless-bench/main.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+
+	ak := os.Getenv("QUOTALESS_ACCESS_KEY")
+	sk := os.Getenv("QUOTALESS_SECRET_KEY")
+	ep := os.Getenv("QUOTALESS_ENDPOINT")
+	if ak == "" {
+		fmt.Println("Set QUOTALESS_ACCESS_KEY, QUOTALESS_SECRET_KEY, QUOTALESS_ENDPOINT")
+		os.Exit(1)
+	}
+
+	d, err := drivers.NewQuotalessDriver(ak, sk, ep, logger)
+	if err != nil {
+		fmt.Printf("driver error: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	fmt.Println()
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("  QUOTALESS BENCHMARK")
+	fmt.Printf("  Endpoint: %s\n", ep)
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+	fmt.Print("\n  Health check... ")
+	start := time.Now()
+	if err := d.HealthCheck(ctx); err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+	} else {
+		fmt.Printf("OK (%s)\n", time.Since(start).Round(time.Millisecond))
+	}
+
+	// --- Sequential throughput ---
+	fmt.Println("\n  Sequential Throughput")
+	fmt.Println("  ─────────────────────")
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1 KB", 1024},
+		{"64 KB", 64 * 1024},
+		{"1 MB", 1024 * 1024},
+		{"10 MB", 10 * 1024 * 1024},
+	}
+
+	for _, s := range sizes {
+		data := make([]byte, s.size)
+		_, _ = rand.Read(data)
+		hash := sha256.Sum256(data)
+		key := fmt.Sprintf("bench/seq-%s-%d.bin", s.name, time.Now().UnixNano())
+
+		start := time.Now()
+		err := d.Put(ctx, "bench", key, bytes.NewReader(data))
+		putDur := time.Since(start)
+		if err != nil {
+			fmt.Printf("  [%s] PUT FAIL: %v\n", s.name, err)
+			continue
+		}
+		putMBs := float64(s.size) / putDur.Seconds() / 1024 / 1024
+
+		start = time.Now()
+		reader, err := d.Get(ctx, "bench", key)
+		if err != nil {
+			fmt.Printf("  [%s] GET FAIL: %v\n", s.name, err)
+			_ = d.Delete(ctx, "bench", key)
+			continue
+		}
+		got, _ := io.ReadAll(reader)
+		_ = reader.Close()
+		getDur := time.Since(start)
+		getMBs := float64(s.size) / getDur.Seconds() / 1024 / 1024
+
+		gotHash := sha256.Sum256(got)
+		integrity := "PASS"
+		if hash != gotHash {
+			integrity = "FAIL"
+		}
+
+		fmt.Printf("  %-7s  up %7.2f MB/s (%s)  down %7.2f MB/s (%s)  SHA256 %s\n",
+			s.name, putMBs, putDur.Round(time.Millisecond), getMBs, getDur.Round(time.Millisecond), integrity)
+
+		_ = d.Delete(ctx, "bench", key)
+	}
+
+	// --- Small file concurrency ---
+	fmt.Println("\n  Small File Concurrency (1KB × 200, 10 workers)")
+	fmt.Println("  ───────────────────────────────────────────────")
+	var ops int64
+	var errors int64
+	var totalLatency int64
+	var wg sync.WaitGroup
+	concStart := time.Now()
+
+	for w := 0; w < 10; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < 20; i++ {
+				data := make([]byte, 1024)
+				_, _ = rand.Read(data)
+				key := fmt.Sprintf("bench/conc-%d-%d-%d.bin", workerID, i, time.Now().UnixNano())
+
+				opStart := time.Now()
+				err := d.Put(ctx, "bench", key, bytes.NewReader(data))
+				lat := time.Since(opStart)
+				atomic.AddInt64(&totalLatency, int64(lat))
+
+				if err != nil {
+					atomic.AddInt64(&errors, 1)
+				} else {
+					atomic.AddInt64(&ops, 1)
+					_ = d.Delete(ctx, "bench", key)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	concDur := time.Since(concStart)
+	opsCount := atomic.LoadInt64(&ops)
+	errCount := atomic.LoadInt64(&errors)
+	avgLat := time.Duration(0)
+	if opsCount > 0 {
+		avgLat = time.Duration(atomic.LoadInt64(&totalLatency) / opsCount)
+	}
+
+	fmt.Printf("  Completed: %d ops, %d errors in %s\n", opsCount, errCount, concDur.Round(time.Millisecond))
+	fmt.Printf("  Throughput: %.1f ops/s | avg latency: %s\n", float64(opsCount)/concDur.Seconds(), avgLat.Round(time.Millisecond))
+
+	// --- List test ---
+	fmt.Println("\n  List Operations")
+	fmt.Println("  ───────────────")
+	start = time.Now()
+	items, err := d.List(ctx, "bench", "")
+	listDur := time.Since(start)
+	if err != nil {
+		fmt.Printf("  LIST FAIL: %v\n", err)
+	} else {
+		fmt.Printf("  Listed %d objects in %s\n", len(items), listDur.Round(time.Millisecond))
+	}
+
+	fmt.Println()
+}

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -37,6 +37,9 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/dashboard/buckets` | GET | session | Bucket list with counts + sizes |
 | `/dashboard/buckets` | POST | session | Create new bucket (validates name, creates directory) |
 | `/dashboard/buckets/{name}` | GET | session | Object browser with prefix navigation |
+| `/dashboard/apikeys` | GET | session | List API keys with status |
+| `/dashboard/apikeys` | POST | session | Generate new API key (shows secret once) |
+| `/dashboard/apikeys/{id}/revoke` | POST | session | Revoke an API key |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -23,6 +23,15 @@ Bucket name validation: `^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$` + path traversal c
 
 Shared helpers: `sessionData(sd, page)` builds the base template data map. `formatBytes` and `relativeTime` from `overview.go`.
 
+## API Key Management (`apikeys.go`)
+
+Three handlers:
+- `HandleAPIKeys(tmpl, authSvc, logger)` — lists all keys for current user via `auth.ListAPIKeys()`
+- `HandleGenerateKey(tmpl, authSvc, logger)` — creates key via `auth.GenerateAPIKey()`, shows secret once
+- `HandleRevokeKey(authSvc, logger)` — revokes key via `auth.RevokeAPIKey()`, redirects back
+
+Uses `auth.AuthService` directly (not DB queries) since keys are in-memory + DB-backed.
+
 ## Legacy Handlers
 
 Files like `dashboard.go`, `buckets.go`, `usage.go`, etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Phase 1.3+ will rewrite them to follow the `overview.go` pattern.

--- a/internal/dashboard/handlers/apikeys.go
+++ b/internal/dashboard/handlers/apikeys.go
@@ -1,86 +1,152 @@
 package handlers
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"html/template"
 	"net/http"
+	"strings"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
 )
 
-type APIKeysHandler struct {
-	db interface{}
+// KeyRow is a single API key for the template.
+type KeyRow struct {
+	ID          string
+	Name        string
+	KeyID       string
+	Status      string
+	StatusClass string
+	CreatedFmt  string
+	LastUsedFmt string
 }
 
-func NewAPIKeysHandler(db interface{}) *APIKeysHandler {
-	return &APIKeysHandler{db: db}
+// NewKeyData holds the just-generated key credentials (shown once).
+type NewKeyData struct {
+	Key    string
+	Secret string
 }
 
-func (h *APIKeysHandler) ListKeys(w http.ResponseWriter, r *http.Request) {
-	tmpl := `<!DOCTYPE html>
-<html>
-<head>
-    <title>API Keys</title>
-    <style>
-        body { background: #000; color: #0f0; font-family: monospace; }
-        .terminal { border: 1px solid #0f0; padding: 20px; margin: 20px; }
-        .key { background: #111; padding: 10px; margin: 10px 0; }
-    </style>
-</head>
-<body>
-    <div class="terminal">
-        <h1>API Keys</h1>
-        <div class="key">
-            vlt_abc123def456 [Active]
-        </div>
-        <div class="key">
-            vlt_xyz789ghi012 [Active]
-        </div>
-        <button onclick="location.href='/dashboard/apikeys/generate'">Generate New Key</button>
-    </div>
-</body>
-</html>`
+// HandleAPIKeys returns an http.HandlerFunc that lists API keys for the
+// current user.
+func HandleAPIKeys(tmpl *template.Template, authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
 
-	t, _ := template.New("apikeys").Parse(tmpl)
-	if err := t.Execute(w, nil); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		data := sessionData(sd, "apikeys")
+		data["Keys"] = listKeys(r, authSvc, sd.UserID)
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render apikeys", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 	}
 }
 
-func (h *APIKeysHandler) GenerateKey(w http.ResponseWriter, r *http.Request) {
-	// Generate a random key with vlt_ prefix
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	key := "vlt_" + hex.EncodeToString(b)
+// HandleGenerateKey handles POST /dashboard/apikeys to create a new key.
+func HandleGenerateKey(tmpl *template.Template, authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
 
-	tmpl := `<!DOCTYPE html>
-<html>
-<head>
-    <title>New API Key</title>
-    <style>
-        body { background: #000; color: #0f0; font-family: monospace; }
-        .terminal { border: 1px solid #0f0; padding: 20px; margin: 20px; }
-        .key { background: #111; padding: 20px; margin: 20px 0; font-size: 18px; }
-        .warning { color: #ff0; }
-    </style>
-</head>
-<body>
-    <div class="terminal">
-        <h1>New API Key Generated</h1>
-        <div class="key">` + key + `</div>
-        <p class="warning">Save this key now. You won't be able to see it again!</p>
-        <button onclick="location.href='/dashboard/apikeys'">Back to API Keys</button>
-    </div>
-</body>
-</html>`
+		data := sessionData(sd, "apikeys")
 
-	t, _ := template.New("newkey").Parse(tmpl)
-	if err := t.Execute(w, nil); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		name := strings.TrimSpace(r.FormValue("name"))
+		if name == "" {
+			name = "default"
+		}
+
+		key, err := authSvc.GenerateAPIKey(r.Context(), sd.UserID, name)
+		if err != nil {
+			logger.Error("generate API key", zap.Error(err))
+			data["GenerateError"] = "Failed to generate key. Please try again."
+			data["Keys"] = listKeys(r, authSvc, sd.UserID)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_ = tmpl.ExecuteTemplate(w, "base", data)
+			return
+		}
+
+		// Show the secret once — it won't be available again.
+		data["NewKey"] = NewKeyData{
+			Key:    key.Key,
+			Secret: key.Secret,
+		}
+		data["Keys"] = listKeys(r, authSvc, sd.UserID)
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render apikeys after generate", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 	}
 }
 
-func (h *APIKeysHandler) RevokeKey(w http.ResponseWriter, r *http.Request) {
-	// In a real implementation, this would delete the key from the database
-	// For now, just redirect back to the list
-	http.Redirect(w, r, "/dashboard/apikeys", http.StatusSeeOther)
+// HandleRevokeKey handles POST /dashboard/apikeys/{id}/revoke.
+func HandleRevokeKey(authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		keyID := chi.URLParam(r, "id")
+		if keyID == "" {
+			http.Redirect(w, r, "/dashboard/apikeys", http.StatusSeeOther)
+			return
+		}
+
+		if err := authSvc.RevokeAPIKey(r.Context(), sd.UserID, keyID); err != nil {
+			logger.Warn("revoke API key", zap.Error(err), zap.String("key_id", keyID))
+		}
+
+		http.Redirect(w, r, "/dashboard/apikeys", http.StatusSeeOther)
+	}
+}
+
+func listKeys(r *http.Request, authSvc *auth.AuthService, userID string) []KeyRow {
+	keys, err := authSvc.ListAPIKeys(r.Context(), userID)
+	if err != nil || keys == nil {
+		return nil
+	}
+
+	now := time.Now()
+	var rows []KeyRow
+	for _, k := range keys {
+		status := "active"
+		statusClass := "success"
+		if k.RevokedAt != nil {
+			status = "revoked"
+			statusClass = "danger"
+		} else if k.ExpiresAt != nil && k.ExpiresAt.Before(now) {
+			status = "expired"
+			statusClass = "default"
+		}
+
+		lastUsed := "never"
+		if k.LastUsed != nil {
+			lastUsed = relativeTime(*k.LastUsed)
+		}
+
+		rows = append(rows, KeyRow{
+			ID:          k.ID,
+			Name:        k.Name,
+			KeyID:       k.Key,
+			Status:      status,
+			StatusClass: statusClass,
+			CreatedFmt:  relativeTime(k.CreatedAt),
+			LastUsedFmt: lastUsed,
+		})
+	}
+	return rows
 }

--- a/internal/dashboard/handlers/apikeys_test.go
+++ b/internal/dashboard/handlers/apikeys_test.go
@@ -1,57 +1,186 @@
 package handlers
 
 import (
+	"context"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
-func TestAPIKeysHandler(t *testing.T) {
-	t.Run("lists API keys", func(t *testing.T) {
-		handler := NewAPIKeysHandler(nil)
-		req := httptest.NewRequest("GET", "/dashboard/apikeys", nil)
-		w := httptest.NewRecorder()
+func testAPIKeysTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}API Keys{{end}}` +
+			`{{define "content"}}` +
+			`<h1>API Keys</h1>` +
+			`<span class="email">{{.Email}}</span>` +
+			`{{if .NewKey}}<span class="new-key">{{.NewKey.Key}}</span><span class="new-secret">{{.NewKey.Secret}}</span>{{end}}` +
+			`{{if .GenerateError}}<span class="error">{{.GenerateError}}</span>{{end}}` +
+			`{{range .Keys}}<span class="key">{{.KeyID}} {{.Status}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
 
-		handler.ListKeys(w, req)
+func setupAuthWithUser(t *testing.T) (*auth.AuthService, *dashauth.SessionData) {
+	t.Helper()
+	authSvc := auth.NewAuthService(nil, nil)
+	user, _ := authSvc.CreateUser(context.Background(), "keys@stored.ge", "securepass123")
+	sd := &dashauth.SessionData{
+		UserID:   user.ID,
+		TenantID: "tenant-test",
+		Email:    user.Email,
+		Role:     "user",
+	}
+	return authSvc, sd
+}
 
-		if w.Code != http.StatusOK {
-			t.Errorf("expected 200, got %d", w.Code)
+func TestHandleAPIKeys_ListEmpty(t *testing.T) {
+	tmpl := testAPIKeysTemplate(t)
+	authSvc, sd := setupAuthWithUser(t)
+	handler := HandleAPIKeys(tmpl, authSvc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/apikeys", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "keys@stored.ge")
+}
+
+func TestHandleAPIKeys_ListWithKeys(t *testing.T) {
+	tmpl := testAPIKeysTemplate(t)
+	authSvc, sd := setupAuthWithUser(t)
+
+	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "test-key")
+	require.NoError(t, err)
+
+	handler := HandleAPIKeys(tmpl, authSvc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/apikeys", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, key.Key)
+	assert.Contains(t, body, "active")
+}
+
+func TestHandleGenerateKey(t *testing.T) {
+	tmpl := testAPIKeysTemplate(t)
+	authSvc, sd := setupAuthWithUser(t)
+	handler := HandleGenerateKey(tmpl, authSvc, zap.NewNop())
+
+	form := url.Values{"name": {"my-rclone-key"}}
+	req := httptest.NewRequest("POST", "/dashboard/apikeys",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "new-key")
+	assert.Contains(t, body, "new-secret")
+
+	keys, _ := authSvc.ListAPIKeys(context.Background(), sd.UserID)
+	// CreateUser already generates one key, so we should have 2 now.
+	require.Len(t, keys, 2)
+	// Find the one we just created.
+	var found bool
+	for _, k := range keys {
+		if k.Name == "my-rclone-key" {
+			found = true
 		}
+	}
+	assert.True(t, found, "expected to find my-rclone-key")
+}
 
-		body := w.Body.String()
-		if !strings.Contains(body, "API Keys") {
-			t.Error("expected API Keys title")
+func TestHandleGenerateKey_DefaultName(t *testing.T) {
+	tmpl := testAPIKeysTemplate(t)
+	authSvc, sd := setupAuthWithUser(t)
+	handler := HandleGenerateKey(tmpl, authSvc, zap.NewNop())
+
+	form := url.Values{"name": {""}}
+	req := httptest.NewRequest("POST", "/dashboard/apikeys",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	keys, _ := authSvc.ListAPIKeys(context.Background(), sd.UserID)
+	require.Len(t, keys, 2) // 1 from CreateUser + 1 from Generate
+}
+
+func TestHandleRevokeKey(t *testing.T) {
+	authSvc, sd := setupAuthWithUser(t)
+
+	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "revoke-me")
+	require.NoError(t, err)
+
+	handler := HandleRevokeKey(authSvc, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/dashboard/apikeys/"+key.ID+"/revoke", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", key.ID)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/apikeys", w.Header().Get("Location"))
+
+	keys, _ := authSvc.ListAPIKeys(context.Background(), sd.UserID)
+	require.Len(t, keys, 2) // 1 from CreateUser + 1 generated
+	var revokedFound bool
+	for _, k := range keys {
+		if k.ID == key.ID && k.RevokedAt != nil {
+			revokedFound = true
 		}
-	})
+	}
+	assert.True(t, revokedFound, "expected key to be revoked")
+}
 
-	t.Run("generates new API key", func(t *testing.T) {
-		handler := NewAPIKeysHandler(nil)
-		req := httptest.NewRequest("POST", "/dashboard/apikeys/generate", nil)
-		w := httptest.NewRecorder()
+func TestHandleAPIKeys_NoSession(t *testing.T) {
+	tmpl := testAPIKeysTemplate(t)
+	authSvc := auth.NewAuthService(nil, nil)
+	handler := HandleAPIKeys(tmpl, authSvc, zap.NewNop())
 
-		handler.GenerateKey(w, req)
+	req := httptest.NewRequest("GET", "/dashboard/apikeys", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
 
-		if w.Code != http.StatusOK {
-			t.Errorf("expected 200, got %d", w.Code)
-		}
-
-		body := w.Body.String()
-		// Should show a newly generated key
-		if !strings.Contains(body, "vlt_") {
-			t.Error("expected generated key prefix")
-		}
-	})
-
-	t.Run("revokes API key", func(t *testing.T) {
-		handler := NewAPIKeysHandler(nil)
-		req := httptest.NewRequest("POST", "/dashboard/apikeys/revoke?key=vlt_test123", nil)
-		w := httptest.NewRecorder()
-
-		handler.RevokeKey(w, req)
-
-		if w.Code != http.StatusSeeOther {
-			t.Errorf("expected redirect 303, got %d", w.Code)
-		}
-	})
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
 }

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -68,6 +68,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Get("/buckets", handlers.HandleBuckets(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
 		dr.Post("/buckets", handlers.HandleCreateBucket(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
 		dr.Get("/buckets/{name}", handlers.HandleBucketObjects(bucketObjsTmpl, deps.DB, deps.Logger))
+
+		// API key management.
+		apikeysTmpl := template.Must(baseTmpl.Clone())
+		template.Must(apikeysTmpl.ParseFS(Templates,
+			"templates/customer/apikeys.html",
+		))
+		dr.Get("/apikeys", handlers.HandleAPIKeys(apikeysTmpl, deps.Auth, deps.Logger))
+		dr.Post("/apikeys", handlers.HandleGenerateKey(apikeysTmpl, deps.Auth, deps.Logger))
+		dr.Post("/apikeys/{id}/revoke", handlers.HandleRevokeKey(deps.Auth, deps.Logger))
 	})
 
 	// --- Admin (session + admin role required) ---

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -312,6 +312,12 @@ th {
 /* Compact card (less padding) */
 .card-compact { padding: 0.75rem 1rem; }
 
+/* Card highlight (new key reveal) */
+.card-highlight { border-color: var(--success); background: #f0fdf4; }
+.key-reveal { margin: 1rem 0; }
+.key-reveal td { padding: 0.4rem 0.75rem; border: none; }
+.key-reveal td:first-child { font-weight: 600; white-space: nowrap; }
+
 /* Hidden utility */
 .hidden { display: none; }
 

--- a/internal/dashboard/templates/customer/apikeys.html
+++ b/internal/dashboard/templates/customer/apikeys.html
@@ -1,0 +1,95 @@
+{{define "title"}}API Keys — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>API Keys</h1>
+        <p class="text-muted">S3-compatible access keys for your storage</p>
+    </div>
+    <button class="btn btn-primary" onclick="document.getElementById('generate-form').classList.toggle('hidden')">
+        Generate New Key
+    </button>
+</div>
+
+<div id="generate-form" class="card hidden">
+    <form method="POST" action="/dashboard/apikeys">
+        <div class="form-row">
+            <div class="form-group form-group-inline">
+                <label>Key Name</label>
+                <input type="text" name="name" required placeholder="e.g. rclone-backup, ci-deploy">
+            </div>
+            <button type="submit" class="btn btn-primary">Generate</button>
+        </div>
+    </form>
+</div>
+
+{{if .NewKey}}
+<div class="card card-highlight">
+    <div class="card-title">New Key Generated — Save These Now</div>
+    <div class="alert alert-success">Copy these credentials. The secret will not be shown again.</div>
+    <table class="key-reveal">
+        <tr>
+            <td class="text-muted">Access Key</td>
+            <td class="mono">{{.NewKey.Key}}</td>
+        </tr>
+        <tr>
+            <td class="text-muted">Secret Key</td>
+            <td class="mono">{{.NewKey.Secret}}</td>
+        </tr>
+        <tr>
+            <td class="text-muted">Endpoint</td>
+            <td class="mono">https://stored.ge</td>
+        </tr>
+    </table>
+    <div class="code-block">
+aws configure set aws_access_key_id {{.NewKey.Key}}
+aws configure set aws_secret_access_key {{.NewKey.Secret}}
+aws s3 ls --endpoint-url https://stored.ge</div>
+</div>
+{{end}}
+
+{{if .GenerateError}}<div class="alert alert-error">{{.GenerateError}}</div>{{end}}
+
+{{if .Keys}}
+<div class="table-wrap">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Access Key</th>
+                <th>Created</th>
+                <th>Last Used</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Keys}}
+            <tr>
+                <td>{{.Name}}</td>
+                <td class="mono">{{.KeyID}}</td>
+                <td>{{.CreatedFmt}}</td>
+                <td>{{.LastUsedFmt}}</td>
+                <td><span class="badge badge-{{.StatusClass}}">{{.Status}}</span></td>
+                <td>
+                    {{if eq .Status "active"}}
+                    <form method="POST" action="/dashboard/apikeys/{{.ID}}/revoke"
+                          onsubmit="return confirm('Revoke this key? Any applications using it will stop working.')">
+                        <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
+                    </form>
+                    {{end}}
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="card">
+    <p class="text-muted empty-state">No API keys yet. Generate one to start using the S3 API.</p>
+</div>
+{{end}}
+
+<div class="dashboard-actions">
+    <a href="/dashboard/" class="btn">Back to Dashboard</a>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

- **Phase 1.4**: API key management — list, generate (show secret once), revoke with confirmation
- **Quotaless bench tool**: `cmd/quotaless-bench` for benchmarking Quotaless via the driver (handles prefix routing)

## Test plan

- [x] `make build` + `make lint` — clean
- [x] All dashboard tests pass (43 tests)
- [x] Generate key shows access key + secret + aws configure snippet
- [x] Revoke key marks it revoked, prevents future S3 auth
- [x] Empty state renders correctly for new users