### PR TITLE
Phases 3.1-5.2 catch-up: admin, bandwidth tracking, CSRF + OAuth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,11 @@ GitHub Actions Deploy (`.github/workflows/deploy.yml`):
 | `STRIPE_SECRET_KEY` | — | Stripe API key (sk_test_... or sk_live_...) |
 | `STRIPE_WEBHOOK_SECRET` | — | Stripe webhook endpoint secret (whsec_...) |
 | `STRIPE_PRICE_VAULT3`, `STRIPE_PRICE_VAULT9`, etc. | — | Stripe Price IDs for each plan |
+| `GOOGLE_CLIENT_ID` | — | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | — | Google OAuth client secret |
+| `GITHUB_CLIENT_ID` | — | GitHub OAuth App client ID |
+| `GITHUB_CLIENT_SECRET` | — | GitHub OAuth App client secret |
+| `VAULTAIRE_BASE_URL` | http://localhost:8000 | Base URL for OAuth callbacks |
 
 ## Production
 

--- a/internal/api/bandwidth.go
+++ b/internal/api/bandwidth.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// countingResponseWriter wraps http.ResponseWriter to count bytes written.
+type countingResponseWriter struct {
+	http.ResponseWriter
+	bytesWritten int64
+}
+
+func (cw *countingResponseWriter) Write(b []byte) (int, error) {
+	n, err := cw.ResponseWriter.Write(b)
+	cw.bytesWritten += int64(n)
+	return n, err
+}
+
+// bandwidthEvent represents a single ingress/egress event for a tenant.
+type bandwidthEvent struct {
+	tenantID string
+	ingress  int64
+	egress   int64
+}
+
+// BandwidthTracker buffers bandwidth events and flushes them to the
+// bandwidth_usage_daily table periodically.
+type BandwidthTracker struct {
+	db     *sql.DB
+	mu     sync.Mutex
+	buffer []bandwidthEvent
+	logger *zap.Logger
+}
+
+// NewBandwidthTracker creates a new tracker. Pass nil db to buffer without flushing.
+func NewBandwidthTracker(db *sql.DB) *BandwidthTracker {
+	return &BandwidthTracker{
+		db:     db,
+		buffer: make([]bandwidthEvent, 0, 128),
+	}
+}
+
+// SetLogger sets the logger for the tracker.
+func (bt *BandwidthTracker) SetLogger(logger *zap.Logger) {
+	bt.logger = logger
+}
+
+// Record adds a bandwidth event to the buffer.
+func (bt *BandwidthTracker) Record(_ context.Context, tenantID string, ingress, egress int64) {
+	if tenantID == "" || (ingress == 0 && egress == 0) {
+		return
+	}
+
+	bt.mu.Lock()
+	bt.buffer = append(bt.buffer, bandwidthEvent{
+		tenantID: tenantID,
+		ingress:  ingress,
+		egress:   egress,
+	})
+	needsFlush := len(bt.buffer) >= 100
+	bt.mu.Unlock()
+
+	if needsFlush {
+		bt.Flush()
+	}
+}
+
+// StartFlusher runs a background goroutine that flushes the buffer every interval.
+// It stops when ctx is cancelled.
+func (bt *BandwidthTracker) StartFlusher(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				bt.Flush() // Final flush on shutdown.
+				return
+			case <-ticker.C:
+				bt.Flush()
+			}
+		}
+	}()
+}
+
+// Flush writes all buffered events to the database, aggregated by tenant+date.
+func (bt *BandwidthTracker) Flush() {
+	bt.mu.Lock()
+	if len(bt.buffer) == 0 {
+		bt.mu.Unlock()
+		return
+	}
+	events := bt.buffer
+	bt.buffer = make([]bandwidthEvent, 0, 128)
+	bt.mu.Unlock()
+
+	if bt.db == nil {
+		return
+	}
+
+	// Aggregate by tenant ID (all events are for today).
+	type agg struct {
+		ingress  int64
+		egress   int64
+		requests int
+	}
+	totals := make(map[string]*agg)
+	for _, e := range events {
+		a, ok := totals[e.tenantID]
+		if !ok {
+			a = &agg{}
+			totals[e.tenantID] = a
+		}
+		a.ingress += e.ingress
+		a.egress += e.egress
+		a.requests++
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for tenantID, a := range totals {
+		_, err := bt.db.ExecContext(ctx, `
+			INSERT INTO bandwidth_usage_daily (tenant_id, date, ingress_bytes, egress_bytes, requests_count)
+			VALUES ($1, CURRENT_DATE, $2, $3, $4)
+			ON CONFLICT (tenant_id, date)
+			DO UPDATE SET
+				ingress_bytes = bandwidth_usage_daily.ingress_bytes + EXCLUDED.ingress_bytes,
+				egress_bytes = bandwidth_usage_daily.egress_bytes + EXCLUDED.egress_bytes,
+				requests_count = bandwidth_usage_daily.requests_count + EXCLUDED.requests_count
+		`, tenantID, a.ingress, a.egress, a.requests)
+		if err != nil && bt.logger != nil {
+			bt.logger.Error("flush bandwidth",
+				zap.String("tenant_id", tenantID), zap.Error(err))
+		}
+	}
+}

--- a/internal/api/bandwidth.go
+++ b/internal/api/bandwidth.go
@@ -89,6 +89,37 @@ func (bt *BandwidthTracker) StartFlusher(ctx context.Context, interval time.Dura
 	}()
 }
 
+// IsOverLimit checks if a tenant has exceeded their monthly bandwidth limit.
+// Returns false (allows access) if DB is nil or on any error (fail open).
+func (bt *BandwidthTracker) IsOverLimit(ctx context.Context, tenantID string) bool {
+	if bt.db == nil {
+		return false
+	}
+
+	var usedBytes, limitBytes sql.NullInt64
+	err := bt.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(b.ingress_bytes + b.egress_bytes), 0),
+			q.bandwidth_limit_bytes
+		FROM tenant_quotas q
+		LEFT JOIN bandwidth_usage_daily b
+			ON b.tenant_id = q.tenant_id
+			AND b.date >= date_trunc('month', CURRENT_DATE)
+		WHERE q.tenant_id = $1
+		GROUP BY q.bandwidth_limit_bytes
+	`, tenantID).Scan(&usedBytes, &limitBytes)
+	if err != nil {
+		return false // fail open
+	}
+
+	// No limit set means unlimited bandwidth.
+	if !limitBytes.Valid || limitBytes.Int64 <= 0 {
+		return false
+	}
+
+	return usedBytes.Valid && usedBytes.Int64 >= limitBytes.Int64
+}
+
 // Flush writes all buffered events to the database, aggregated by tenant+date.
 func (bt *BandwidthTracker) Flush() {
 	bt.mu.Lock()

--- a/internal/api/bandwidth_test.go
+++ b/internal/api/bandwidth_test.go
@@ -71,3 +71,18 @@ func TestBandwidthTracker_AggregatesByTenantAndDate(t *testing.T) {
 	assert.Equal(t, int64(400), totalIngress)
 	assert.Equal(t, int64(600), totalEgress)
 }
+
+func TestCheckBandwidthLimit_NilDB(t *testing.T) {
+	// Nil DB should always allow (fail open).
+	bt := NewBandwidthTracker(nil)
+	assert.False(t, bt.IsOverLimit(context.Background(), "tenant-1"))
+}
+
+func TestWriteS3Error_BandwidthExceeded(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteS3Error(w, ErrSlowDown, "/test", "req-1")
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>SlowDown</Code>")
+	assert.Contains(t, w.Body.String(), "bandwidth")
+}

--- a/internal/api/bandwidth_test.go
+++ b/internal/api/bandwidth_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountingResponseWriter_CountsBytes(t *testing.T) {
+	// Arrange
+	w := httptest.NewRecorder()
+	cw := &countingResponseWriter{ResponseWriter: w}
+
+	// Act
+	n1, _ := cw.Write([]byte("hello"))
+	n2, _ := cw.Write([]byte(" world"))
+
+	// Assert
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, 6, n2)
+	assert.Equal(t, int64(11), cw.bytesWritten)
+	assert.Equal(t, "hello world", w.Body.String())
+}
+
+func TestCountingResponseWriter_PreservesStatusCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	cw := &countingResponseWriter{ResponseWriter: w}
+
+	cw.WriteHeader(http.StatusNotFound)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestBandwidthTracker_RecordAndFlush(t *testing.T) {
+	// Arrange
+	bt := NewBandwidthTracker(nil) // nil DB — will buffer but not flush to DB
+
+	// Act
+	bt.Record(context.Background(), "tenant-1", 1000, 0)
+	bt.Record(context.Background(), "tenant-1", 500, 2000)
+	bt.Record(context.Background(), "tenant-2", 0, 300)
+
+	// Assert — check buffered events
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	require.Len(t, bt.buffer, 3)
+	assert.Equal(t, "tenant-1", bt.buffer[0].tenantID)
+	assert.Equal(t, int64(1000), bt.buffer[0].ingress)
+	assert.Equal(t, int64(0), bt.buffer[0].egress)
+}
+
+func TestBandwidthTracker_AggregatesByTenantAndDate(t *testing.T) {
+	// Arrange
+	bt := NewBandwidthTracker(nil)
+
+	// Act — multiple records for same tenant
+	bt.Record(context.Background(), "tenant-1", 100, 200)
+	bt.Record(context.Background(), "tenant-1", 300, 400)
+
+	// Assert
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	assert.Len(t, bt.buffer, 2)
+	// Total should be 400 ingress, 600 egress when flushed
+	totalIngress := bt.buffer[0].ingress + bt.buffer[1].ingress
+	totalEgress := bt.buffer[0].egress + bt.buffer[1].egress
+	assert.Equal(t, int64(400), totalIngress)
+	assert.Equal(t, int64(600), totalEgress)
+}

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -2,8 +2,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"strings"
@@ -15,6 +17,13 @@ import (
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
 )
+
+// xmlEscape escapes a string for safe inclusion in XML element content.
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
+}
 
 // S3Request represents a parsed S3 API request
 type S3Request struct {
@@ -199,13 +208,15 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 
 			w.Header().Set("Content-Type", "application/xml")
 			w.WriteHeader(http.StatusForbidden)
-			if _, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+			// Escape the error message to prevent XML/XSS injection.
+			safeMsg := xmlEscape(err.Error())
+			if _, werr := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
 <Error>
     <Code>SignatureDoesNotMatch</Code>
     <Message>%s</Message>
     <RequestId>%d</RequestId>
-</Error>`, err.Error(), time.Now().UnixNano()); err != nil { // #nosec G705 — S3 XML protocol output
-				s.logger.Error("failed to write response", zap.Error(err))
+</Error>`, safeMsg, time.Now().UnixNano()); werr != nil {
+				s.logger.Error("failed to write response", zap.Error(werr))
 			}
 			return
 		}

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -315,37 +315,54 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	// Wrap response writer to count egress bytes for bandwidth tracking.
+	cw := &countingResponseWriter{ResponseWriter: w}
+
+	// Track ingress bytes from PUT/UploadPart request bodies.
+	var ingressBytes int64
+	if s3Req.Operation == "PutObject" || s3Req.Operation == "UploadPart" {
+		ingressBytes = r.ContentLength
+		if ingressBytes < 0 {
+			ingressBytes = 0
+		}
+	}
+
 	switch s3Req.Operation {
 	case "GetObject":
-		s.handleGetObject(w, r, s3Req)
+		s.handleGetObject(cw, r, s3Req)
 	case "HeadObject":
-		s.handleHeadObject(w, r, s3Req)
+		s.handleHeadObject(cw, r, s3Req)
 	case "PutObject":
-		s.handlePutObject(w, r, s3Req)
+		s.handlePutObject(cw, r, s3Req)
 	case "DeleteObject":
-		s.handleDeleteObject(w, r, s3Req)
+		s.handleDeleteObject(cw, r, s3Req)
 	case "ListObjects":
-		s.handleListObjects(w, r, s3Req)
+		s.handleListObjects(cw, r, s3Req)
 	case "ListBuckets":
-		s.handleListBuckets(w, r, s3Req)
+		s.handleListBuckets(cw, r, s3Req)
 	case "CreateBucket":
-		s.CreateBucket(w, r)
+		s.CreateBucket(cw, r)
 	case "DeleteBucket":
-		s.DeleteBucket(w, r)
+		s.DeleteBucket(cw, r)
 	case "InitiateMultipartUpload":
-		s.handleInitiateMultipartUpload(w, r, s3Req.Bucket, s3Req.Object)
+		s.handleInitiateMultipartUpload(cw, r, s3Req.Bucket, s3Req.Object)
 	case "UploadPart":
-		s.handleUploadPart(w, r, s3Req.Bucket, s3Req.Object)
+		s.handleUploadPart(cw, r, s3Req.Bucket, s3Req.Object)
 	case "CompleteMultipartUpload":
-		s.handleCompleteMultipartUpload(w, r, s3Req.Bucket, s3Req.Object)
+		s.handleCompleteMultipartUpload(cw, r, s3Req.Bucket, s3Req.Object)
 	case "AbortMultipartUpload":
-		s.handleAbortMultipartUpload(w, r, s3Req.Bucket, s3Req.Object)
+		s.handleAbortMultipartUpload(cw, r, s3Req.Bucket, s3Req.Object)
 	case "ListParts":
-		s.handleListParts(w, r, s3Req.Bucket, s3Req.Object)
+		s.handleListParts(cw, r, s3Req.Bucket, s3Req.Object)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))
-		WriteS3Error(w, ErrNotImplemented, r.URL.Path, generateRequestID())
+		WriteS3Error(cw, ErrNotImplemented, r.URL.Path, generateRequestID())
+	}
+
+	// Record bandwidth for authenticated requests.
+	if tenantID != "" && tenantID != "default" && s.bandwidthTracker != nil {
+		s.bandwidthTracker.Record(r.Context(), tenantID, ingressBytes, cw.bytesWritten)
 	}
 }
 

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -225,6 +225,15 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 			zap.String("tenant_id", tenantID),
 			zap.String("method", r.Method),
 			zap.String("path", r.URL.Path))
+
+		// Phase 3.4: check if tenant is suspended before processing request.
+		if s.db != nil && isTenantSuspended(r.Context(), s.db, tenantID) {
+			s.logger.Warn("suspended tenant attempted S3 request",
+				zap.String("tenant_id", tenantID),
+				zap.String("path", r.URL.Path))
+			WriteS3Error(w, ErrAccountSuspended, r.URL.Path, generateRequestID())
+			return
+		}
 	} else {
 		s.logger.Debug("anonymous request",
 			zap.String("method", r.Method),
@@ -437,4 +446,15 @@ func (s *Server) handleListObjects(w http.ResponseWriter, r *http.Request, req *
 // handleListBuckets handles listing all buckets
 func (s *Server) handleListBuckets(w http.ResponseWriter, r *http.Request, req *S3Request) {
 	s.ListBuckets(w, r)
+}
+
+// isTenantSuspended checks if a tenant has been suspended by an admin.
+func isTenantSuspended(ctx context.Context, db *sql.DB, tenantID string) bool {
+	var suspendedAt sql.NullTime
+	err := db.QueryRowContext(ctx,
+		`SELECT suspended_at FROM tenants WHERE id = $1`, tenantID).Scan(&suspendedAt)
+	if err != nil {
+		return false // fail open — if we can't check, allow access
+	}
+	return suspendedAt.Valid
 }

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -315,6 +315,19 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	// Phase 4.2: check bandwidth limit before data-transfer operations.
+	if tenantID != "" && tenantID != "default" && s.bandwidthTracker != nil {
+		if s3Req.Operation == "GetObject" || s3Req.Operation == "PutObject" || s3Req.Operation == "UploadPart" {
+			if s.bandwidthTracker.IsOverLimit(r.Context(), tenantID) {
+				s.logger.Warn("bandwidth limit exceeded",
+					zap.String("tenant_id", tenantID),
+					zap.String("operation", s3Req.Operation))
+				WriteS3Error(w, ErrSlowDown, r.URL.Path, generateRequestID())
+				return
+			}
+		}
+	}
+
 	// Wrap response writer to count egress bytes for bandwidth tracking.
 	cw := &countingResponseWriter{ResponseWriter: w}
 

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -37,6 +37,7 @@ const (
 	ErrMethodNotAllowed      = "MethodNotAllowed"
 	ErrSignatureDoesNotMatch = "SignatureDoesNotMatch"
 	ErrAccountSuspended      = "AccountSuspended"
+	ErrSlowDown              = "SlowDown"
 )
 
 // Error messages
@@ -60,6 +61,7 @@ var errorMessages = map[string]string{
 	ErrMethodNotAllowed:      "The specified method is not allowed against this resource",
 	ErrSignatureDoesNotMatch: "The request signature we calculated does not match the signature you provided",
 	ErrAccountSuspended:      "Your account has been suspended. Contact support for assistance.",
+	ErrSlowDown:              "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
 }
 
 // HTTP status codes for errors
@@ -83,6 +85,7 @@ var errorStatusCodes = map[string]int{
 	ErrMethodNotAllowed:      http.StatusMethodNotAllowed,
 	ErrSignatureDoesNotMatch: http.StatusForbidden,
 	ErrAccountSuspended:      http.StatusForbidden,
+	ErrSlowDown:              http.StatusTooManyRequests,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -36,6 +36,7 @@ const (
 	ErrMalformedXML          = "MalformedXML"
 	ErrMethodNotAllowed      = "MethodNotAllowed"
 	ErrSignatureDoesNotMatch = "SignatureDoesNotMatch"
+	ErrAccountSuspended      = "AccountSuspended"
 )
 
 // Error messages
@@ -58,6 +59,7 @@ var errorMessages = map[string]string{
 	ErrMalformedXML:          "The XML you provided was not well-formed or did not validate against our published schema",
 	ErrMethodNotAllowed:      "The specified method is not allowed against this resource",
 	ErrSignatureDoesNotMatch: "The request signature we calculated does not match the signature you provided",
+	ErrAccountSuspended:      "Your account has been suspended. Contact support for assistance.",
 }
 
 // HTTP status codes for errors
@@ -80,6 +82,7 @@ var errorStatusCodes = map[string]int{
 	ErrMalformedXML:          http.StatusBadRequest,
 	ErrMethodNotAllowed:      http.StatusMethodNotAllowed,
 	ErrSignatureDoesNotMatch: http.StatusForbidden,
+	ErrAccountSuspended:      http.StatusForbidden,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,6 +25,19 @@ import (
 	"github.com/FairForge/vaultaire/internal/rbac"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+// OAuth provider endpoints.
+var (
+	googleEndpoint = oauth2.Endpoint{
+		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL: "https://oauth2.googleapis.com/token",
+	}
+	githubEndpoint = oauth2.Endpoint{
+		AuthURL:  "https://github.com/login/oauth/authorize",
+		TokenURL: "https://github.com/login/oauth/access_token",
+	}
 )
 
 type Server struct {
@@ -47,6 +60,8 @@ type Server struct {
 	healthChecker    *BackendHealthChecker
 	sessionStore     dashauth.SessionStore
 	bandwidthTracker *BandwidthTracker
+	googleOAuth      *oauth2.Config
+	githubOAuth      *oauth2.Config
 	startTime        time.Time
 }
 
@@ -125,6 +140,32 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		registerStripePlans(s.stripe)
 
 		logger.Info("stripe billing service initialized")
+	}
+
+	// OAuth providers. Only active when client ID+secret are set.
+	baseURL := os.Getenv("VAULTAIRE_BASE_URL")
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://localhost:%d", cfg.Server.Port)
+	}
+	if googleID := os.Getenv("GOOGLE_CLIENT_ID"); googleID != "" {
+		s.googleOAuth = &oauth2.Config{
+			ClientID:     googleID,
+			ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+			RedirectURL:  baseURL + "/auth/google/callback",
+			Scopes:       []string{"openid", "email", "profile"},
+			Endpoint:     googleEndpoint,
+		}
+		logger.Info("google oauth initialized")
+	}
+	if githubID := os.Getenv("GITHUB_CLIENT_ID"); githubID != "" {
+		s.githubOAuth = &oauth2.Config{
+			ClientID:     githubID,
+			ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
+			RedirectURL:  baseURL + "/auth/github/callback",
+			Scopes:       []string{"user:email"},
+			Endpoint:     githubEndpoint,
+		}
+		logger.Info("github oauth initialized")
 	}
 
 	s.rbacService = NewRBACService(logger)
@@ -323,6 +364,8 @@ func (s *Server) setupRoutes() {
 		Logger:   s.logger,
 		DataPath: dataPath,
 		Stripe:   s.stripe,
+		Google:   s.googleOAuth,
+		GitHub:   s.githubOAuth,
 	})
 
 	s.logger.Info("Registering S3 catch-all handler")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -28,25 +28,26 @@ import (
 )
 
 type Server struct {
-	config         *config.Config
-	logger         *zap.Logger
-	router         chi.Router
-	httpServer     *http.Server
-	db             *sql.DB
-	events         chan Event
-	engine         *engine.CoreEngine
-	quotaManager   QuotaManager
-	rbacService    *RBACService
-	auth           *auth.AuthService
-	auditLogger    *auth.AuditLogger
-	stripe         *billing.StripeService
-	webhookHandler *billing.WebhookHandler
-	requestCount   int64
-	testMode       bool
-	errorCount     int64
-	healthChecker  *BackendHealthChecker
-	sessionStore   dashauth.SessionStore
-	startTime      time.Time
+	config           *config.Config
+	logger           *zap.Logger
+	router           chi.Router
+	httpServer       *http.Server
+	db               *sql.DB
+	events           chan Event
+	engine           *engine.CoreEngine
+	quotaManager     QuotaManager
+	rbacService      *RBACService
+	auth             *auth.AuthService
+	auditLogger      *auth.AuditLogger
+	stripe           *billing.StripeService
+	webhookHandler   *billing.WebhookHandler
+	requestCount     int64
+	testMode         bool
+	errorCount       int64
+	healthChecker    *BackendHealthChecker
+	sessionStore     dashauth.SessionStore
+	bandwidthTracker *BandwidthTracker
+	startTime        time.Time
 }
 
 type QuotaManager interface {
@@ -107,6 +108,11 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	} else {
 		s.sessionStore = dashauth.NewMemoryStore()
 	}
+
+	// Bandwidth tracker — buffers S3 bandwidth events and flushes to DB.
+	s.bandwidthTracker = NewBandwidthTracker(s.db)
+	s.bandwidthTracker.SetLogger(logger)
+	s.bandwidthTracker.StartFlusher(context.Background(), 5*time.Second)
 
 	// Stripe billing service. Only active when STRIPE_SECRET_KEY is set.
 	if stripeKey := os.Getenv("STRIPE_SECRET_KEY"); stripeKey != "" {

--- a/internal/api/suspension_test.go
+++ b/internal/api/suspension_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteS3Error_AccountSuspended(t *testing.T) {
+	// Arrange
+	w := httptest.NewRecorder()
+
+	// Act
+	WriteS3Error(w, ErrAccountSuspended, "/test-bucket/test.txt", "req-123")
+
+	// Assert
+	assert.Equal(t, 403, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "<Code>AccountSuspended</Code>")
+	assert.Contains(t, body, "suspended")
+	assert.Equal(t, "application/xml", w.Header().Get("Content-Type"))
+}
+
+func TestIsTenantSuspended_NilDB(t *testing.T) {
+	// isTenantSuspended should fail open (return false) when DB is nil.
+	// Can't call with nil db (would panic), so we just verify the function exists
+	// and the error codes are properly registered.
+	assert.Equal(t, "Your account has been suspended. Contact support for assistance.", errorMessages[ErrAccountSuspended])
+	assert.Equal(t, 403, errorStatusCodes[ErrAccountSuspended])
+}
+
+func TestWriteS3Error_AccessDenied(t *testing.T) {
+	// Verify existing AccessDenied still works alongside new AccountSuspended.
+	w := httptest.NewRecorder()
+	WriteS3Error(w, ErrAccessDenied, "/bucket", "req-456")
+
+	assert.Equal(t, 403, w.Code)
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, "<Code>AccessDenied</Code>"))
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -201,17 +201,21 @@ func (a *AuthService) CreateUserWithTenant(ctx context.Context, email, password,
 		return nil, nil, nil, fmt.Errorf("user already exists")
 	}
 
-	// Hash password
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("hash password: %w", err)
+	// Hash password (empty for OAuth-only users).
+	var hashStr string
+	if password != "" {
+		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("hash password: %w", err)
+		}
+		hashStr = string(hash)
 	}
 
 	// Create user
 	user := &User{
 		ID:           uuid.New().String(),
 		Email:        email,
-		PasswordHash: string(hash),
+		PasswordHash: hashStr,
 		Company:      company,
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
@@ -312,6 +316,11 @@ func (a *AuthService) ValidatePassword(ctx context.Context, email, password stri
 		return false, nil
 	}
 
+	// OAuth-only users have no password — reject login via password form.
+	if user.PasswordHash == "" {
+		return false, nil
+	}
+
 	err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password))
 	if err == bcrypt.ErrMismatchedHashAndPassword {
 		return false, nil
@@ -371,6 +380,57 @@ func (a *AuthService) GetUserByID(ctx context.Context, userID string) (*User, er
 		return nil, fmt.Errorf("user not found")
 	}
 	return user, nil
+}
+
+// GetUserByOAuth looks up a user by OAuth provider and provider ID.
+// Returns nil, nil if no linked account is found.
+func (a *AuthService) GetUserByOAuth(ctx context.Context, provider, providerID string) (*User, error) {
+	if a.sqlDB == nil {
+		return nil, nil
+	}
+	var userID string
+	err := a.sqlDB.QueryRowContext(ctx,
+		`SELECT user_id FROM oauth_accounts WHERE provider = $1 AND provider_id = $2`,
+		provider, providerID).Scan(&userID)
+	if err != nil {
+		return nil, nil //nolint:nilerr // not found is not an error
+	}
+	user, exists := a.userIndex[userID]
+	if !exists {
+		return nil, nil
+	}
+	return user, nil
+}
+
+// LinkOAuthAccount associates an OAuth provider account with an existing user.
+func (a *AuthService) LinkOAuthAccount(ctx context.Context, userID, provider, providerID, email, name string) error {
+	if a.sqlDB == nil {
+		return nil
+	}
+	_, err := a.sqlDB.ExecContext(ctx,
+		`INSERT INTO oauth_accounts (user_id, provider, provider_id, email, name)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (provider, provider_id) DO NOTHING`,
+		userID, provider, providerID, email, name)
+	if err != nil {
+		return fmt.Errorf("link oauth account: %w", err)
+	}
+	return nil
+}
+
+// CreateUserFromOAuth creates a new user+tenant via OAuth (no password).
+// Also links the OAuth account.
+func (a *AuthService) CreateUserFromOAuth(ctx context.Context, email, company, provider, providerID string) (*User, *Tenant, error) {
+	user, tenant, _, err := a.CreateUserWithTenant(ctx, email, "", company)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create oauth user: %w", err)
+	}
+
+	if err := a.LinkOAuthAccount(ctx, user.ID, provider, providerID, email, company); err != nil {
+		return nil, nil, fmt.Errorf("link oauth on create: %w", err)
+	}
+
+	return user, tenant, nil
 }
 
 // ValidateS3Request validates S3 API requests and returns tenant

--- a/internal/cache/recovery.go
+++ b/internal/cache/recovery.go
@@ -155,15 +155,16 @@ func (c *SSDCache) CleanOrphanedFiles() (*IntegrityReport, error) {
 	for i := 0; i < c.shardCount; i++ {
 		shardPath := filepath.Join(c.ssdPath, fmt.Sprintf("shard-%d", i))
 
-		err := filepath.Walk(shardPath, func(path string, info os.FileInfo, err error) error { // #nosec G122 — recovery scan is admin-only, symlink traversal is acceptable
+		err := filepath.Walk(shardPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".cache") {
 				return nil
 			}
 
 			if !validPaths[path] {
-				// Move to orphaned directory
+				// Move to orphaned directory.
+				// #nosec G122 — recovery scan is admin-only, symlink traversal is acceptable
 				newPath := filepath.Join(orphanedDir, filepath.Base(path))
-				if err := os.Rename(path, newPath); err == nil {
+				if err := os.Rename(path, newPath); err == nil { // #nosec G122
 					report.OrphanedFiles++
 					report.SpaceReclaimed += info.Size()
 				}

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -48,6 +48,7 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/dashboard/billing` | GET | session | Billing: plan, upgrade, value stack, cost comparison |
 | `/dashboard/billing/upgrade` | POST | session | Redirect to Stripe Checkout for chosen plan |
 | `/dashboard/billing/portal` | POST | session | Redirect to Stripe Billing Portal |
+| `/admin/tenants/{id}/bandwidth-limit` | POST | session + admin | Update tenant bandwidth limit |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -32,6 +32,15 @@ Three handlers:
 
 Uses `auth.AuthService` directly (not DB queries) since keys are in-memory + DB-backed.
 
+## Bandwidth Chart (`bandwidth_chart.go`)
+
+Shared bandwidth chart logic used by both customer usage page and admin tenant detail:
+- `ChartBar` — SVG bar coordinates struct
+- `BandwidthDay` — date + ingress/egress totals
+- `BuildChartBars(days)` — pure function: converts bandwidth days to SVG bar data (600x200 chart area)
+- `QueryBandwidthDays(ctx, db, tenantID)` — fetches last 30 days from `bandwidth_usage_daily`
+- `QueryMonthBandwidth(ctx, db, tenantID)` — current month ingress/egress/requests totals
+
 ## Usage Page (`usage.go`)
 
 `HandleUsage(tmpl, db, logger)` renders the detailed usage page:
@@ -40,6 +49,7 @@ Uses `auth.AuthService` directly (not DB queries) since keys are in-memory + DB-
 - 30-day SVG bar chart (stacked ingress/egress bars, server-rendered)
 - Daily breakdown table (date, ingress, egress, total, requests)
 - htmx auto-refresh on chart via `hx-trigger="every 30s"`
+- Delegates to shared `bandwidth_chart.go` functions for chart building and bandwidth queries
 
 Queries: `tenant_quotas`, `bandwidth_usage_daily` (30 days). Chart bars are `ChartBar` structs with pre-computed SVG coordinates.
 

--- a/internal/dashboard/handlers/admin.go
+++ b/internal/dashboard/handlers/admin.go
@@ -21,6 +21,7 @@ func HandleAdminOverview(tmpl *template.Template, db *sql.DB, logger *zap.Logger
 		}
 
 		data := sessionData(sd, "admin-overview")
+		withCSRF(r.Context(), data)
 		data["TenantCount"] = 0
 		data["TotalStorageFmt"] = "0 B"
 		data["ActiveSubCount"] = 0

--- a/internal/dashboard/handlers/admin.go
+++ b/internal/dashboard/handlers/admin.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// HandleAdminOverview renders the admin dashboard overview page.
+func HandleAdminOverview(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-overview")
+		data["TenantCount"] = 0
+		data["TotalStorageFmt"] = "0 B"
+		data["ActiveSubCount"] = 0
+		data["MonthlyRevenue"] = "$0.00"
+
+		if db != nil {
+			data["TenantCount"], data["TotalStorageFmt"],
+				data["ActiveSubCount"], data["MonthlyRevenue"] = queryAdminStats(r.Context(), db, logger)
+			data["RecentUsers"] = queryRecentUsers(r.Context(), db, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin overview", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+type recentUser struct {
+	Email         string
+	Company       string
+	Plan          string
+	RegisteredFmt string
+}
+
+func queryAdminStats(ctx context.Context, db *sql.DB, logger *zap.Logger) (int, string, int, string) {
+	var tenantCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenants`).Scan(&tenantCount); err != nil {
+		logger.Debug("admin: count tenants", zap.Error(err))
+	}
+
+	var totalBytes int64
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(used_bytes), 0) FROM tenant_quotas`).Scan(&totalBytes); err != nil {
+		logger.Debug("admin: sum storage", zap.Error(err))
+	}
+
+	var activeSubCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tenants WHERE subscription_status = 'active'`).Scan(&activeSubCount); err != nil {
+		logger.Debug("admin: count active subs", zap.Error(err))
+	}
+
+	// Estimate revenue from active Vault subscriptions.
+	var revenueCents int64
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(CASE
+			WHEN plan = 'vault3' THEN 299
+			WHEN plan = 'vault9' THEN 900
+			WHEN plan = 'vault18' THEN 1800
+			WHEN plan = 'vault36' THEN 3600
+			ELSE 0
+		END), 0) FROM tenants WHERE subscription_status = 'active'
+	`).Scan(&revenueCents); err != nil {
+		logger.Debug("admin: estimate revenue", zap.Error(err))
+	}
+
+	return tenantCount, formatBytes(totalBytes), activeSubCount,
+		fmt.Sprintf("$%.2f", float64(revenueCents)/100)
+}
+
+func queryRecentUsers(ctx context.Context, db *sql.DB, logger *zap.Logger) []recentUser {
+	rows, err := db.QueryContext(ctx, `
+		SELECT u.email, COALESCE(u.company, ''), COALESCE(t.plan, 'free'), u.created_at
+		FROM users u
+		LEFT JOIN tenants t ON t.id = u.tenant_id
+		ORDER BY u.created_at DESC
+		LIMIT 10
+	`)
+	if err != nil {
+		logger.Debug("admin: recent users", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var users []recentUser
+	for rows.Next() {
+		var u recentUser
+		var created sql.NullTime
+		if err := rows.Scan(&u.Email, &u.Company, &u.Plan, &created); err != nil {
+			continue
+		}
+		if created.Valid {
+			u.RegisteredFmt = relativeTime(created.Time)
+		}
+		users = append(users, u)
+	}
+	return users
+}

--- a/internal/dashboard/handlers/admin_system.go
+++ b/internal/dashboard/handlers/admin_system.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"runtime"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// HandleAdminSystem renders the admin system health page with runtime
+// and database connection pool stats.
+func HandleAdminSystem(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	startTime := time.Now()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-system")
+
+		// Go runtime stats.
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		data["Goroutines"] = runtime.NumGoroutine()
+		data["MemAllocFmt"] = formatBytes(int64(mem.Alloc))
+		data["MemSysFmt"] = formatBytes(int64(mem.Sys))
+		data["NumGC"] = mem.NumGC
+		data["GoVersion"] = runtime.Version()
+		data["Uptime"] = time.Since(startTime).Truncate(time.Second).String()
+
+		// DB connection pool stats.
+		if db != nil {
+			stats := db.Stats()
+			data["DBOpen"] = stats.OpenConnections
+			data["DBInUse"] = stats.InUse
+			data["DBIdle"] = stats.Idle
+			data["DBMaxOpen"] = stats.MaxOpenConnections
+			data["DBWaitCount"] = stats.WaitCount
+			data["DBStatus"] = "connected"
+		} else {
+			data["DBStatus"] = "not connected"
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin system", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}

--- a/internal/dashboard/handlers/admin_system.go
+++ b/internal/dashboard/handlers/admin_system.go
@@ -24,6 +24,7 @@ func HandleAdminSystem(tmpl *template.Template, db *sql.DB, logger *zap.Logger) 
 		}
 
 		data := sessionData(sd, "admin-system")
+		withCSRF(r.Context(), data)
 
 		// Go runtime stats.
 		var mem runtime.MemStats

--- a/internal/dashboard/handlers/admin_system_test.go
+++ b/internal/dashboard/handlers/admin_system_test.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func testAdminSystemTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}System{{end}}` +
+			`{{define "content"}}` +
+			`<h1>System Health</h1>` +
+			`<span class="goroutines">{{.Goroutines}}</span>` +
+			`<span class="memory">{{.MemAllocFmt}}</span>` +
+			`<span class="gc">{{.NumGC}}</span>` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleAdminSystem_NoSession(t *testing.T) {
+	handler := HandleAdminSystem(testAdminSystemTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/system", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminSystem_AdminSession(t *testing.T) {
+	handler := HandleAdminSystem(testAdminSystemTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/system", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "System Health")
+	// Runtime stats should always have values.
+	assert.NotContains(t, body, `<span class="goroutines">0</span>`)
+	assert.NotContains(t, body, `<span class="memory">0 B</span>`)
+}

--- a/internal/dashboard/handlers/admin_test.go
+++ b/internal/dashboard/handlers/admin_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testAdminTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	// Minimal admin layout + content template for testing.
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Admin{{end}}` +
+			`{{define "content"}}` +
+			`<h1>Admin Overview</h1>` +
+			`<span class="email">{{.Email}}</span>` +
+			`<span class="role">{{.Role}}</span>` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleAdminOverview_AdminSession(t *testing.T) {
+	// Arrange
+	tmpl := testAdminTemplate(t)
+	handler := HandleAdminOverview(tmpl, nil, zap.NewNop())
+
+	store := dashauth.NewMemoryStore()
+	token, err := store.Create(context.Background(), dashauth.SessionData{
+		UserID:   "admin-1",
+		TenantID: "tenant-1",
+		Email:    "admin@stored.ge",
+		Role:     "admin",
+	}, time.Hour)
+	require.NoError(t, err)
+
+	sd, err := store.Get(context.Background(), token)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/admin/", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	// Act
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Admin Overview")
+	assert.Contains(t, body, "admin@stored.ge")
+	assert.Contains(t, body, "admin")
+}
+
+func TestHandleAdminOverview_NoSession(t *testing.T) {
+	// Arrange
+	tmpl := testAdminTemplate(t)
+	handler := HandleAdminOverview(tmpl, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/", nil)
+
+	// Act
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Assert — redirects to login when session missing
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}

--- a/internal/dashboard/handlers/apikeys.go
+++ b/internal/dashboard/handlers/apikeys.go
@@ -40,6 +40,7 @@ func HandleAPIKeys(tmpl *template.Template, authSvc *auth.AuthService, logger *z
 		}
 
 		data := sessionData(sd, "apikeys")
+		withCSRF(r.Context(), data)
 		data["Keys"] = listKeys(r, authSvc, sd.UserID)
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -60,6 +61,7 @@ func HandleGenerateKey(tmpl *template.Template, authSvc *auth.AuthService, logge
 		}
 
 		data := sessionData(sd, "apikeys")
+		withCSRF(r.Context(), data)
 
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {

--- a/internal/dashboard/handlers/bandwidth_chart.go
+++ b/internal/dashboard/handlers/bandwidth_chart.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"time"
+)
+
+// ChartBar represents a single bar in the SVG bandwidth chart.
+type ChartBar struct {
+	X         float64
+	InH       float64 // Ingress bar height
+	EgH       float64 // Egress bar height (stacked on top)
+	InY       float64
+	EgY       float64
+	W         float64
+	Label     string // Date label (e.g. "Apr 3")
+	ShowLabel bool   // Only show every 5th label to avoid clutter
+}
+
+// BandwidthDay holds one day's bandwidth totals.
+type BandwidthDay struct {
+	Date    time.Time
+	Ingress int64
+	Egress  int64
+}
+
+// BuildChartBars converts a slice of daily bandwidth data into SVG bar
+// coordinates. Chart area is 600x200. Returns nil for empty input.
+func BuildChartBars(days []BandwidthDay) []ChartBar {
+	if len(days) == 0 {
+		return nil
+	}
+
+	var maxVal int64
+	for _, d := range days {
+		total := d.Ingress + d.Egress
+		if total > maxVal {
+			maxVal = total
+		}
+	}
+
+	const chartW, chartH = 600.0, 200.0
+	barW := chartW / float64(len(days)) * 0.8
+	gap := chartW / float64(len(days)) * 0.2
+
+	bars := make([]ChartBar, 0, len(days))
+	for i, d := range days {
+		x := float64(i) * (barW + gap)
+		inH, egH := 0.0, 0.0
+		if maxVal > 0 {
+			inH = float64(d.Ingress) / float64(maxVal) * chartH
+			egH = float64(d.Egress) / float64(maxVal) * chartH
+		}
+		if d.Ingress > 0 && inH < 2 {
+			inH = 2
+		}
+		if d.Egress > 0 && egH < 2 {
+			egH = 2
+		}
+
+		showLabel := i%5 == 0 || i == len(days)-1
+		bars = append(bars, ChartBar{
+			X:         math.Round(x*100) / 100,
+			InH:       math.Round(inH*100) / 100,
+			EgH:       math.Round(egH*100) / 100,
+			InY:       math.Round((chartH-inH)*100) / 100,
+			EgY:       math.Round((chartH-inH-egH)*100) / 100,
+			W:         math.Round(barW*100) / 100,
+			Label:     d.Date.Format("Jan 2"),
+			ShowLabel: showLabel,
+		})
+	}
+	return bars
+}
+
+// QueryBandwidthDays fetches the last 30 days of bandwidth data for a tenant.
+func QueryBandwidthDays(ctx context.Context, db *sql.DB, tenantID string) ([]BandwidthDay, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT date, COALESCE(ingress_bytes, 0), COALESCE(egress_bytes, 0)
+		 FROM bandwidth_usage_daily
+		 WHERE tenant_id = $1 AND date >= CURRENT_DATE - INTERVAL '30 days'
+		 ORDER BY date ASC`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var days []BandwidthDay
+	for rows.Next() {
+		var d BandwidthDay
+		if err := rows.Scan(&d.Date, &d.Ingress, &d.Egress); err != nil {
+			continue
+		}
+		days = append(days, d)
+	}
+	return days, nil
+}
+
+// QueryMonthBandwidth returns the current month's ingress, egress, and request totals.
+func QueryMonthBandwidth(ctx context.Context, db *sql.DB, tenantID string) (ingress, egress, requests int64, err error) {
+	err = db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(ingress_bytes), 0),
+		        COALESCE(SUM(egress_bytes), 0),
+		        COALESCE(SUM(requests_count), 0)
+		 FROM bandwidth_usage_daily
+		 WHERE tenant_id = $1 AND date >= date_trunc('month', CURRENT_DATE)`,
+		tenantID).Scan(&ingress, &egress, &requests)
+	return
+}

--- a/internal/dashboard/handlers/bandwidth_chart_test.go
+++ b/internal/dashboard/handlers/bandwidth_chart_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildChartBars_Empty(t *testing.T) {
+	bars := BuildChartBars(nil)
+	assert.Nil(t, bars)
+}
+
+func TestBuildChartBars_SingleDay(t *testing.T) {
+	days := []BandwidthDay{
+		{Date: time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), Ingress: 1000, Egress: 500},
+	}
+
+	bars := BuildChartBars(days)
+	require.Len(t, bars, 1)
+	assert.Equal(t, "Apr 7", bars[0].Label)
+	assert.True(t, bars[0].ShowLabel)
+	assert.True(t, bars[0].InH > 0)
+	assert.True(t, bars[0].EgH > 0)
+}
+
+func TestBuildChartBars_MultipleDays(t *testing.T) {
+	days := make([]BandwidthDay, 10)
+	base := time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC)
+	for i := range days {
+		days[i] = BandwidthDay{
+			Date:    base.AddDate(0, 0, i),
+			Ingress: int64((i + 1) * 1024 * 1024),
+			Egress:  int64((i + 1) * 512 * 1024),
+		}
+	}
+
+	bars := BuildChartBars(days)
+	require.Len(t, bars, 10)
+
+	// First and every 5th bar should show label.
+	assert.True(t, bars[0].ShowLabel)
+	assert.False(t, bars[1].ShowLabel)
+	assert.True(t, bars[5].ShowLabel)
+	// Last bar always shows label.
+	assert.True(t, bars[9].ShowLabel)
+
+	// Last bar should have the tallest total (max values).
+	assert.True(t, bars[9].InH >= bars[0].InH)
+}
+
+func TestBuildChartBars_MinimumHeight(t *testing.T) {
+	// A day with tiny non-zero values should still get min 2px height.
+	days := []BandwidthDay{
+		{Date: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Ingress: 1000000, Egress: 1000000},
+		{Date: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC), Ingress: 1, Egress: 1},
+	}
+
+	bars := BuildChartBars(days)
+	require.Len(t, bars, 2)
+	// The second bar should have minimum 2px for each non-zero dimension.
+	assert.True(t, bars[1].InH >= 2)
+	assert.True(t, bars[1].EgH >= 2)
+}
+
+func TestBuildChartBars_ZeroMax(t *testing.T) {
+	// All zeros should still produce bars with zero height.
+	days := []BandwidthDay{
+		{Date: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Ingress: 0, Egress: 0},
+	}
+
+	bars := BuildChartBars(days)
+	require.Len(t, bars, 1)
+	assert.Equal(t, 0.0, bars[0].InH)
+	assert.Equal(t, 0.0, bars[0].EgH)
+}

--- a/internal/dashboard/handlers/billing.go
+++ b/internal/dashboard/handlers/billing.go
@@ -23,6 +23,7 @@ func HandleBilling(tmpl *template.Template, stripe *billing.StripeService, db *s
 		}
 
 		data := sessionData(sd, "billing")
+		withCSRF(r.Context(), data)
 		ctx := r.Context()
 
 		populateBillingPlan(ctx, db, data, sd.TenantID)

--- a/internal/dashboard/handlers/buckets.go
+++ b/internal/dashboard/handlers/buckets.go
@@ -56,6 +56,7 @@ func HandleBuckets(tmpl *template.Template, db *sql.DB, dataPath string, logger 
 		}
 
 		data := sessionData(sd, "buckets")
+		withCSRF(r.Context(), data)
 
 		if db != nil {
 			buckets := listBuckets(r.Context(), db, sd.TenantID)
@@ -84,6 +85,7 @@ func HandleCreateBucket(tmpl *template.Template, db *sql.DB, dataPath string, lo
 		}
 
 		data := sessionData(sd, "buckets")
+		withCSRF(r.Context(), data)
 
 		name := strings.TrimSpace(r.FormValue("name"))
 		name = strings.ToLower(name)
@@ -143,6 +145,7 @@ func HandleBucketObjects(tmpl *template.Template, db *sql.DB, logger *zap.Logger
 		prefix := r.URL.Query().Get("prefix")
 
 		data := sessionData(sd, "buckets")
+		withCSRF(r.Context(), data)
 		data["BucketName"] = bucketName
 		data["Prefix"] = prefix
 

--- a/internal/dashboard/handlers/context.go
+++ b/internal/dashboard/handlers/context.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"time"
 
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
 )
 
 // sessionData builds the base template data map from the session.
@@ -19,6 +21,11 @@ func sessionData(sd *dashauth.SessionData, page string) map[string]any {
 		"TenantID": sd.TenantID,
 		"Page":     page,
 	}
+}
+
+// withCSRF adds the CSRF token from the request context to the template data map.
+func withCSRF(ctx context.Context, data map[string]any) {
+	data["CSRFToken"] = middleware.Token(ctx)
 }
 
 // formatBytes returns a human-readable size string (e.g. "1.5 GB").

--- a/internal/dashboard/handlers/oauth.go
+++ b/internal/dashboard/handlers/oauth.go
@@ -76,10 +76,13 @@ func HandleOAuthCallback(
 
 		// Clear state cookie.
 		http.SetCookie(w, &http.Cookie{
-			Name:   oauthStateCookie,
-			Value:  "",
-			Path:   "/",
-			MaxAge: -1,
+			Name:     oauthStateCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   -1,
 		})
 
 		// Check for error from provider.

--- a/internal/dashboard/handlers/oauth.go
+++ b/internal/dashboard/handlers/oauth.go
@@ -1,0 +1,308 @@
+package handlers
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+const (
+	oauthStateCookie = "oauth_state"
+	oauthStateTTL    = 10 * time.Minute
+	sessionTTL       = 24 * time.Hour
+)
+
+// HandleOAuthLogin redirects the user to the provider's consent screen.
+func HandleOAuthLogin(cfg *oauth2.Config, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		state, err := generateState()
+		if err != nil {
+			logger.Error("generate oauth state", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthStateCookie,
+			Value:    state,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(oauthStateTTL.Seconds()),
+		})
+
+		url := cfg.AuthCodeURL(state)
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+	}
+}
+
+// HandleOAuthCallback processes the OAuth callback from a provider.
+// It exchanges the code for a token, fetches user info, and creates or links
+// the user account.
+func HandleOAuthCallback(
+	cfg *oauth2.Config,
+	provider string,
+	fetchUser func(ctx context.Context, token *oauth2.Token) (oauthUser, error),
+	authSvc *auth.AuthService,
+	sessions dashauth.SessionStore,
+	db *sql.DB,
+	logger *zap.Logger,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Validate state.
+		cookie, err := r.Cookie(oauthStateCookie)
+		if err != nil || cookie.Value == "" {
+			logger.Debug("oauth: missing state cookie")
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+		if r.URL.Query().Get("state") != cookie.Value {
+			logger.Debug("oauth: state mismatch")
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Clear state cookie.
+		http.SetCookie(w, &http.Cookie{
+			Name:   oauthStateCookie,
+			Value:  "",
+			Path:   "/",
+			MaxAge: -1,
+		})
+
+		// Check for error from provider.
+		if errParam := r.URL.Query().Get("error"); errParam != "" {
+			logger.Info("oauth: provider error", zap.String("error", errParam))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Exchange code for token.
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		token, err := cfg.Exchange(r.Context(), code)
+		if err != nil {
+			logger.Error("oauth: exchange code", zap.String("provider", provider), zap.Error(err))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Fetch user info from provider.
+		ou, err := fetchUser(r.Context(), token)
+		if err != nil {
+			logger.Error("oauth: fetch user info", zap.String("provider", provider), zap.Error(err))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if ou.Email == "" {
+			logger.Error("oauth: no email from provider", zap.String("provider", provider))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Find or create user.
+		user, err := findOrCreateOAuthUser(r.Context(), authSvc, db, provider, ou)
+		if err != nil {
+			logger.Error("oauth: find or create user", zap.String("provider", provider), zap.Error(err))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Determine role.
+		role := "user"
+		if db != nil {
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT role FROM users WHERE id = $1`, user.ID).Scan(&role)
+		}
+
+		// Create session.
+		sessionToken, err := sessions.Create(r.Context(), dashauth.SessionData{
+			UserID:   user.ID,
+			TenantID: user.TenantID,
+			Email:    user.Email,
+			Role:     role,
+		}, sessionTTL)
+		if err != nil {
+			logger.Error("oauth: create session", zap.Error(err))
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		dashauth.SetSessionCookie(w, sessionToken, sessionTTL)
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+	}
+}
+
+// oauthUser holds the normalized user info from an OAuth provider.
+type oauthUser struct {
+	ID    string
+	Email string
+	Name  string
+}
+
+// findOrCreateOAuthUser resolves an OAuth login to a User.
+// 1. Existing OAuth link → return user
+// 2. Existing email match → link OAuth + return user
+// 3. No match → create new user + link OAuth
+func findOrCreateOAuthUser(ctx context.Context, authSvc *auth.AuthService, db *sql.DB, provider string, ou oauthUser) (*auth.User, error) {
+	// Check for existing OAuth link.
+	user, err := authSvc.GetUserByOAuth(ctx, provider, ou.ID)
+	if err == nil && user != nil {
+		return user, nil
+	}
+
+	// Check for existing user with same email.
+	user, err = authSvc.GetUserByEmail(ctx, ou.Email)
+	if err == nil && user != nil {
+		// Link this OAuth account to the existing user.
+		if linkErr := authSvc.LinkOAuthAccount(ctx, user.ID, provider, ou.ID, ou.Email, ou.Name); linkErr != nil {
+			return nil, fmt.Errorf("link oauth: %w", linkErr)
+		}
+		return user, nil
+	}
+
+	// Create new user via OAuth.
+	user, _, err = authSvc.CreateUserFromOAuth(ctx, ou.Email, ou.Name, provider, ou.ID)
+	if err != nil {
+		return nil, fmt.Errorf("create oauth user: %w", err)
+	}
+
+	return user, nil
+}
+
+// --- Google ---
+
+// FetchGoogleUser exchanges an OAuth token for Google user info.
+func FetchGoogleUser(cfg *oauth2.Config) func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+	return func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+		client := cfg.Client(ctx, token)
+		resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+		if err != nil {
+			return oauthUser{}, fmt.Errorf("google userinfo request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return oauthUser{}, fmt.Errorf("read google response: %w", err)
+		}
+
+		var info struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+			Name  string `json:"name"`
+		}
+		if err := json.Unmarshal(body, &info); err != nil {
+			return oauthUser{}, fmt.Errorf("parse google userinfo: %w", err)
+		}
+
+		return oauthUser{ID: info.ID, Email: info.Email, Name: info.Name}, nil
+	}
+}
+
+// --- GitHub ---
+
+// FetchGithubUser exchanges an OAuth token for GitHub user info.
+func FetchGithubUser(cfg *oauth2.Config) func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+	return func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+		client := cfg.Client(ctx, token)
+
+		// Get user profile.
+		resp, err := client.Get("https://api.github.com/user")
+		if err != nil {
+			return oauthUser{}, fmt.Errorf("github user request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return oauthUser{}, fmt.Errorf("read github response: %w", err)
+		}
+
+		var info struct {
+			ID    int    `json:"id"`
+			Login string `json:"login"`
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		}
+		if err := json.Unmarshal(body, &info); err != nil {
+			return oauthUser{}, fmt.Errorf("parse github user: %w", err)
+		}
+
+		email := info.Email
+
+		// If email is private, fetch from /user/emails endpoint.
+		if email == "" {
+			email, err = fetchGithubPrimaryEmail(ctx, client)
+			if err != nil {
+				return oauthUser{}, err
+			}
+		}
+
+		name := info.Name
+		if name == "" {
+			name = info.Login
+		}
+
+		return oauthUser{
+			ID:    fmt.Sprintf("%d", info.ID),
+			Email: email,
+			Name:  name,
+		}, nil
+	}
+}
+
+func fetchGithubPrimaryEmail(ctx context.Context, client *http.Client) (string, error) {
+	resp, err := client.Get("https://api.github.com/user/emails")
+	if err != nil {
+		return "", fmt.Errorf("github emails request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read github emails: %w", err)
+	}
+
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.Unmarshal(body, &emails); err != nil {
+		return "", fmt.Errorf("parse github emails: %w", err)
+	}
+
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			return e.Email, nil
+		}
+	}
+
+	return "", fmt.Errorf("no verified primary email from github")
+}
+
+func generateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/dashboard/handlers/oauth_test.go
+++ b/internal/dashboard/handlers/oauth_test.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+func testOAuthConfig() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		RedirectURL:  "http://localhost:8000/auth/test/callback",
+		Scopes:       []string{"email"},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://example.com/auth",
+			TokenURL: "https://example.com/token",
+		},
+	}
+}
+
+func TestHandleOAuthLogin_Redirect(t *testing.T) {
+	cfg := testOAuthConfig()
+	handler := HandleOAuthLogin(cfg, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/auth/test", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Should redirect to OAuth provider.
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	location := w.Header().Get("Location")
+	assert.Contains(t, location, "https://example.com/auth")
+	assert.Contains(t, location, "client_id=test-client-id")
+	assert.Contains(t, location, "scope=email")
+	assert.Contains(t, location, "state=")
+
+	// Should set state cookie.
+	cookies := w.Result().Cookies()
+	var stateCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "oauth_state" {
+			stateCookie = c
+		}
+	}
+	require.NotNil(t, stateCookie)
+	assert.True(t, stateCookie.HttpOnly)
+	assert.NotEmpty(t, stateCookie.Value)
+}
+
+func TestHandleOAuthCallback_MissingStateCookie(t *testing.T) {
+	cfg := testOAuthConfig()
+	handler := HandleOAuthCallback(cfg, "test",
+		func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+			return oauthUser{}, nil
+		},
+		nil, nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/auth/test/callback?state=abc&code=xyz", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleOAuthCallback_StateMismatch(t *testing.T) {
+	cfg := testOAuthConfig()
+	handler := HandleOAuthCallback(cfg, "test",
+		func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+			return oauthUser{}, nil
+		},
+		nil, nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/auth/test/callback?state=wrong&code=xyz", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "correct"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleOAuthCallback_ProviderError(t *testing.T) {
+	cfg := testOAuthConfig()
+	handler := HandleOAuthCallback(cfg, "test",
+		func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+			return oauthUser{}, nil
+		},
+		nil, nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/auth/test/callback?state=abc&error=access_denied", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "abc"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleOAuthCallback_MissingCode(t *testing.T) {
+	cfg := testOAuthConfig()
+	handler := HandleOAuthCallback(cfg, "test",
+		func(ctx context.Context, token *oauth2.Token) (oauthUser, error) {
+			return oauthUser{}, nil
+		},
+		nil, nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/auth/test/callback?state=abc", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "abc"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestFindOrCreateOAuthUser_NewUser(t *testing.T) {
+	authSvc := createTestAuthSvc(t)
+
+	ou := oauthUser{ID: "google-123", Email: "new@example.com", Name: "New User"}
+	user, err := findOrCreateOAuthUser(context.Background(), authSvc, nil, "google", ou)
+
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, "new@example.com", user.Email)
+	assert.Equal(t, "", user.PasswordHash) // OAuth user, no password
+	assert.NotEmpty(t, user.TenantID)
+}
+
+func TestFindOrCreateOAuthUser_ExistingEmail(t *testing.T) {
+	authSvc := createTestAuthSvc(t)
+
+	// Create existing user with password.
+	existing, _, _, err := authSvc.CreateUserWithTenant(context.Background(), "existing@example.com", "password123", "TestCo")
+	require.NoError(t, err)
+
+	// OAuth login with same email.
+	ou := oauthUser{ID: "google-456", Email: "existing@example.com", Name: "Existing User"}
+	user, err := findOrCreateOAuthUser(context.Background(), authSvc, nil, "google", ou)
+
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, existing.ID, user.ID) // Same user, not a new one
+}
+
+func TestFindOrCreateOAuthUser_ExistingOAuth(t *testing.T) {
+	authSvc := createTestAuthSvc(t)
+
+	// Create user via OAuth.
+	ou := oauthUser{ID: "github-789", Email: "oauth@example.com", Name: "OAuth User"}
+	first, err := findOrCreateOAuthUser(context.Background(), authSvc, nil, "github", ou)
+	require.NoError(t, err)
+
+	// Login again with same OAuth.
+	second, err := findOrCreateOAuthUser(context.Background(), authSvc, nil, "github", ou)
+	require.NoError(t, err)
+
+	// Should be the same user (looked up by email since no DB for GetUserByOAuth).
+	assert.Equal(t, first.ID, second.ID)
+}
+
+func createTestAuthSvc(t *testing.T) *auth.AuthService {
+	t.Helper()
+	return auth.NewAuthService(nil, nil)
+}

--- a/internal/dashboard/handlers/overview.go
+++ b/internal/dashboard/handlers/overview.go
@@ -37,6 +37,7 @@ func HandleOverview(tmpl *template.Template, db *sql.DB, logger *zap.Logger) htt
 			"TenantID": sd.TenantID,
 			"Page":     "dashboard",
 		}
+		withCSRF(r.Context(), data)
 
 		ctx := r.Context()
 

--- a/internal/dashboard/handlers/settings.go
+++ b/internal/dashboard/handlers/settings.go
@@ -20,6 +20,7 @@ func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.
 		}
 
 		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
 		populateProfile(authSvc, db, r, sd, data)
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -59,6 +60,7 @@ func HandleUpdateProfile(tmpl *template.Template, authSvc *auth.AuthService, db 
 		}
 
 		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
 		data["ProfileSuccess"] = "Profile updated."
 		populateProfile(authSvc, db, r, sd, data)
 
@@ -84,6 +86,7 @@ func HandleChangePassword(tmpl *template.Template, authSvc *auth.AuthService, db
 		confirm := r.FormValue("confirm_password")
 
 		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
 		populateProfile(authSvc, db, r, sd, data)
 
 		renderWithMsg := func(errMsg, successMsg string) {
@@ -152,6 +155,7 @@ func HandleUpdateNotifications(tmpl *template.Template, authSvc *auth.AuthServic
 		}
 
 		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
 		data["NotifSuccess"] = "Notification preferences updated."
 		populateProfile(authSvc, db, r, sd, data)
 

--- a/internal/dashboard/handlers/tenants.go
+++ b/internal/dashboard/handlers/tenants.go
@@ -326,7 +326,7 @@ func HandleSuspendTenant(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
 			` hx-post="/admin/tenants/%s/enable"`+
 			` hx-target="#tenant-status"`+
 			` hx-swap="innerHTML"`+
-			` hx-confirm="Enable this tenant?">Enable</button>`, tenantID)
+			` hx-confirm="Enable this tenant?">Enable</button>`, template.HTMLEscapeString(tenantID))
 	}
 }
 
@@ -366,7 +366,7 @@ func HandleEnableTenant(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
 			` hx-post="/admin/tenants/%s/suspend"`+
 			` hx-target="#tenant-status"`+
 			` hx-swap="innerHTML"`+
-			` hx-confirm="Suspend this tenant? They will lose API access.">Suspend</button>`, tenantID)
+			` hx-confirm="Suspend this tenant? They will lose API access.">Suspend</button>`, template.HTMLEscapeString(tenantID))
 	}
 }
 
@@ -539,6 +539,6 @@ func HandleChangeTier(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = fmt.Fprintf(w, `<div class="alert alert-success">Tier changed to %s (%s limit).</div>`,
-			newTier, formatBytes(limitBytes))
+			template.HTMLEscapeString(newTier), formatBytes(limitBytes))
 	}
 }

--- a/internal/dashboard/handlers/tenants.go
+++ b/internal/dashboard/handlers/tenants.go
@@ -46,6 +46,7 @@ func HandleTenantList(tmpl *template.Template, db *sql.DB, logger *zap.Logger) h
 		}
 
 		data := sessionData(sd, "admin-tenants")
+		withCSRF(r.Context(), data)
 		query := r.URL.Query().Get("q")
 		data["SearchQuery"] = query
 
@@ -148,6 +149,7 @@ func HandleTenantDetail(tmpl *template.Template, db *sql.DB, logger *zap.Logger)
 		}
 
 		data := sessionData(sd, "admin-tenants")
+		withCSRF(r.Context(), data)
 		if !loadTenantDetail(r.Context(), db, tenantID, data, logger) {
 			http.NotFound(w, r)
 			return

--- a/internal/dashboard/handlers/tenants.go
+++ b/internal/dashboard/handlers/tenants.go
@@ -1,0 +1,448 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// tierLimits maps plan names to storage limits in bytes.
+var tierLimits = map[string]int64{
+	"starter": 1099511627776,  // 1 TB
+	"vault3":  3298534883328,  // 3 TB
+	"vault9":  9895604649984,  // 9 TB
+	"vault18": 19791209299968, // 18 TB
+	"vault36": 39582418599936, // 36 TB
+}
+
+type tenantRow struct {
+	ID              string
+	Name            string
+	Email           string
+	Plan            string
+	Status          string
+	StatusClass     string
+	StorageUsedFmt  string
+	StorageLimitFmt string
+	UsagePercent    int
+	UsageBarClass   string
+}
+
+// HandleTenantList renders the admin tenant list page.
+func HandleTenantList(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-tenants")
+		query := r.URL.Query().Get("q")
+		data["SearchQuery"] = query
+
+		if db != nil {
+			data["Tenants"] = queryTenantList(r.Context(), db, query, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render tenant list", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func queryTenantList(ctx context.Context, db *sql.DB, search string, logger *zap.Logger) []tenantRow {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.id, t.name, t.email, COALESCE(t.plan, 'starter'),
+		       t.subscription_status, t.suspended_at,
+		       COALESCE(q.storage_used_bytes, 0), COALESCE(q.storage_limit_bytes, 1099511627776)
+		FROM tenants t
+		LEFT JOIN tenant_quotas q ON q.tenant_id = t.id
+		WHERE ($1 = '' OR t.name ILIKE '%' || $1 || '%' OR t.email ILIKE '%' || $1 || '%')
+		ORDER BY t.created_at DESC
+		LIMIT 100
+	`, search)
+	if err != nil {
+		logger.Debug("admin: list tenants", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tenants []tenantRow
+	for rows.Next() {
+		var tr tenantRow
+		var subStatus string
+		var suspendedAt sql.NullTime
+		var usedBytes, limitBytes int64
+		if err := rows.Scan(&tr.ID, &tr.Name, &tr.Email, &tr.Plan,
+			&subStatus, &suspendedAt, &usedBytes, &limitBytes); err != nil {
+			continue
+		}
+		tr.StorageUsedFmt = formatBytes(usedBytes)
+		tr.StorageLimitFmt = formatBytes(limitBytes)
+		if limitBytes > 0 {
+			tr.UsagePercent = int(usedBytes * 100 / limitBytes)
+		}
+		tr.UsageBarClass = usageBarClass(tr.UsagePercent)
+		tr.Status, tr.StatusClass = tenantStatus(subStatus, suspendedAt.Valid)
+		tenants = append(tenants, tr)
+	}
+	return tenants
+}
+
+func tenantStatus(subStatus string, isSuspended bool) (string, string) {
+	if isSuspended {
+		return "suspended", "danger"
+	}
+	switch subStatus {
+	case "active":
+		return "active", "success"
+	case "past_due":
+		return "past due", "warning"
+	case "canceled":
+		return "canceled", "default"
+	default:
+		return "free", "default"
+	}
+}
+
+func usageBarClass(pct int) string {
+	switch {
+	case pct >= 90:
+		return "danger"
+	case pct >= 75:
+		return "warning"
+	default:
+		return ""
+	}
+}
+
+// HandleTenantDetail renders the admin tenant detail page.
+func HandleTenantDetail(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		if db == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		data := sessionData(sd, "admin-tenants")
+		if !loadTenantDetail(r.Context(), db, tenantID, data, logger) {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render tenant detail", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+type tierOption struct {
+	Value string
+	Label string
+}
+
+var availableTiers = []tierOption{
+	{"starter", "Starter (1 TB)"},
+	{"vault3", "Vault3 (3 TB)"},
+	{"vault9", "Vault9 (9 TB)"},
+	{"vault18", "Vault18 (18 TB)"},
+	{"vault36", "Vault36 (36 TB)"},
+}
+
+func loadTenantDetail(ctx context.Context, db *sql.DB, tenantID string, data map[string]any, logger *zap.Logger) bool {
+	var name, email, plan, subStatus string
+	var stripeCustomerID, stripeSubID sql.NullString
+	var suspendedAt sql.NullTime
+	var createdAt sql.NullTime
+
+	err := db.QueryRowContext(ctx, `
+		SELECT t.name, t.email, COALESCE(t.plan, 'starter'), t.subscription_status,
+		       t.stripe_customer_id, t.stripe_subscription_id, t.suspended_at, t.created_at
+		FROM tenants t WHERE t.id = $1
+	`, tenantID).Scan(&name, &email, &plan, &subStatus,
+		&stripeCustomerID, &stripeSubID, &suspendedAt, &createdAt)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			logger.Debug("admin: tenant detail", zap.Error(err))
+		}
+		return false
+	}
+
+	data["TenantID"] = tenantID
+	data["TenantName"] = name
+	data["TenantEmail"] = email
+	data["Plan"] = plan
+	data["IsSuspended"] = suspendedAt.Valid
+
+	status, statusClass := tenantStatus(subStatus, suspendedAt.Valid)
+	data["Status"] = status
+	data["StatusClass"] = statusClass
+
+	subLabel, subClass := subStatusDisplay(subStatus)
+	data["SubStatusLabel"] = subLabel
+	data["SubStatusClass"] = subClass
+
+	if createdAt.Valid {
+		data["CreatedFmt"] = createdAt.Time.Format("Jan 2, 2006")
+	}
+
+	data["AvailableTiers"] = availableTiers
+
+	// Load quota data.
+	var usedBytes, limitBytes int64
+	var tier string
+	err = db.QueryRowContext(ctx, `
+		SELECT COALESCE(storage_used_bytes, 0), COALESCE(storage_limit_bytes, 1099511627776),
+		       COALESCE(tier, 'starter')
+		FROM tenant_quotas WHERE tenant_id = $1
+	`, tenantID).Scan(&usedBytes, &limitBytes, &tier)
+	if err != nil && err != sql.ErrNoRows {
+		logger.Debug("admin: tenant quota", zap.Error(err))
+	}
+	data["StorageUsedFmt"] = formatBytes(usedBytes)
+	data["StorageLimitFmt"] = formatBytes(limitBytes)
+	data["StorageLimitGB"] = limitBytes / (1024 * 1024 * 1024)
+	pct := 0
+	if limitBytes > 0 {
+		pct = int(usedBytes * 100 / limitBytes)
+	}
+	data["StoragePercent"] = pct
+	data["StorageBarClass"] = usageBarClass(pct)
+	data["Tier"] = tier
+
+	return true
+}
+
+func subStatusDisplay(s string) (string, string) {
+	switch s {
+	case "active":
+		return "Active", "success"
+	case "past_due":
+		return "Past Due", "warning"
+	case "canceled":
+		return "Canceled", "default"
+	default:
+		return "None", "default"
+	}
+}
+
+// HandleSuspendTenant sets suspended_at on a tenant and returns an htmx fragment.
+func HandleSuspendTenant(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database not available", http.StatusInternalServerError)
+			return
+		}
+
+		if _, err := db.ExecContext(r.Context(),
+			`UPDATE tenants SET suspended_at = NOW() WHERE id = $1 AND suspended_at IS NULL`,
+			tenantID); err != nil {
+			logger.Error("suspend tenant", zap.String("tenant_id", tenantID), zap.Error(err))
+			http.Error(w, "Failed to suspend tenant", http.StatusInternalServerError)
+			return
+		}
+
+		logger.Info("tenant suspended", zap.String("tenant_id", tenantID), zap.String("by", sd.Email))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w, `<span class="badge badge-danger">suspended</span>`+
+			` <button class="btn btn-sm btn-primary"`+
+			` hx-post="/admin/tenants/%s/enable"`+
+			` hx-target="#tenant-status"`+
+			` hx-swap="innerHTML"`+
+			` hx-confirm="Enable this tenant?">Enable</button>`, tenantID)
+	}
+}
+
+// HandleEnableTenant clears suspended_at and returns an htmx fragment.
+func HandleEnableTenant(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database not available", http.StatusInternalServerError)
+			return
+		}
+
+		if _, err := db.ExecContext(r.Context(),
+			`UPDATE tenants SET suspended_at = NULL WHERE id = $1`,
+			tenantID); err != nil {
+			logger.Error("enable tenant", zap.String("tenant_id", tenantID), zap.Error(err))
+			http.Error(w, "Failed to enable tenant", http.StatusInternalServerError)
+			return
+		}
+
+		logger.Info("tenant enabled", zap.String("tenant_id", tenantID), zap.String("by", sd.Email))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w, `<span class="badge badge-success">active</span>`+
+			` <button class="btn btn-sm btn-danger"`+
+			` hx-post="/admin/tenants/%s/suspend"`+
+			` hx-target="#tenant-status"`+
+			` hx-swap="innerHTML"`+
+			` hx-confirm="Suspend this tenant? They will lose API access.">Suspend</button>`, tenantID)
+	}
+}
+
+// HandleUpdateQuota updates a tenant's storage limit and returns an htmx fragment.
+func HandleUpdateQuota(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		limitGB, err := strconv.ParseInt(r.FormValue("storage_limit"), 10, 64)
+		if err != nil || limitGB <= 0 {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, `<div class="alert alert-error">Invalid storage limit. Enter a positive number in GB.</div>`)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database not available", http.StatusInternalServerError)
+			return
+		}
+
+		limitBytes := limitGB * 1024 * 1024 * 1024
+		if _, err := db.ExecContext(r.Context(),
+			`UPDATE tenant_quotas SET storage_limit_bytes = $1, updated_at = NOW() WHERE tenant_id = $2`,
+			limitBytes, tenantID); err != nil {
+			logger.Error("update quota", zap.String("tenant_id", tenantID), zap.Error(err))
+			http.Error(w, "Failed to update quota", http.StatusInternalServerError)
+			return
+		}
+
+		logger.Info("quota updated",
+			zap.String("tenant_id", tenantID),
+			zap.Int64("limit_gb", limitGB),
+			zap.String("by", sd.Email))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w, `<div class="alert alert-success">Storage limit updated to %s.</div>`, formatBytes(limitBytes))
+	}
+}
+
+// HandleChangeTier changes a tenant's plan and adjusts quota limits.
+func HandleChangeTier(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		newTier := r.FormValue("tier")
+		limitBytes, ok := tierLimits[newTier]
+		if !ok {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, `<div class="alert alert-error">Invalid tier.</div>`)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database not available", http.StatusInternalServerError)
+			return
+		}
+
+		tx, err := db.BeginTx(r.Context(), nil)
+		if err != nil {
+			logger.Error("begin tx for tier change", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		if _, err := tx.ExecContext(r.Context(),
+			`UPDATE tenants SET plan = $1 WHERE id = $2`, newTier, tenantID); err != nil {
+			logger.Error("update tenant plan", zap.Error(err))
+			http.Error(w, "Failed to change tier", http.StatusInternalServerError)
+			return
+		}
+
+		if _, err := tx.ExecContext(r.Context(),
+			`UPDATE tenant_quotas SET tier = $1, storage_limit_bytes = $2, updated_at = NOW() WHERE tenant_id = $3`,
+			newTier, limitBytes, tenantID); err != nil {
+			logger.Error("update tenant quota tier", zap.Error(err))
+			http.Error(w, "Failed to change tier", http.StatusInternalServerError)
+			return
+		}
+
+		if err := tx.Commit(); err != nil {
+			logger.Error("commit tier change", zap.Error(err))
+			http.Error(w, "Failed to change tier", http.StatusInternalServerError)
+			return
+		}
+
+		logger.Info("tier changed",
+			zap.String("tenant_id", tenantID),
+			zap.String("tier", newTier),
+			zap.String("by", sd.Email))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w, `<div class="alert alert-success">Tier changed to %s (%s limit).</div>`,
+			newTier, formatBytes(limitBytes))
+	}
+}

--- a/internal/dashboard/handlers/tenants.go
+++ b/internal/dashboard/handlers/tenants.go
@@ -235,6 +235,43 @@ func loadTenantDetail(ctx context.Context, db *sql.DB, tenantID string, data map
 	data["StorageBarClass"] = usageBarClass(pct)
 	data["Tier"] = tier
 
+	// Bandwidth: current month totals + 30-day chart.
+	ingress, egress, requests, _ := QueryMonthBandwidth(ctx, db, tenantID)
+	data["IngressFmt"] = formatBytes(ingress)
+	data["EgressFmt"] = formatBytes(egress)
+	data["BandwidthTotalFmt"] = formatBytes(ingress + egress)
+	data["RequestsCount"] = requests
+
+	// Bandwidth limit.
+	var bwLimitBytes sql.NullInt64
+	_ = db.QueryRowContext(ctx,
+		`SELECT bandwidth_limit_bytes FROM tenant_quotas WHERE tenant_id = $1`, tenantID).Scan(&bwLimitBytes)
+	if bwLimitBytes.Valid && bwLimitBytes.Int64 > 0 {
+		data["BandwidthLimitFmt"] = formatBytes(bwLimitBytes.Int64)
+		data["BandwidthLimitGB"] = bwLimitBytes.Int64 / (1024 * 1024 * 1024)
+	} else {
+		data["BandwidthLimitFmt"] = "Unlimited"
+		data["BandwidthLimitGB"] = int64(0)
+	}
+
+	days, _ := QueryBandwidthDays(ctx, db, tenantID)
+	if len(days) > 0 {
+		data["ChartBars"] = BuildChartBars(days)
+		data["HasChartData"] = true
+		var maxVal int64
+		for _, d := range days {
+			total := d.Ingress + d.Egress
+			if total > maxVal {
+				maxVal = total
+			}
+		}
+		data["ChartMaxLabel"] = formatBytes(maxVal)
+	} else {
+		data["ChartBars"] = nil
+		data["HasChartData"] = false
+		data["ChartMaxLabel"] = "0 B"
+	}
+
 	return true
 }
 
@@ -375,6 +412,63 @@ func HandleUpdateQuota(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = fmt.Fprintf(w, `<div class="alert alert-success">Storage limit updated to %s.</div>`, formatBytes(limitBytes))
+	}
+}
+
+// HandleUpdateBandwidthLimit sets or clears a tenant's bandwidth limit.
+// A value of 0 means unlimited.
+func HandleUpdateBandwidthLimit(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		limitGB, err := strconv.ParseInt(r.FormValue("bandwidth_limit"), 10, 64)
+		if err != nil || limitGB < 0 {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, `<div class="alert alert-error">Invalid bandwidth limit. Enter a non-negative number in GB (0 = unlimited).</div>`)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database not available", http.StatusInternalServerError)
+			return
+		}
+
+		var limitBytes *int64
+		if limitGB > 0 {
+			v := limitGB * 1024 * 1024 * 1024
+			limitBytes = &v
+		}
+
+		if _, err := db.ExecContext(r.Context(),
+			`UPDATE tenant_quotas SET bandwidth_limit_bytes = $1, updated_at = NOW() WHERE tenant_id = $2`,
+			limitBytes, tenantID); err != nil {
+			logger.Error("update bandwidth limit", zap.String("tenant_id", tenantID), zap.Error(err))
+			http.Error(w, "Failed to update bandwidth limit", http.StatusInternalServerError)
+			return
+		}
+
+		logger.Info("bandwidth limit updated",
+			zap.String("tenant_id", tenantID),
+			zap.Int64("limit_gb", limitGB),
+			zap.String("by", sd.Email))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if limitGB == 0 {
+			_, _ = fmt.Fprint(w, `<div class="alert alert-success">Bandwidth limit removed (unlimited).</div>`)
+		} else {
+			_, _ = fmt.Fprintf(w, `<div class="alert alert-success">Bandwidth limit updated to %s/month.</div>`, formatBytes(*limitBytes))
+		}
 	}
 }
 

--- a/internal/dashboard/handlers/tenants_test.go
+++ b/internal/dashboard/handlers/tenants_test.go
@@ -235,6 +235,76 @@ func TestHandleUpdateQuota_NoDB(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+// --- Bandwidth limit tests ---
+
+func TestHandleUpdateBandwidthLimit_NoSession(t *testing.T) {
+	handler := HandleUpdateBandwidthLimit(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/bandwidth-limit", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestHandleUpdateBandwidthLimit_InvalidInput(t *testing.T) {
+	handler := HandleUpdateBandwidthLimit(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("bandwidth_limit=notanumber")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/bandwidth-limit", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid bandwidth limit")
+}
+
+func TestHandleUpdateBandwidthLimit_NegativeInput(t *testing.T) {
+	handler := HandleUpdateBandwidthLimit(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("bandwidth_limit=-5")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/bandwidth-limit", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleUpdateBandwidthLimit_NoDB(t *testing.T) {
+	handler := HandleUpdateBandwidthLimit(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("bandwidth_limit=100")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/bandwidth-limit", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleUpdateBandwidthLimit_ZeroMeansUnlimited(t *testing.T) {
+	handler := HandleUpdateBandwidthLimit(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("bandwidth_limit=0")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/bandwidth-limit", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// NoDB so it'll be 500, but the handler accepts 0 as valid (unlimited).
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 // --- Tier change tests ---
 
 func TestHandleChangeTier_NoSession(t *testing.T) {

--- a/internal/dashboard/handlers/tenants_test.go
+++ b/internal/dashboard/handlers/tenants_test.go
@@ -1,0 +1,277 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- Test helpers ---
+
+func testAdminTenantsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Tenants{{end}}` +
+			`{{define "content"}}` +
+			`<h1>Tenants</h1>` +
+			`<span class="email">{{.Email}}</span>` +
+			`<span class="search">{{.SearchQuery}}</span>` +
+			`{{if .Tenants}}{{range .Tenants}}` +
+			`<span class="tenant">{{.Name}} {{.Email}} {{.Plan}} {{.Status}}</span>` +
+			`{{end}}{{else}}` +
+			`<p class="empty">No tenants found.</p>` +
+			`{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func testAdminTenantDetailTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Tenant Detail{{end}}` +
+			`{{define "content"}}` +
+			`<h1>{{.TenantName}}</h1>` +
+			`<span class="email">{{.TenantEmail}}</span>` +
+			`<span class="plan">{{.Plan}}</span>` +
+			`<span class="storage">{{.StorageUsedFmt}} / {{.StorageLimitFmt}}</span>` +
+			`<span class="suspended">{{.IsSuspended}}</span>` +
+			`{{end}}`))
+	return tmpl
+}
+
+func adminCtx(t *testing.T) context.Context {
+	t.Helper()
+	store := dashauth.NewMemoryStore()
+	token, err := store.Create(context.Background(), dashauth.SessionData{
+		UserID: "admin-1", TenantID: "t-admin", Email: "admin@stored.ge", Role: "admin",
+	}, time.Hour)
+	require.NoError(t, err)
+	sd, err := store.Get(context.Background(), token)
+	require.NoError(t, err)
+	return context.WithValue(context.Background(), dashauth.SessionKey, sd)
+}
+
+func withChiParam(ctx context.Context, key, val string) context.Context {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, val)
+	return context.WithValue(ctx, chi.RouteCtxKey, rctx)
+}
+
+// --- Tenant list tests ---
+
+func TestHandleTenantList_NoSession(t *testing.T) {
+	handler := HandleTenantList(testAdminTenantsTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/tenants", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleTenantList_NoDB(t *testing.T) {
+	handler := HandleTenantList(testAdminTenantsTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/tenants", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Tenants")
+	assert.Contains(t, body, "No tenants found.")
+}
+
+func TestHandleTenantList_WithSearch(t *testing.T) {
+	handler := HandleTenantList(testAdminTenantsTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/tenants?q=test", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "test")
+}
+
+// --- Tenant detail tests ---
+
+func TestHandleTenantDetail_NoSession(t *testing.T) {
+	handler := HandleTenantDetail(testAdminTenantDetailTemplate(t), nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/tenants/t-1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleTenantDetail_EmptyID(t *testing.T) {
+	handler := HandleTenantDetail(testAdminTenantDetailTemplate(t), nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "")
+	req := httptest.NewRequest("GET", "/admin/tenants/", nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleTenantDetail_NoDB(t *testing.T) {
+	handler := HandleTenantDetail(testAdminTenantDetailTemplate(t), nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "nonexistent")
+	req := httptest.NewRequest("GET", "/admin/tenants/nonexistent", nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Suspend/Enable tests ---
+
+func TestHandleSuspendTenant_NoSession(t *testing.T) {
+	handler := HandleSuspendTenant(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/suspend", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestHandleSuspendTenant_NoDB(t *testing.T) {
+	handler := HandleSuspendTenant(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/suspend", nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleEnableTenant_NoSession(t *testing.T) {
+	handler := HandleEnableTenant(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/enable", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestHandleEnableTenant_NoDB(t *testing.T) {
+	handler := HandleEnableTenant(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/enable", nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Quota update tests ---
+
+func TestHandleUpdateQuota_NoSession(t *testing.T) {
+	handler := HandleUpdateQuota(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/quota", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestHandleUpdateQuota_InvalidInput(t *testing.T) {
+	handler := HandleUpdateQuota(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("storage_limit=notanumber")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/quota", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid storage limit")
+}
+
+func TestHandleUpdateQuota_NoDB(t *testing.T) {
+	handler := HandleUpdateQuota(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("storage_limit=100")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/quota", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Tier change tests ---
+
+func TestHandleChangeTier_NoSession(t *testing.T) {
+	handler := HandleChangeTier(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/tier", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestHandleChangeTier_InvalidTier(t *testing.T) {
+	handler := HandleChangeTier(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("tier=bogus")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/tier", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid tier")
+}
+
+func TestHandleChangeTier_NoDB(t *testing.T) {
+	handler := HandleChangeTier(nil, zap.NewNop())
+
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	body := strings.NewReader("tier=vault3")
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/tier", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/dashboard/handlers/usage.go
+++ b/internal/dashboard/handlers/usage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"html/template"
-	"math"
 	"net/http"
 	"time"
 
@@ -19,18 +18,6 @@ type UsageDayRow struct {
 	EgressFmt  string
 	TotalFmt   string
 	Requests   int64
-}
-
-// ChartBar represents a single bar in the SVG bandwidth chart.
-type ChartBar struct {
-	X         float64
-	InH       float64 // Ingress bar height
-	EgH       float64 // Egress bar height (stacked on top)
-	InY       float64
-	EgY       float64
-	W         float64
-	Label     string // Date label (e.g. "Apr 3")
-	ShowLabel bool   // Only show every 5th label to avoid clutter
 }
 
 // HandleUsage renders the usage page with storage, bandwidth, and a
@@ -102,15 +89,7 @@ func populateUsageStorage(ctx context.Context, db *sql.DB, tenantID string, data
 }
 
 func populateUsageBandwidth(ctx context.Context, db *sql.DB, tenantID string, data map[string]any) {
-	// Current month totals.
-	var ingress, egress, requests int64
-	err := db.QueryRowContext(ctx,
-		`SELECT COALESCE(SUM(ingress_bytes), 0),
-		        COALESCE(SUM(egress_bytes), 0),
-		        COALESCE(SUM(requests_count), 0)
-		 FROM bandwidth_usage_daily
-		 WHERE tenant_id = $1 AND date >= date_trunc('month', CURRENT_DATE)`,
-		tenantID).Scan(&ingress, &egress, &requests)
+	ingress, egress, requests, err := QueryMonthBandwidth(ctx, db, tenantID)
 	if err != nil {
 		ingress, egress, requests = 0, 0, 0
 	}
@@ -122,80 +101,25 @@ func populateUsageBandwidth(ctx context.Context, db *sql.DB, tenantID string, da
 }
 
 func populateUsageChart(ctx context.Context, db *sql.DB, tenantID string, data map[string]any) {
-	rows, err := db.QueryContext(ctx,
-		`SELECT date, COALESCE(ingress_bytes, 0), COALESCE(egress_bytes, 0)
-		 FROM bandwidth_usage_daily
-		 WHERE tenant_id = $1 AND date >= CURRENT_DATE - INTERVAL '30 days'
-		 ORDER BY date ASC`, tenantID)
-	if err != nil {
+	days, err := QueryBandwidthDays(ctx, db, tenantID)
+	if err != nil || len(days) == 0 {
 		data["ChartBars"] = nil
 		data["HasChartData"] = false
 		return
 	}
-	defer func() { _ = rows.Close() }()
 
-	type dayData struct {
-		date    time.Time
-		ingress int64
-		egress  int64
-	}
-	var days []dayData
+	bars := BuildChartBars(days)
+	data["ChartBars"] = bars
+	data["HasChartData"] = true
+
+	// Compute max for the chart label.
 	var maxVal int64
-
-	for rows.Next() {
-		var d dayData
-		if err := rows.Scan(&d.date, &d.ingress, &d.egress); err != nil {
-			continue
-		}
-		total := d.ingress + d.egress
+	for _, d := range days {
+		total := d.Ingress + d.Egress
 		if total > maxVal {
 			maxVal = total
 		}
-		days = append(days, d)
 	}
-
-	if len(days) == 0 {
-		data["ChartBars"] = nil
-		data["HasChartData"] = false
-		return
-	}
-
-	// Build SVG bar data. Chart area is 600x200.
-	const chartW, chartH = 600.0, 200.0
-	barW := chartW / float64(len(days)) * 0.8
-	gap := chartW / float64(len(days)) * 0.2
-
-	var bars []ChartBar
-	for i, d := range days {
-		x := float64(i) * (barW + gap)
-		inH, egH := 0.0, 0.0
-		if maxVal > 0 {
-			inH = float64(d.ingress) / float64(maxVal) * chartH
-			egH = float64(d.egress) / float64(maxVal) * chartH
-		}
-		// Minimum visible height for non-zero values.
-		if d.ingress > 0 && inH < 2 {
-			inH = 2
-		}
-		if d.egress > 0 && egH < 2 {
-			egH = 2
-		}
-
-		showLabel := i%5 == 0 || i == len(days)-1
-		bars = append(bars, ChartBar{
-			X:         math.Round(x*100) / 100,
-			InH:       math.Round(inH*100) / 100,
-			EgH:       math.Round(egH*100) / 100,
-			InY:       math.Round((chartH-inH)*100) / 100,
-			EgY:       math.Round((chartH-inH-egH)*100) / 100,
-			W:         math.Round(barW*100) / 100,
-			Label:     d.date.Format("Jan 2"),
-			ShowLabel: showLabel,
-		})
-	}
-
-	data["ChartBars"] = bars
-	data["HasChartData"] = true
 	data["ChartMaxLabel"] = formatBytes(maxVal)
 }
 

--- a/internal/dashboard/handlers/usage.go
+++ b/internal/dashboard/handlers/usage.go
@@ -31,6 +31,7 @@ func HandleUsage(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.H
 		}
 
 		data := sessionData(sd, "usage")
+		withCSRF(r.Context(), data)
 		ctx := r.Context()
 
 		if db != nil {

--- a/internal/dashboard/middleware/csrf.go
+++ b/internal/dashboard/middleware/csrf.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+type csrfKey struct{}
+
+// CSRF implements the double-submit cookie pattern. On every request it
+// ensures a csrf_token cookie exists and stores the token in the request
+// context. On state-changing methods (POST, PUT, PATCH, DELETE) it
+// validates that the submitted token (form field or header) matches the
+// cookie.
+func CSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Read or generate token.
+		token := ""
+		if c, err := r.Cookie("csrf_token"); err == nil && c.Value != "" {
+			token = c.Value
+		} else {
+			token = generateToken()
+			http.SetCookie(w, &http.Cookie{
+				Name:     "csrf_token",
+				Value:    token,
+				Path:     "/",
+				HttpOnly: true,
+				Secure:   true,
+				SameSite: http.SameSiteLaxMode,
+			})
+		}
+
+		// Inject token into context for handlers/templates.
+		ctx := context.WithValue(r.Context(), csrfKey{}, token)
+		r = r.WithContext(ctx)
+
+		// Safe methods pass through without validation.
+		if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Validate: submitted token must match cookie.
+		submitted := r.Header.Get("X-CSRF-Token")
+		if submitted == "" {
+			submitted = r.FormValue("csrf_token")
+		}
+
+		if submitted == "" || submitted != token {
+			http.Error(w, "CSRF token invalid", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Token returns the CSRF token from the request context.
+func Token(ctx context.Context) string {
+	if v, ok := ctx.Value(csrfKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+func generateToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic("csrf: failed to generate random token")
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/dashboard/middleware/csrf_test.go
+++ b/internal/dashboard/middleware/csrf_test.go
@@ -1,0 +1,151 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func okHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tok := Token(r.Context())
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(tok))
+	}
+}
+
+func TestCSRF_GET_SetsTokenCookieAndContext(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Should set csrf_token cookie.
+	cookies := w.Result().Cookies()
+	var csrfCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "csrf_token" {
+			csrfCookie = c
+		}
+	}
+	require.NotNil(t, csrfCookie)
+	assert.Len(t, csrfCookie.Value, 64) // 32 bytes hex-encoded
+	assert.True(t, csrfCookie.HttpOnly)
+	assert.Equal(t, http.SameSiteLaxMode, csrfCookie.SameSite)
+
+	// Body should contain the token (handler writes it).
+	assert.Equal(t, csrfCookie.Value, w.Body.String())
+}
+
+func TestCSRF_GET_ReusesExistingCookie(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "existing-token-value-0123456789ab"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "existing-token-value-0123456789ab", w.Body.String())
+}
+
+func TestCSRF_POST_ValidFormField(t *testing.T) {
+	handler := CSRF(okHandler())
+	token := "abc123def456abc123def456abc123def456abc123def456abc123def456abc12345"
+
+	body := strings.NewReader("csrf_token=" + token + "&name=test")
+	req := httptest.NewRequest("POST", "/dashboard/settings/profile", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCSRF_POST_ValidHeader(t *testing.T) {
+	handler := CSRF(okHandler())
+	token := "abc123def456abc123def456abc123def456abc123def456abc123def456abc12345"
+
+	req := httptest.NewRequest("POST", "/admin/tenants/t-1/suspend", nil)
+	req.Header.Set("X-CSRF-Token", token)
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCSRF_POST_MissingToken(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "some-token"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "CSRF")
+}
+
+func TestCSRF_POST_MismatchedToken(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	body := strings.NewReader("csrf_token=wrong-token")
+	req := httptest.NewRequest("POST", "/dashboard/settings/profile", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "csrf_token", Value: "correct-token"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCSRF_POST_NoCookie(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	body := strings.NewReader("csrf_token=some-token")
+	req := httptest.NewRequest("POST", "/dashboard/settings/profile", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCSRF_SkipsGET(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCSRF_SkipsHEAD(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("HEAD", "/dashboard", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCSRF_SkipsOPTIONS(t *testing.T) {
+	handler := CSRF(okHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/dashboard", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -120,6 +120,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/tenant_detail.html",
 	))
+	systemTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/system.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
@@ -130,6 +134,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/enable", handlers.HandleEnableTenant(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/quota", handlers.HandleUpdateQuota(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/tier", handlers.HandleChangeTier(deps.DB, deps.Logger))
+		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
 	})
 }
 

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 )
 
 const sessionTTL = 24 * time.Hour
@@ -26,6 +27,8 @@ type Deps struct {
 	Logger   *zap.Logger
 	DataPath string                 // Local storage root for bucket creation.
 	Stripe   *billing.StripeService // Nil when STRIPE_SECRET_KEY is not set.
+	Google   *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
+	GitHub   *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
 }
 
 // RegisterRoutes mounts the dashboard, auth, admin, and static-asset
@@ -42,11 +45,25 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	))
 
 	// --- Public auth routes ---
-	r.Get("/login", renderPage(baseTmpl, "login"))
+	r.Get("/login", renderAuthPage(baseTmpl, "login", deps))
 	r.Post("/login", handleLogin(baseTmpl, deps))
-	r.Get("/register", renderPage(baseTmpl, "register"))
+	r.Get("/register", renderAuthPage(baseTmpl, "register", deps))
 	r.Post("/register", handleRegister(baseTmpl, deps))
 	r.Get("/logout", handleLogout(deps.Sessions))
+
+	// --- OAuth login ---
+	if deps.Google != nil {
+		r.Get("/auth/google", handlers.HandleOAuthLogin(deps.Google, deps.Logger))
+		r.Get("/auth/google/callback", handlers.HandleOAuthCallback(
+			deps.Google, "google", handlers.FetchGoogleUser(deps.Google),
+			deps.Auth, deps.Sessions, deps.DB, deps.Logger))
+	}
+	if deps.GitHub != nil {
+		r.Get("/auth/github", handlers.HandleOAuthLogin(deps.GitHub, deps.Logger))
+		r.Get("/auth/github/callback", handlers.HandleOAuthCallback(
+			deps.GitHub, "github", handlers.FetchGithubUser(deps.GitHub),
+			deps.Auth, deps.Sessions, deps.DB, deps.Logger))
+	}
 
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
@@ -142,24 +159,17 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	})
 }
 
-// renderPage returns a handler that executes the "base" layout with a
-// page-specific content block. Until Phase 1 templates are built, each
-// page renders a minimal placeholder inside the base layout.
-func renderPage(base *template.Template, page string) http.HandlerFunc {
-	// Clone the base layout and add a page-specific content block.
+// renderAuthPage renders a public auth page (login, register) with OAuth flags.
+func renderAuthPage(base *template.Template, page string, deps Deps) http.HandlerFunc {
 	tmpl := template.Must(base.Clone())
 	template.Must(tmpl.Parse(pageContent(page)))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		sd := dashauth.GetSession(r.Context())
-		data := map[string]any{}
-		if sd != nil {
-			data["Email"] = sd.Email
-			data["Role"] = sd.Role
-			data["UserID"] = sd.UserID
-			data["TenantID"] = sd.TenantID
+		data := map[string]any{
+			"Page":      page,
+			"HasGoogle": deps.Google != nil,
+			"HasGithub": deps.GitHub != nil,
 		}
-		data["Page"] = page
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -179,9 +189,11 @@ func handleLogin(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusUnauthorized)
 			_ = errTmpl.ExecuteTemplate(w, "base", map[string]any{
-				"Error": msg,
-				"Email": email,
-				"Page":  "login",
+				"Error":     msg,
+				"Email":     email,
+				"Page":      "login",
+				"HasGoogle": deps.Google != nil,
+				"HasGithub": deps.GitHub != nil,
 			})
 		}
 
@@ -234,10 +246,12 @@ func handleRegister(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = errTmpl.ExecuteTemplate(w, "base", map[string]any{
-				"Error":   msg,
-				"Email":   email,
-				"Company": company,
-				"Page":    "register",
+				"Error":     msg,
+				"Email":     email,
+				"Company":   company,
+				"Page":      "register",
+				"HasGoogle": deps.Google != nil,
+				"HasGithub": deps.GitHub != nil,
 			})
 		}
 
@@ -304,6 +318,13 @@ func pageContent(page string) string {
 			`<div class="auth-brand">stored.ge</div>` +
 			`<h1>Sign In</h1>` +
 			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
+			`{{if or .HasGoogle .HasGithub}}` +
+			`<div class="oauth-buttons">` +
+			`{{if .HasGoogle}}<a href="/auth/google" class="btn btn-oauth btn-google">Sign in with Google</a>{{end}}` +
+			`{{if .HasGithub}}<a href="/auth/github" class="btn btn-oauth btn-github">Sign in with GitHub</a>{{end}}` +
+			`</div>` +
+			`<div class="auth-divider"><span>or</span></div>` +
+			`{{end}}` +
 			`<form method="POST" action="/login">` +
 			`<div class="form-group"><label>Email</label><input type="email" name="email" value="{{.Email}}" required></div>` +
 			`<div class="form-group"><label>Password</label><input type="password" name="password" required></div>` +
@@ -319,6 +340,13 @@ func pageContent(page string) string {
 			`<div class="auth-brand">stored.ge</div>` +
 			`<h1>Create Account</h1>` +
 			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
+			`{{if or .HasGoogle .HasGithub}}` +
+			`<div class="oauth-buttons">` +
+			`{{if .HasGoogle}}<a href="/auth/google" class="btn btn-oauth btn-google">Sign up with Google</a>{{end}}` +
+			`{{if .HasGithub}}<a href="/auth/github" class="btn btn-oauth btn-github">Sign up with GitHub</a>{{end}}` +
+			`</div>` +
+			`<div class="auth-divider"><span>or</span></div>` +
+			`{{end}}` +
 			`<form method="POST" action="/register">` +
 			`<div class="form-group"><label>Email</label><input type="email" name="email" value="{{.Email}}" required></div>` +
 			`<div class="form-group"><label>Password</label><input type="password" name="password" required minlength="8"></div>` +

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/billing"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 )
@@ -50,6 +51,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
 		dr.Use(dashauth.RequireSession(deps.Sessions))
+		dr.Use(middleware.CSRF)
 
 		// Overview: parse the real template from embedded FS.
 		overviewTmpl := template.Must(baseTmpl.Clone())
@@ -127,6 +129,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
+		ar.Use(middleware.CSRF)
 		ar.Get("/", handlers.HandleAdminOverview(adminTmpl, deps.DB, deps.Logger))
 		ar.Get("/tenants", handlers.HandleTenantList(tenantListTmpl, deps.DB, deps.Logger))
 		ar.Get("/tenants/{id}", handlers.HandleTenantDetail(tenantDetailTmpl, deps.DB, deps.Logger))

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -112,10 +112,24 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/dashboard.html",
 	))
+	tenantListTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/tenants.html",
+	))
+	tenantDetailTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/tenant_detail.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
 		ar.Get("/", handlers.HandleAdminOverview(adminTmpl, deps.DB, deps.Logger))
+		ar.Get("/tenants", handlers.HandleTenantList(tenantListTmpl, deps.DB, deps.Logger))
+		ar.Get("/tenants/{id}", handlers.HandleTenantDetail(tenantDetailTmpl, deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/suspend", handlers.HandleSuspendTenant(deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/enable", handlers.HandleEnableTenant(deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/quota", handlers.HandleUpdateQuota(deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/tier", handlers.HandleChangeTier(deps.DB, deps.Logger))
 	})
 }
 

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -134,6 +134,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/enable", handlers.HandleEnableTenant(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/quota", handlers.HandleUpdateQuota(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/tier", handlers.HandleChangeTier(deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/bandwidth-limit", handlers.HandleUpdateBandwidthLimit(deps.DB, deps.Logger))
 		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
 	})
 }

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -108,9 +108,14 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	})
 
 	// --- Admin (session + admin role required) ---
+	adminTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/dashboard.html",
+	))
+
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
-		ar.Get("/", renderPage(baseTmpl, "admin"))
+		ar.Get("/", handlers.HandleAdminOverview(adminTmpl, deps.DB, deps.Logger))
 	})
 }
 
@@ -299,12 +304,6 @@ func pageContent(page string) string {
 			`</form>` +
 			`<div class="auth-footer">Have an account? <a href="/login">Sign in</a></div>` +
 			`</div></div>{{end}}`
-	case "admin":
-		return `{{define "title"}}Admin — stored.ge{{end}}` +
-			`{{define "content"}}` +
-			`<h1>Admin Panel</h1>` +
-			`<p>Admin features coming in Phase 3.</p>` +
-			`{{end}}`
 	default:
 		return `{{define "content"}}<p>Page not found.</p>{{end}}`
 	}

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -255,6 +255,7 @@ th {
     font-size: 0.9rem;
 }
 .sidebar-link:hover { color: #fff; background: #334155; }
+.sidebar-link--active { color: #fff; background: #334155; font-weight: 600; }
 .sidebar-footer { padding: 0.5rem 0; border-top: 1px solid #334155; }
 .admin-main { flex: 1; padding: 2rem; }
 

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -221,6 +221,27 @@ th {
 }
 .auth-footer a { color: var(--primary); text-decoration: none; }
 
+/* OAuth */
+.oauth-buttons { display: flex; flex-direction: column; gap: 0.5rem; }
+.btn-oauth {
+    display: flex; align-items: center; justify-content: center;
+    padding: 0.6rem 1rem; border-radius: 6px; font-weight: 500;
+    text-decoration: none; font-size: 0.9rem; border: 1px solid #ddd;
+    transition: background 0.15s;
+}
+.btn-google { background: #fff; color: #333; }
+.btn-google:hover { background: #f5f5f5; }
+.btn-github { background: #24292e; color: #fff; border-color: #24292e; }
+.btn-github:hover { background: #333; }
+.auth-divider {
+    display: flex; align-items: center; margin: 1rem 0;
+    color: var(--text-muted); font-size: 0.8rem;
+}
+.auth-divider::before, .auth-divider::after {
+    content: ""; flex: 1; height: 1px; background: #ddd;
+}
+.auth-divider span { padding: 0 0.75rem; }
+
 /* Mono / code */
 .mono { font-family: var(--mono); font-size: 0.85rem; }
 .code-block {

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -289,10 +289,42 @@ th {
 }
 .badge-success { background: #f0fdf4; color: var(--success); }
 .badge-danger { background: #fef2f2; color: var(--danger); }
+.badge-warning { background: #fffbeb; color: var(--warning); }
 .badge-default { background: var(--bg); color: var(--text-muted); }
 
 /* Empty state */
 .empty-state { padding: 1.5rem 0; text-align: center; }
+
+/* Search form */
+.search-form { display: flex; gap: 0.5rem; align-items: center; }
+.search-input {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+    font-family: var(--font);
+    width: 260px;
+}
+
+/* Breadcrumb */
+.breadcrumb { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.5rem; }
+.breadcrumb a { color: var(--primary); text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+
+/* Inline form row */
+.form-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.form-input-sm {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    font-family: var(--font);
+}
+
+/* Alerts */
+.alert { padding: 0.5rem 0.75rem; border-radius: var(--radius); font-size: 0.85rem; margin-bottom: 0.5rem; }
+.alert-error { background: #fef2f2; color: var(--danger); border: 1px solid #fecaca; }
+.alert-success { background: #f0fdf4; color: var(--success); border: 1px solid #bbf7d0; }
 
 /* Page header (title + action button side by side) */
 .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; }

--- a/internal/dashboard/templates/admin/dashboard.html
+++ b/internal/dashboard/templates/admin/dashboard.html
@@ -1,0 +1,66 @@
+{{define "title"}}Admin — stored.ge{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Admin Overview</h1>
+    <p class="text-muted">Signed in as {{.Email}}</p>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Tenants</div>
+        <div class="card-value">{{.TenantCount}}</div>
+        <div class="card-detail">registered accounts</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Total Storage</div>
+        <div class="card-value">{{.TotalStorageFmt}}</div>
+        <div class="card-detail">across all tenants</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Active Subscriptions</div>
+        <div class="card-value">{{.ActiveSubCount}}</div>
+        <div class="card-detail">paying customers</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Monthly Revenue</div>
+        <div class="card-value">{{.MonthlyRevenue}}</div>
+        <div class="card-detail">estimated from active plans</div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Recent Registrations</div>
+    {{if .RecentUsers}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Company</th>
+                    <th>Plan</th>
+                    <th>Registered</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .RecentUsers}}
+                <tr>
+                    <td>{{.Email}}</td>
+                    <td>{{.Company}}</td>
+                    <td><span class="badge">{{.Plan}}</span></td>
+                    <td>{{.RegisteredFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted empty-state">No users registered yet.</p>
+    {{end}}
+</div>
+
+<div class="dashboard-actions">
+    <a href="/admin/tenants" class="btn btn-primary">Manage Tenants</a>
+    <a href="/admin/system" class="btn">System Health</a>
+    <a href="/dashboard" class="btn">Customer View</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/admin/system.html
+++ b/internal/dashboard/templates/admin/system.html
@@ -1,0 +1,69 @@
+{{define "title"}}System Health — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>System Health</h1>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Uptime</div>
+        <div class="card-value" style="font-size:1rem">{{.Uptime}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Go Version</div>
+        <div class="card-value" style="font-size:1rem">{{.GoVersion}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Goroutines</div>
+        <div class="card-value">{{.Goroutines}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Memory (Alloc)</div>
+        <div class="card-value">{{.MemAllocFmt}}</div>
+        <div class="card-detail">System: {{.MemSysFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">GC Cycles</div>
+        <div class="card-value">{{.NumGC}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Database</div>
+        <div class="card-value" style="font-size:1rem">
+            <span class="badge badge-{{if eq .DBStatus "connected"}}success{{else}}danger{{end}}">{{.DBStatus}}</span>
+        </div>
+    </div>
+</div>
+
+{{if eq .DBStatus "connected"}}
+<div class="card">
+    <div class="card-title">Database Connection Pool</div>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Open</th>
+                    <th>In Use</th>
+                    <th>Idle</th>
+                    <th>Max Open</th>
+                    <th>Wait Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>{{.DBOpen}}</td>
+                    <td>{{.DBInUse}}</td>
+                    <td>{{.DBIdle}}</td>
+                    <td>{{.DBMaxOpen}}</td>
+                    <td>{{.DBWaitCount}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}
+
+<div class="dashboard-actions">
+    <a href="/admin" class="btn">Admin Overview</a>
+    <a href="/admin/tenants" class="btn">Tenants</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/admin/tenant_detail.html
+++ b/internal/dashboard/templates/admin/tenant_detail.html
@@ -1,0 +1,91 @@
+{{define "title"}}{{.TenantName}} — Admin{{end}}
+{{define "content"}}
+<div class="breadcrumb">
+    <a href="/admin/tenants">Tenants</a> &rsaquo; {{.TenantName}}
+</div>
+
+<div class="dashboard-header">
+    <h1>{{.TenantName}}</h1>
+    <div id="tenant-status">
+        {{if .IsSuspended}}
+        <span class="badge badge-danger">suspended</span>
+        <button class="btn btn-sm btn-primary"
+            hx-post="/admin/tenants/{{.TenantID}}/enable"
+            hx-target="#tenant-status"
+            hx-swap="innerHTML"
+            hx-confirm="Enable this tenant?">Enable</button>
+        {{else}}
+        <span class="badge badge-success">active</span>
+        <button class="btn btn-sm btn-danger"
+            hx-post="/admin/tenants/{{.TenantID}}/suspend"
+            hx-target="#tenant-status"
+            hx-swap="innerHTML"
+            hx-confirm="Suspend this tenant? They will lose API access.">Suspend</button>
+        {{end}}
+    </div>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Email</div>
+        <div class="card-value" style="font-size:1rem">{{.TenantEmail}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Plan</div>
+        <div class="card-value card-value-plan">{{.Plan}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Registered</div>
+        <div class="card-value" style="font-size:1rem">{{.CreatedFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Subscription</div>
+        <div class="card-value" style="font-size:1rem">
+            <span class="badge badge-{{.SubStatusClass}}">{{.SubStatusLabel}}</span>
+        </div>
+    </div>
+</div>
+
+<div class="card" id="quota-section">
+    <div class="card-title">Storage Quota</div>
+    <div class="card-value">{{.StorageUsedFmt}} / {{.StorageLimitFmt}}</div>
+    <div class="usage-bar">
+        <div class="usage-bar-fill {{.StorageBarClass}}" style="width: {{.StoragePercent}}%"></div>
+    </div>
+    <div class="card-detail">{{.StoragePercent}}% used ({{.Tier}} tier)</div>
+
+    <div id="quota-feedback"></div>
+    <form style="margin-top:1rem"
+        hx-post="/admin/tenants/{{.TenantID}}/quota"
+        hx-target="#quota-feedback"
+        hx-swap="innerHTML">
+        <div class="form-row">
+            <label>Storage Limit (GB)</label>
+            <input type="number" name="storage_limit" value="{{.StorageLimitGB}}" min="1" class="form-input-sm">
+            <button type="submit" class="btn btn-sm btn-primary">Update</button>
+        </div>
+    </form>
+</div>
+
+<div class="card" id="tier-section">
+    <div class="card-title">Change Tier</div>
+    <div id="tier-feedback"></div>
+    <form hx-post="/admin/tenants/{{.TenantID}}/tier"
+          hx-target="#tier-feedback"
+          hx-swap="innerHTML">
+        <div class="form-row">
+            <select name="tier" class="form-input-sm">
+                {{range .AvailableTiers}}
+                <option value="{{.Value}}" {{if eq $.Tier .Value}}selected{{end}}>{{.Label}}</option>
+                {{end}}
+            </select>
+            <button type="submit" class="btn btn-sm btn-primary">Change</button>
+        </div>
+    </form>
+</div>
+
+<div class="dashboard-actions">
+    <a href="/admin/tenants" class="btn">Back to Tenants</a>
+    <a href="/admin" class="btn">Admin Overview</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/admin/tenant_detail.html
+++ b/internal/dashboard/templates/admin/tenant_detail.html
@@ -84,6 +84,65 @@
     </form>
 </div>
 
+<div class="card" id="bandwidth-section">
+    <div class="card-title">Bandwidth (Current Month)</div>
+    <div class="card-grid" style="margin-bottom:1rem">
+        <div>
+            <div class="card-detail">Ingress</div>
+            <div class="card-value" style="font-size:1rem">{{.IngressFmt}}</div>
+        </div>
+        <div>
+            <div class="card-detail">Egress</div>
+            <div class="card-value" style="font-size:1rem">{{.EgressFmt}}</div>
+        </div>
+        <div>
+            <div class="card-detail">Total</div>
+            <div class="card-value" style="font-size:1rem">{{.BandwidthTotalFmt}}</div>
+        </div>
+        <div>
+            <div class="card-detail">Requests</div>
+            <div class="card-value" style="font-size:1rem">{{.RequestsCount}}</div>
+        </div>
+    </div>
+    <div class="card-detail">Limit: {{.BandwidthLimitFmt}}</div>
+
+    {{if .HasChartData}}
+    <div style="margin-top:1rem">
+        <div class="card-detail" style="margin-bottom:0.5rem">30-Day Bandwidth</div>
+        <svg viewBox="0 0 620 240" style="width:100%;max-width:620px;background:#f8f9fa;border-radius:4px">
+            <text x="2" y="12" font-size="10" fill="#666">{{.ChartMaxLabel}}</text>
+            <g transform="translate(10,20)">
+                {{range .ChartBars}}
+                <rect x="{{.X}}" y="{{.InY}}" width="{{.W}}" height="{{.InH}}" fill="#3b82f6" rx="1"/>
+                <rect x="{{.X}}" y="{{.EgY}}" width="{{.W}}" height="{{.EgH}}" fill="#10b981" rx="1"/>
+                {{if .ShowLabel}}
+                <text x="{{.X}}" y="215" font-size="9" fill="#999">{{.Label}}</text>
+                {{end}}
+                {{end}}
+            </g>
+        </svg>
+        <div style="margin-top:0.5rem;font-size:0.8rem;color:#666">
+            <span style="color:#3b82f6">&#9632;</span> Ingress
+            <span style="color:#10b981;margin-left:1rem">&#9632;</span> Egress
+        </div>
+    </div>
+    {{else}}
+    <div class="card-detail" style="margin-top:1rem;color:#999">No bandwidth data yet.</div>
+    {{end}}
+
+    <div id="bandwidth-feedback"></div>
+    <form style="margin-top:1rem"
+        hx-post="/admin/tenants/{{.TenantID}}/bandwidth-limit"
+        hx-target="#bandwidth-feedback"
+        hx-swap="innerHTML">
+        <div class="form-row">
+            <label>Bandwidth Limit (GB, 0 = unlimited)</label>
+            <input type="number" name="bandwidth_limit" value="{{.BandwidthLimitGB}}" min="0" class="form-input-sm">
+            <button type="submit" class="btn btn-sm btn-primary">Update</button>
+        </div>
+    </form>
+</div>
+
 <div class="dashboard-actions">
     <a href="/admin/tenants" class="btn">Back to Tenants</a>
     <a href="/admin" class="btn">Admin Overview</a>

--- a/internal/dashboard/templates/admin/tenants.html
+++ b/internal/dashboard/templates/admin/tenants.html
@@ -1,0 +1,50 @@
+{{define "title"}}Tenants — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Tenants</h1>
+    <form method="GET" action="/admin/tenants" class="search-form">
+        <input type="text" name="q" value="{{.SearchQuery}}" placeholder="Search by name or email..." class="search-input">
+        <button type="submit" class="btn btn-sm">Search</button>
+    </form>
+</div>
+
+{{if .Tenants}}
+<div class="card">
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Plan</th>
+                    <th>Storage</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Tenants}}
+                <tr>
+                    <td><a href="/admin/tenants/{{.ID}}">{{.Name}}</a></td>
+                    <td>{{.Email}}</td>
+                    <td><span class="badge">{{.Plan}}</span></td>
+                    <td>
+                        <div>{{.StorageUsedFmt}} / {{.StorageLimitFmt}}</div>
+                        <div class="usage-bar" style="width:80px">
+                            <div class="usage-bar-fill {{.UsageBarClass}}" style="width: {{.UsagePercent}}%"></div>
+                        </div>
+                    </td>
+                    <td><span class="badge badge-{{.StatusClass}}">{{.Status}}</span></td>
+                    <td><a href="/admin/tenants/{{.ID}}" class="btn btn-sm">View</a></td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{else}}
+<div class="card">
+    <p class="text-muted empty-state">No tenants found.</p>
+</div>
+{{end}}
+{{end}}

--- a/internal/dashboard/templates/customer/apikeys.html
+++ b/internal/dashboard/templates/customer/apikeys.html
@@ -12,6 +12,7 @@
 
 <div id="generate-form" class="card hidden">
     <form method="POST" action="/dashboard/apikeys">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="form-row">
             <div class="form-group form-group-inline">
                 <label>Key Name</label>
@@ -74,6 +75,7 @@ aws s3 ls --endpoint-url https://stored.ge</div>
                     {{if eq .Status "active"}}
                     <form method="POST" action="/dashboard/apikeys/{{.ID}}/revoke"
                           onsubmit="return confirm('Revoke this key? Any applications using it will stop working.')">
+                        <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                         <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
                     </form>
                     {{end}}

--- a/internal/dashboard/templates/customer/billing.html
+++ b/internal/dashboard/templates/customer/billing.html
@@ -7,6 +7,7 @@
     </div>
     {{if .HasSubscription}}
     <form method="POST" action="/dashboard/billing/portal">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <button type="submit" class="btn">Manage Payment</button>
     </form>
     {{end}}
@@ -39,6 +40,7 @@
             <div class="plan-price">{{.PriceFmt}}</div>
             {{if .StorageTB}}<div class="plan-detail">{{.StorageTB}} TB storage</div>{{end}}
             <form method="POST" action="/dashboard/billing/upgrade">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                 <input type="hidden" name="plan" value="{{.ID}}">
                 <button type="submit" class="btn btn-primary btn-block">Choose Plan</button>
             </form>

--- a/internal/dashboard/templates/customer/buckets.html
+++ b/internal/dashboard/templates/customer/buckets.html
@@ -12,6 +12,7 @@
 
 <div id="create-form" class="card hidden">
     <form method="POST" action="/dashboard/buckets">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="form-row">
             <div class="form-group form-group-inline">
                 <label>Bucket Name</label>

--- a/internal/dashboard/templates/customer/settings.html
+++ b/internal/dashboard/templates/customer/settings.html
@@ -11,6 +11,7 @@
     <div class="card-title">Profile</div>
     {{if .ProfileSuccess}}<div class="alert alert-success">{{.ProfileSuccess}}</div>{{end}}
     <form method="POST" action="/dashboard/settings/profile">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="form-group">
             <label>Email</label>
             <input type="email" value="{{.ProfileEmail}}" disabled>
@@ -31,6 +32,7 @@
     {{if .PasswordError}}<div class="alert alert-error">{{.PasswordError}}</div>{{end}}
     {{if .PasswordSuccess}}<div class="alert alert-success">{{.PasswordSuccess}}</div>{{end}}
     <form method="POST" action="/dashboard/settings/password">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="form-group">
             <label>Current Password</label>
             <input type="password" name="current_password" required>
@@ -51,6 +53,7 @@
     <div class="card-title">Notifications</div>
     {{if .NotifSuccess}}<div class="alert alert-success">{{.NotifSuccess}}</div>{{end}}
     <form method="POST" action="/dashboard/settings/notifications">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <label class="checkbox-label">
             <input type="checkbox" name="email_notifications" {{if .EmailNotifications}}checked{{end}}>
             Email notifications for usage alerts and billing

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -7,6 +7,7 @@
     <title>{{block "title" .}}Admin &mdash; stored.ge{{end}}</title>
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/htmx.min.js"></script>
+    {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
     {{block "head" .}}{{end}}
 </head>
 <body class="admin-body">
@@ -29,6 +30,12 @@
             {{block "content" .}}{{end}}
         </main>
     </div>
+    <script>
+    document.body.addEventListener('htmx:configRequest', function(evt) {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        if (m) evt.detail.headers['X-CSRF-Token'] = m.content;
+    });
+    </script>
 </body>
 </html>
 {{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -16,12 +16,9 @@
                 <a href="/admin">stored.ge admin</a>
             </div>
             <nav class="sidebar-nav">
-                <a href="/admin" class="sidebar-link">Overview</a>
-                <a href="/admin/users" class="sidebar-link">Users</a>
-                <a href="/admin/tenants" class="sidebar-link">Tenants</a>
-                <a href="/admin/billing" class="sidebar-link">Billing</a>
-                <a href="/admin/backends" class="sidebar-link">Backends</a>
-                <a href="/admin/logs" class="sidebar-link">Logs</a>
+                <a href="/admin" class="sidebar-link{{if eq .Page "admin-overview"}} sidebar-link--active{{end}}">Overview</a>
+                <a href="/admin/tenants" class="sidebar-link{{if eq .Page "admin-tenants"}} sidebar-link--active{{end}}">Tenants</a>
+                <a href="/admin/system" class="sidebar-link{{if eq .Page "admin-system"}} sidebar-link--active{{end}}">System</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>

--- a/internal/dashboard/templates/layouts/base.html
+++ b/internal/dashboard/templates/layouts/base.html
@@ -7,6 +7,7 @@
     <title>{{block "title" .}}stored.ge{{end}}</title>
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/htmx.min.js"></script>
+    {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
     {{block "head" .}}{{end}}
 </head>
 <body>
@@ -30,6 +31,13 @@
     <main class="container">
         {{block "content" .}}{{end}}
     </main>
+
+    <script>
+    document.body.addEventListener('htmx:configRequest', function(evt) {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        if (m) evt.detail.headers['X-CSRF-Token'] = m.content;
+    });
+    </script>
 
     <footer class="footer">
         <div class="container">

--- a/internal/dashboard/templates/layouts/base.html
+++ b/internal/dashboard/templates/layouts/base.html
@@ -17,6 +17,7 @@
         </div>
         <div class="nav-links">
             {{if .Email}}
+            {{if eq .Role "admin"}}<a href="/admin" class="nav-link">Admin</a>{{end}}
             <span class="nav-user">{{.Email}}</span>
             <a href="/logout" class="nav-link">Sign out</a>
             {{else}}

--- a/internal/database/migrations/020_bandwidth_banking.sql
+++ b/internal/database/migrations/020_bandwidth_banking.sql
@@ -1,0 +1,36 @@
+-- 020_bandwidth_banking.sql
+-- Bandwidth banking foundation: rollover tracking and alert thresholds.
+-- Idempotent — safe to re-run on every deploy.
+
+-- Track monthly bandwidth rollover balances per tenant.
+-- Unused bandwidth can carry forward to the next month.
+CREATE TABLE IF NOT EXISTS bandwidth_rollover (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   VARCHAR(255) NOT NULL,
+    month       DATE NOT NULL,                -- first day of the month
+    base_bytes  BIGINT NOT NULL DEFAULT 0,    -- plan's base bandwidth allowance
+    rollover_bytes BIGINT NOT NULL DEFAULT 0, -- carried over from previous month
+    used_bytes  BIGINT NOT NULL DEFAULT 0,    -- actual usage that month
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bandwidth_rollover_tenant
+    ON bandwidth_rollover (tenant_id, month DESC);
+
+-- Bandwidth alert configuration per tenant.
+-- Admin can set thresholds; when usage crosses them, alerts fire.
+CREATE TABLE IF NOT EXISTS bandwidth_alerts (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id      VARCHAR(255) NOT NULL,
+    threshold_pct  INTEGER NOT NULL DEFAULT 80,  -- alert at this % of limit
+    alert_type     VARCHAR(50) NOT NULL DEFAULT 'email', -- "email", "dashboard", "webhook"
+    enabled        BOOLEAN NOT NULL DEFAULT true,
+    last_fired_at  TIMESTAMP,
+    created_at     TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, threshold_pct, alert_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bandwidth_alerts_tenant
+    ON bandwidth_alerts (tenant_id);

--- a/internal/database/migrations/021_oauth_accounts.sql
+++ b/internal/database/migrations/021_oauth_accounts.sql
@@ -1,0 +1,19 @@
+-- 021_oauth_accounts.sql
+-- OAuth provider accounts linked to users.
+-- Idempotent — safe to re-run on every deploy.
+
+-- Allow users to authenticate via external OAuth providers (Google, GitHub, etc).
+-- Separate table so one user can link multiple providers.
+CREATE TABLE IF NOT EXISTS oauth_accounts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL,
+    provider    VARCHAR(50) NOT NULL,       -- 'google', 'github'
+    provider_id VARCHAR(255) NOT NULL,      -- provider's unique user ID
+    email       VARCHAR(255),               -- email from provider (informational)
+    name        VARCHAR(255),               -- display name from provider
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (provider, provider_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_accounts_user
+    ON oauth_accounts (user_id);

--- a/internal/devops/deployment.go
+++ b/internal/devops/deployment.go
@@ -197,15 +197,23 @@ func (d *Deployment) setStatusLocked(status, message string) {
 	})
 }
 
+func (d *Deployment) setEndedAt() {
+	d.mu.Lock()
+	d.endedAt = time.Now()
+	d.mu.Unlock()
+}
+
 func (d *Deployment) execute(ctx context.Context) {
 	d.setStatus(DeployStatusRunning, "Deployment started")
+	d.mu.Lock()
 	d.startedAt = time.Now()
+	d.mu.Unlock()
 
 	// Run pre-deploy hook
 	if d.config.Hooks != nil && d.config.Hooks.PreDeploy != nil {
 		if err := d.config.Hooks.PreDeploy(); err != nil {
 			d.setStatus(DeployStatusFailed, fmt.Sprintf("Pre-deploy hook failed: %v", err))
-			d.endedAt = time.Now()
+			d.setEndedAt()
 			return
 		}
 	}
@@ -218,7 +226,7 @@ func (d *Deployment) execute(ctx context.Context) {
 				return // Already canceled
 			}
 			d.setStatus(DeployStatusFailed, fmt.Sprintf("Deployment failed: %v", err))
-			d.endedAt = time.Now()
+			d.setEndedAt()
 			return
 		}
 	}
@@ -227,13 +235,13 @@ func (d *Deployment) execute(ctx context.Context) {
 	if d.config.Hooks != nil && d.config.Hooks.PostDeploy != nil {
 		if err := d.config.Hooks.PostDeploy(); err != nil {
 			d.setStatus(DeployStatusFailed, fmt.Sprintf("Post-deploy hook failed: %v", err))
-			d.endedAt = time.Now()
+			d.setEndedAt()
 			return
 		}
 	}
 
 	d.setStatus(DeployStatusSuccess, "Deployment completed successfully")
-	d.endedAt = time.Now()
+	d.setEndedAt()
 }
 
 // DeployTarget is the interface for deployment targets

--- a/internal/testing/api/api_test.go
+++ b/internal/testing/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -364,9 +365,9 @@ func TestClient_HealthCheck(t *testing.T) {
 }
 
 func TestClient_WaitForReady(t *testing.T) {
-	ready := false
+	var ready atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ready {
+		if ready.Load() {
 			w.WriteHeader(http.StatusOK)
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -380,7 +381,7 @@ func TestClient_WaitForReady(t *testing.T) {
 	// Make ready after short delay
 	go func() {
 		time.Sleep(200 * time.Millisecond)
-		ready = true
+		ready.Store(true)
 	}()
 
 	err := client.WaitForReady(ctx, "/health", time.Second)


### PR DESCRIPTION
## Summary

Catch-up PR bringing main from Phase 1.5 → Phase 5.2. This rolls up 10 commits across 9 phases that were committed locally but never pushed.

### Phase 3 (admin dashboard)
- **3.1** — admin auth guard + overview page (`RequireAdmin` middleware, role-based 403, admin layout, real DB stats)
- **3.3** — tenant management (search, suspend/enable, quota adjustment, tier change)
- **3.4** — enforce tenant suspension in S3 handler
- **3.5** — admin system health page

### Phase 4 (bandwidth)
- **4.1** — bandwidth tracking middleware (`bandwidth_usage_daily` table, ingress/egress per request)
- **4.2** — bandwidth enforcement with monthly limit check (HTTP 429 over limit)
- **4.3** — admin bandwidth view + banking foundation

### Phase 5 (security polish, part 1)
- **5.1** — CSRF protection (double-submit cookie pattern)
- **5.2** — OAuth login with Google and GitHub

### Plus
- `fix(tests)` — resolve data races in devops and api test packages

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes for all touched packages (auth, dashboard, api)
- [x] `make lint` passes (0 issues)
- [ ] CI `build-and-test` passes
- [ ] CI `integration-tests` passes
- [ ] CI `gosec` passes

## Why this is one PR

These 10 commits chain on top of each other; phase 3.3 builds on 3.1, phase 4.2 needs 4.1's middleware in place, etc. Splitting them into individual PRs would still require sequential merging. Combining them into one squash-merge keeps main's history clean and gets us caught up faster. Phases 5.3-5.7 will follow in their own individual PRs.