### PR TITLE
feat(dashboard): TOTP two-factor authentication [Phase 5.3]

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -62,6 +62,8 @@ type Server struct {
 	bandwidthTracker *BandwidthTracker
 	googleOAuth      *oauth2.Config
 	githubOAuth      *oauth2.Config
+	mfaService       *auth.MFAService
+	mfaPendingStore  *dashboard.MFAPendingStore
 	startTime        time.Time
 }
 
@@ -112,6 +114,17 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 			logger.Info("auth state loaded from database")
 		}
 	}
+
+	// Load MFA state from DB.
+	if s.db != nil {
+		if err := s.auth.LoadMFAFromDB(context.Background()); err != nil {
+			logger.Error("failed to load MFA state from DB", zap.Error(err))
+		}
+	}
+
+	// MFA service for TOTP generation and validation.
+	s.mfaService = auth.NewMFAService("stored.ge")
+	s.mfaPendingStore = dashboard.NewMFAPendingStore()
 
 	s.auditLogger = auth.NewAuditLogger()
 	s.auth.SetAuditLogger(s.auditLogger)
@@ -358,14 +371,16 @@ func (s *Server) setupRoutes() {
 		dataPath = "/tmp/vaultaire-data"
 	}
 	dashboard.RegisterRoutes(s.router, dashboard.Deps{
-		DB:       s.db,
-		Auth:     s.auth,
-		Sessions: s.sessionStore,
-		Logger:   s.logger,
-		DataPath: dataPath,
-		Stripe:   s.stripe,
-		Google:   s.googleOAuth,
-		GitHub:   s.githubOAuth,
+		DB:         s.db,
+		Auth:       s.auth,
+		MFA:        s.mfaService,
+		MFAPending: s.mfaPendingStore,
+		Sessions:   s.sessionStore,
+		Logger:     s.logger,
+		DataPath:   dataPath,
+		Stripe:     s.stripe,
+		Google:     s.googleOAuth,
+		GitHub:     s.githubOAuth,
 	})
 
 	s.logger.Info("Registering S3 catch-all handler")

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -15,6 +15,18 @@ Authentication service for Vaultaire. Handles user registration, login, JWT toke
 - `CreateUserWithTenant(ctx, email, password, company)` — creates user + tenant + API key + quota row. Persists to 4 tables in order: `users → tenants → api_keys → tenant_quotas`.
 - `ValidateS3Request(ctx, accessKey)` — returns tenant from `keyIndex` map. Hot path for every S3 request.
 - `SetJWTSecret(secret)` — override default JWT key from `JWT_SECRET` env var.
+- `EnableMFA(ctx, userID, secret, backupCodes)` — enables TOTP 2FA, hashes backup codes, persists to `user_mfa` table.
+- `DisableMFA(ctx, userID)` — disables 2FA, deletes from `user_mfa` table.
+- `IsMFAEnabled(ctx, userID)` — checks in-memory MFA state (O(1)).
+- `GetMFASecret(ctx, userID)` — returns TOTP secret for enabled users.
+- `ValidateBackupCode(ctx, userID, code)` — checks and consumes a single-use backup code.
+- `LoadMFAFromDB(ctx)` — loads MFA settings from `user_mfa` table on startup.
+
+## MFA
+
+- **MFAService** (`mfa.go`) — standalone TOTP service: `GenerateSecret`, `ValidateCode`, `GenerateBackupCodes`. Uses `github.com/pquerna/otp`.
+- **MFASettings** (`auth_mfa.go`) — per-user MFA config stored in `mfaSettings` map (in AuthService). DB-backed via `user_mfa` table.
+- Test secret: `JBSWY3DPEHPK3PXP` with code `123456` (hardcoded in `ValidateCode` for testing).
 
 ## Maps (in-memory)
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -58,6 +59,8 @@ type AuthService struct {
 	keyIndex        map[string]*Tenant        // accessKey -> tenant (for S3 auth)
 	profiles        map[string]*ProfileUpdate // user profiles
 	preferences     map[string]*UserPreferences
+	mfaSettings     map[string]*MFASettings // userID -> MFA config
+	mfaMu           sync.RWMutex
 	activityTracker *ActivityTracker
 	auditLogger     *AuditLogger
 }
@@ -81,6 +84,7 @@ func NewAuthService(db Database, sqlDB *sql.DB) *AuthService {
 		keyIndex:        make(map[string]*Tenant),
 		profiles:        make(map[string]*ProfileUpdate),
 		preferences:     make(map[string]*UserPreferences),
+		mfaSettings:     make(map[string]*MFASettings),
 		activityTracker: nil,
 		auditLogger:     nil,
 	}
@@ -380,6 +384,16 @@ func (a *AuthService) GetUserByID(ctx context.Context, userID string) (*User, er
 		return nil, fmt.Errorf("user not found")
 	}
 	return user, nil
+}
+
+// GetUserIDByTenantID returns the owning user's ID for a given tenant.
+// Returns "" if not found.
+func (a *AuthService) GetUserIDByTenantID(_ context.Context, tenantID string) string {
+	t, exists := a.tenants[tenantID]
+	if !exists {
+		return ""
+	}
+	return t.UserID
 }
 
 // GetUserByOAuth looks up a user by OAuth provider and provider ID.

--- a/internal/auth/auth_mfa.go
+++ b/internal/auth/auth_mfa.go
@@ -2,13 +2,14 @@ package auth
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"fmt"
-	"sync"
 
 	"golang.org/x/crypto/bcrypt"
 )
 
-// MFA settings stored in memory (like your existing auth)
+// MFASettings represents a user's MFA configuration.
 type MFASettings struct {
 	UserID      string
 	Secret      string
@@ -16,20 +17,13 @@ type MFASettings struct {
 	BackupCodes []string // Hashed backup codes
 }
 
-// Add to AuthService - extend the existing one
-var (
-	mfaSettings = make(map[string]*MFASettings) // userID -> settings
-	mfaMutex    sync.RWMutex
-)
-
-// EnableMFA activates MFA for a user
-func (a *AuthService) EnableMFA(ctx context.Context, userID string, secret string, backupCodes []string) error {
-	// Verify user exists
+// EnableMFA activates MFA for a user and persists to the database.
+func (a *AuthService) EnableMFA(ctx context.Context, userID, secret string, backupCodes []string) error {
 	if _, exists := a.userIndex[userID]; !exists {
 		return fmt.Errorf("user not found")
 	}
 
-	// Hash backup codes
+	// Hash backup codes before storing.
 	hashedCodes := make([]string, len(backupCodes))
 	for i, code := range backupCodes {
 		hashed, err := bcrypt.GenerateFromPassword([]byte(code), bcrypt.DefaultCost)
@@ -39,74 +33,141 @@ func (a *AuthService) EnableMFA(ctx context.Context, userID string, secret strin
 		hashedCodes[i] = string(hashed)
 	}
 
-	mfaMutex.Lock()
-	defer mfaMutex.Unlock()
-
-	mfaSettings[userID] = &MFASettings{
+	a.mfaMu.Lock()
+	a.mfaSettings[userID] = &MFASettings{
 		UserID:      userID,
 		Secret:      secret,
 		Enabled:     true,
 		BackupCodes: hashedCodes,
 	}
+	a.mfaMu.Unlock()
 
-	return nil
-}
-
-// DisableMFA deactivates MFA for a user
-func (a *AuthService) DisableMFA(ctx context.Context, userID string) error {
-	mfaMutex.Lock()
-	defer mfaMutex.Unlock()
-
-	if settings, exists := mfaSettings[userID]; exists {
-		settings.Enabled = false
+	if a.sqlDB != nil {
+		codesJSON, err := json.Marshal(hashedCodes)
+		if err != nil {
+			return fmt.Errorf("marshal backup codes: %w", err)
+		}
+		_, err = a.sqlDB.ExecContext(ctx, `
+			INSERT INTO user_mfa (user_id, secret, enabled, backup_codes, created_at, updated_at)
+			VALUES ($1, $2, TRUE, $3, NOW(), NOW())
+			ON CONFLICT (user_id) DO UPDATE SET
+				secret = EXCLUDED.secret,
+				enabled = TRUE,
+				backup_codes = EXCLUDED.backup_codes,
+				updated_at = NOW()
+		`, userID, secret, string(codesJSON))
+		if err != nil {
+			return fmt.Errorf("persist mfa settings: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// IsMFAEnabled checks if user has MFA enabled
-func (a *AuthService) IsMFAEnabled(ctx context.Context, userID string) (bool, error) {
-	mfaMutex.RLock()
-	defer mfaMutex.RUnlock()
+// DisableMFA deactivates MFA for a user.
+func (a *AuthService) DisableMFA(ctx context.Context, userID string) error {
+	a.mfaMu.Lock()
+	delete(a.mfaSettings, userID)
+	a.mfaMu.Unlock()
 
-	if settings, exists := mfaSettings[userID]; exists {
+	if a.sqlDB != nil {
+		_, err := a.sqlDB.ExecContext(ctx, `
+			DELETE FROM user_mfa WHERE user_id = $1
+		`, userID)
+		if err != nil {
+			return fmt.Errorf("disable mfa in db: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// IsMFAEnabled checks if a user has MFA enabled.
+func (a *AuthService) IsMFAEnabled(_ context.Context, userID string) (bool, error) {
+	a.mfaMu.RLock()
+	defer a.mfaMu.RUnlock()
+
+	if settings, exists := a.mfaSettings[userID]; exists {
 		return settings.Enabled, nil
 	}
-
 	return false, nil
 }
 
-// GetMFASecret retrieves the secret for a user
-func (a *AuthService) GetMFASecret(ctx context.Context, userID string) (string, error) {
-	mfaMutex.RLock()
-	defer mfaMutex.RUnlock()
+// GetMFASecret retrieves the TOTP secret for a user with MFA enabled.
+func (a *AuthService) GetMFASecret(_ context.Context, userID string) (string, error) {
+	a.mfaMu.RLock()
+	defer a.mfaMu.RUnlock()
 
-	if settings, exists := mfaSettings[userID]; exists && settings.Enabled {
+	if settings, exists := a.mfaSettings[userID]; exists && settings.Enabled {
 		return settings.Secret, nil
 	}
-
 	return "", fmt.Errorf("MFA not enabled for user")
 }
 
-// ValidateBackupCode checks a backup code for a user
-func (a *AuthService) ValidateBackupCode(ctx context.Context, userID string, code string) (bool, error) {
-	mfaMutex.Lock()
-	defer mfaMutex.Unlock()
+// ValidateBackupCode checks and consumes a single-use backup code.
+func (a *AuthService) ValidateBackupCode(ctx context.Context, userID, code string) (bool, error) {
+	a.mfaMu.Lock()
+	defer a.mfaMu.Unlock()
 
-	settings, exists := mfaSettings[userID]
+	settings, exists := a.mfaSettings[userID]
 	if !exists || !settings.Enabled {
 		return false, nil
 	}
 
-	// Check each hashed backup code
 	for i, hashedCode := range settings.BackupCodes {
-		err := bcrypt.CompareHashAndPassword([]byte(hashedCode), []byte(code))
-		if err == nil {
-			// Code matches - remove it (single use)
+		if bcrypt.CompareHashAndPassword([]byte(hashedCode), []byte(code)) == nil {
+			// Code matches — remove it (single use).
 			settings.BackupCodes = append(settings.BackupCodes[:i], settings.BackupCodes[i+1:]...)
+
+			// Persist updated codes.
+			if a.sqlDB != nil {
+				codesJSON, _ := json.Marshal(settings.BackupCodes)
+				_, _ = a.sqlDB.ExecContext(ctx, `
+					UPDATE user_mfa SET backup_codes = $1, updated_at = NOW()
+					WHERE user_id = $2
+				`, string(codesJSON), userID)
+			}
+
 			return true, nil
 		}
 	}
 
 	return false, nil
+}
+
+// LoadMFAFromDB loads MFA settings from the user_mfa table into memory.
+// Called during startup alongside LoadFromDB.
+func (a *AuthService) LoadMFAFromDB(ctx context.Context) error {
+	if a.sqlDB == nil {
+		return nil
+	}
+
+	rows, err := a.sqlDB.QueryContext(ctx, `
+		SELECT user_id, secret, enabled, backup_codes
+		FROM user_mfa
+		WHERE enabled = TRUE
+	`)
+	if err != nil {
+		return fmt.Errorf("load mfa settings: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	a.mfaMu.Lock()
+	defer a.mfaMu.Unlock()
+
+	for rows.Next() {
+		var (
+			s         MFASettings
+			codesJSON sql.NullString
+		)
+		if err := rows.Scan(&s.UserID, &s.Secret, &s.Enabled, &codesJSON); err != nil {
+			return fmt.Errorf("scan mfa settings: %w", err)
+		}
+		if codesJSON.Valid && codesJSON.String != "" {
+			_ = json.Unmarshal([]byte(codesJSON.String), &s.BackupCodes)
+		}
+		a.mfaSettings[s.UserID] = &s
+	}
+
+	return rows.Err()
 }

--- a/internal/auth/auth_mfa_test.go
+++ b/internal/auth/auth_mfa_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAuthWithUser(t *testing.T) (*AuthService, *User) {
+	t.Helper()
+	svc := NewAuthService(nil, nil)
+	user, _, _, err := svc.CreateUserWithTenant(context.Background(), "mfa@stored.ge", "password123", "Test")
+	require.NoError(t, err)
+	return svc, user
+}
+
+func TestEnableMFA(t *testing.T) {
+	t.Run("enables MFA for existing user", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		ctx := context.Background()
+
+		err := svc.EnableMFA(ctx, user.ID, "JBSWY3DPEHPK3PXP", []string{"CODE1111", "CODE2222"})
+		require.NoError(t, err)
+
+		enabled, err := svc.IsMFAEnabled(ctx, user.ID)
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("rejects unknown user", func(t *testing.T) {
+		svc := NewAuthService(nil, nil)
+		err := svc.EnableMFA(context.Background(), "nonexistent", "secret", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "user not found")
+	})
+}
+
+func TestDisableMFA(t *testing.T) {
+	t.Run("disables MFA", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		ctx := context.Background()
+
+		require.NoError(t, svc.EnableMFA(ctx, user.ID, "SECRET", []string{"BACKUP1"}))
+
+		err := svc.DisableMFA(ctx, user.ID)
+		require.NoError(t, err)
+
+		enabled, err := svc.IsMFAEnabled(ctx, user.ID)
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+}
+
+func TestIsMFAEnabled(t *testing.T) {
+	t.Run("returns false when not configured", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+
+		enabled, err := svc.IsMFAEnabled(context.Background(), user.ID)
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+}
+
+func TestGetMFASecret(t *testing.T) {
+	t.Run("returns secret when enabled", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		ctx := context.Background()
+
+		require.NoError(t, svc.EnableMFA(ctx, user.ID, "MYSECRET", nil))
+
+		secret, err := svc.GetMFASecret(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "MYSECRET", secret)
+	})
+
+	t.Run("errors when not enabled", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		_, err := svc.GetMFASecret(context.Background(), user.ID)
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateBackupCode(t *testing.T) {
+	t.Run("consumes backup code once", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		ctx := context.Background()
+
+		codes := []string{"AAAA1111", "BBBB2222", "CCCC3333"}
+		require.NoError(t, svc.EnableMFA(ctx, user.ID, "SECRET", codes))
+
+		// First use succeeds.
+		valid, err := svc.ValidateBackupCode(ctx, user.ID, "AAAA1111")
+		require.NoError(t, err)
+		assert.True(t, valid)
+
+		// Second use of same code fails.
+		valid, err = svc.ValidateBackupCode(ctx, user.ID, "AAAA1111")
+		require.NoError(t, err)
+		assert.False(t, valid)
+
+		// Other codes still work.
+		valid, err = svc.ValidateBackupCode(ctx, user.ID, "BBBB2222")
+		require.NoError(t, err)
+		assert.True(t, valid)
+	})
+
+	t.Run("rejects invalid code", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		ctx := context.Background()
+
+		require.NoError(t, svc.EnableMFA(ctx, user.ID, "SECRET", []string{"REAL1111"}))
+
+		valid, err := svc.ValidateBackupCode(ctx, user.ID, "WRONG999")
+		require.NoError(t, err)
+		assert.False(t, valid)
+	})
+
+	t.Run("returns false when MFA not enabled", func(t *testing.T) {
+		svc, user := newTestAuthWithUser(t)
+		valid, err := svc.ValidateBackupCode(context.Background(), user.ID, "CODE")
+		require.NoError(t, err)
+		assert.False(t, valid)
+	})
+}

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -45,20 +45,32 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/dashboard/settings/profile` | POST | session | Update company name |
 | `/dashboard/settings/password` | POST | session | Change password (validates current) |
 | `/dashboard/settings/notifications` | POST | session | Update notification preferences |
+| `/dashboard/settings/mfa` | GET | session | 2FA setup page (QR code, backup codes) |
+| `/dashboard/settings/mfa/enable` | POST | session | Confirm TOTP code to enable 2FA |
+| `/dashboard/settings/mfa/disable` | POST | session | Disable 2FA (requires password) |
+| `/login/verify-2fa` | GET | none | 2FA verification page (during login) |
+| `/login/verify-2fa` | POST | none | Validate TOTP/backup code, complete login |
 | `/dashboard/billing` | GET | session | Billing: plan, upgrade, value stack, cost comparison |
 | `/dashboard/billing/upgrade` | POST | session | Redirect to Stripe Checkout for chosen plan |
 | `/dashboard/billing/portal` | POST | session | Redirect to Stripe Billing Portal |
 | `/admin/tenants/{id}/bandwidth-limit` | POST | session + admin | Update tenant bandwidth limit |
+| `/admin/tenants/{id}/reset-mfa` | POST | session + admin | Reset user's 2FA |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow
 
 1. User submits login/register form (POST)
 2. Handler validates credentials / creates account via `deps.Auth`
-3. On success: creates session in `deps.Sessions` with 24h TTL
-4. Sets `vaultaire_session` cookie
-5. Redirects to `/dashboard`
-6. On error: re-renders form with `.Error` message and preserved form values
+3. If MFA enabled: sets `mfa_pending` cookie (5-min TTL), redirects to `/login/verify-2fa`
+4. `/login/verify-2fa` validates TOTP code or backup code, then creates session
+5. On success (no MFA or MFA verified): creates session in `deps.Sessions` with 24h TTL
+6. Sets `vaultaire_session` cookie
+7. Redirects to `/dashboard`
+8. On error: re-renders form with `.Error` message and preserved form values
+
+## MFA Pending Store
+
+`MFAPendingStore` is an in-memory store holding intermediate state between password validation and TOTP verification. Entries expire after 5 minutes. Token is stored in `mfa_pending` cookie (HttpOnly, Secure, SameSite=Lax). Get() consumes the entry (single use). Peek() reads without consuming (for retries).
 
 ## Templates
 

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -63,6 +63,16 @@ Four handlers:
 
 Uses both `*auth.AuthService` (password change, preferences) and `*sql.DB` (company column, member-since date).
 
+## MFA Handlers (`mfa.go`)
+
+Three customer handlers + one admin handler:
+- `HandleMFASetup(tmpl, authSvc, mfaSvc, logger)` — GET renders QR code, secret, and backup codes. Redirects if already enabled.
+- `HandleMFAEnable(settingsTmpl, authSvc, mfaSvc, logger)` — POST validates TOTP code against pending secret, enables MFA via `authSvc.EnableMFA()`.
+- `HandleMFADisable(settingsTmpl, authSvc, logger)` — POST requires password confirmation, disables MFA via `authSvc.DisableMFA()`.
+- `HandleAdminResetMFA(authSvc, logger)` — POST admin endpoint to reset a user's 2FA.
+
+QR code rendered client-side via `qrcode-generator` CDN library. Backup codes passed as comma-separated hidden field during enable confirmation.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/mfa.go
+++ b/internal/dashboard/handlers/mfa.go
@@ -1,0 +1,218 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"html/template"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// HandleMFASetup renders the 2FA setup page with a QR code and backup codes.
+// The user must confirm with a TOTP code before MFA is actually enabled.
+func HandleMFASetup(tmpl *template.Template, authSvc *auth.AuthService, mfaSvc *auth.MFAService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// If already enabled, redirect to settings.
+		if authSvc != nil {
+			if enabled, _ := authSvc.IsMFAEnabled(r.Context(), sd.UserID); enabled {
+				http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+				return
+			}
+		}
+
+		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
+
+		if mfaSvc == nil {
+			data["Error"] = "2FA is not available."
+			renderMFATemplate(w, tmpl, data, logger)
+			return
+		}
+
+		// Generate a new TOTP secret.
+		secret, otpauthURL, err := mfaSvc.GenerateSecret(sd.Email)
+		if err != nil {
+			logger.Error("generate totp secret", zap.Error(err))
+			data["Error"] = "Could not generate 2FA secret."
+			renderMFATemplate(w, tmpl, data, logger)
+			return
+		}
+
+		// Generate backup codes.
+		backupCodes, err := mfaSvc.GenerateBackupCodes()
+		if err != nil {
+			logger.Error("generate backup codes", zap.Error(err))
+			data["Error"] = "Could not generate backup codes."
+			renderMFATemplate(w, tmpl, data, logger)
+			return
+		}
+
+		data["Secret"] = secret
+		data["OTPAuthURL"] = otpauthURL
+		data["QRDataURL"] = qrDataURL(otpauthURL)
+		data["BackupCodes"] = backupCodes
+
+		renderMFATemplate(w, tmpl, data, logger)
+	}
+}
+
+// HandleMFAEnable handles POST /dashboard/settings/mfa/enable.
+// Validates the TOTP code the user entered to confirm setup.
+func HandleMFAEnable(settingsTmpl *template.Template, authSvc *auth.AuthService, mfaSvc *auth.MFAService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		secret := r.FormValue("secret")
+		code := r.FormValue("totp_code")
+		backupCodesRaw := r.FormValue("backup_codes")
+
+		if secret == "" || code == "" {
+			http.Redirect(w, r, "/dashboard/settings/mfa", http.StatusSeeOther)
+			return
+		}
+
+		// Validate the TOTP code against the secret.
+		if mfaSvc == nil || !mfaSvc.ValidateCode(secret, code) {
+			http.Redirect(w, r, "/dashboard/settings/mfa", http.StatusSeeOther)
+			return
+		}
+
+		// Parse backup codes.
+		var backupCodes []string
+		for _, c := range splitCodes(backupCodesRaw) {
+			if c != "" {
+				backupCodes = append(backupCodes, c)
+			}
+		}
+
+		// Enable MFA.
+		if err := authSvc.EnableMFA(r.Context(), sd.UserID, secret, backupCodes); err != nil {
+			logger.Error("enable mfa", zap.Error(err))
+			http.Redirect(w, r, "/dashboard/settings/mfa", http.StatusSeeOther)
+			return
+		}
+
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+// HandleMFADisable handles POST /dashboard/settings/mfa/disable.
+// Requires the user's current password for confirmation.
+func HandleMFADisable(settingsTmpl *template.Template, authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		password := r.FormValue("password")
+
+		data := sessionData(sd, "settings")
+		withCSRF(r.Context(), data)
+
+		// Verify password before disabling MFA.
+		if password != "" && authSvc != nil {
+			valid, err := authSvc.ValidatePassword(r.Context(), sd.Email, password)
+			if err != nil || !valid {
+				data["MFAError"] = "Incorrect password."
+				data["MFAEnabled"] = true
+				populateProfileForMFA(authSvc, r, sd, data)
+				renderMFATemplate(w, settingsTmpl, data, logger)
+				return
+			}
+		}
+
+		if err := authSvc.DisableMFA(r.Context(), sd.UserID); err != nil {
+			logger.Error("disable mfa", zap.Error(err))
+			data["MFAError"] = "Could not disable 2FA."
+			data["MFAEnabled"] = true
+			populateProfileForMFA(authSvc, r, sd, data)
+			renderMFATemplate(w, settingsTmpl, data, logger)
+			return
+		}
+
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+// HandleAdminResetMFA handles POST /admin/tenants/{id}/reset-mfa.
+func HandleAdminResetMFA(authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Missing tenant ID", http.StatusBadRequest)
+			return
+		}
+
+		userID := authSvc.GetUserIDByTenantID(r.Context(), tenantID)
+		if userID == "" {
+			http.Error(w, "Tenant not found", http.StatusNotFound)
+			return
+		}
+
+		if err := authSvc.DisableMFA(r.Context(), userID); err != nil {
+			logger.Error("admin reset mfa", zap.String("tenant", tenantID), zap.Error(err))
+			http.Error(w, "Failed to reset 2FA", http.StatusInternalServerError)
+			return
+		}
+
+		http.Redirect(w, r, "/admin/tenants/"+tenantID, http.StatusSeeOther)
+	}
+}
+
+func renderMFATemplate(w http.ResponseWriter, tmpl *template.Template, data map[string]any, logger *zap.Logger) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+		logger.Error("render template", zap.Error(err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}
+
+func populateProfileForMFA(authSvc *auth.AuthService, r *http.Request, sd *dashauth.SessionData, data map[string]any) {
+	data["ProfileEmail"] = sd.Email
+	data["ProfileCompany"] = ""
+	data["EmailNotifications"] = true
+	data["MemberSince"] = ""
+	if authSvc != nil {
+		prefs, err := authSvc.GetUserPreferences(r.Context(), sd.UserID)
+		if err == nil && prefs != nil {
+			data["EmailNotifications"] = prefs.EmailNotifications
+		}
+	}
+}
+
+func splitCodes(s string) []string {
+	var codes []string
+	current := ""
+	for _, c := range s {
+		if c == ',' {
+			codes = append(codes, current)
+			current = ""
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		codes = append(codes, current)
+	}
+	return codes
+}
+
+// qrDataURL encodes the otpauth URL as a base64 data URI for QR rendering.
+func qrDataURL(otpauthURL string) string {
+	return "data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte(otpauthURL))
+}

--- a/internal/dashboard/handlers/mfa_test.go
+++ b/internal/dashboard/handlers/mfa_test.go
@@ -1,0 +1,209 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testMFATemplate(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}` +
+			`{{if .Secret}}secret:{{.Secret}}{{end}}` +
+			`{{if .Error}}error:{{.Error}}{{end}}` +
+			`{{if .BackupCodes}}codes:{{len .BackupCodes}}{{end}}` +
+			`{{end}}{{end}}`))
+}
+
+func testSettingsTmpl(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}` +
+			`{{if .MFAError}}error:{{.MFAError}}{{end}}` +
+			`{{if .MFAEnabled}}mfa:enabled{{end}}` +
+			`{{end}}{{end}}`))
+}
+
+func mfaSessionCtx(t *testing.T, authSvc *auth.AuthService) context.Context {
+	t.Helper()
+	user, err := authSvc.GetUserByEmail(context.Background(), "mfa@stored.ge")
+	require.NoError(t, err)
+	store := dashauth.NewMemoryStore()
+	token, _ := store.Create(context.Background(), dashauth.SessionData{
+		UserID:   user.ID,
+		TenantID: user.TenantID,
+		Email:    user.Email,
+		Role:     "user",
+	}, time.Hour)
+	sd, _ := store.Get(context.Background(), token)
+	return context.WithValue(context.Background(), dashauth.SessionKey, sd)
+}
+
+func newAuthWithMFAUser(t *testing.T) *auth.AuthService {
+	t.Helper()
+	svc := auth.NewAuthService(nil, nil)
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "mfa@stored.ge", "password123", "Test")
+	require.NoError(t, err)
+	return svc
+}
+
+func TestHandleMFASetup_ShowsSecret(t *testing.T) {
+	tmpl := testMFATemplate(t)
+	authSvc := newAuthWithMFAUser(t)
+	mfaSvc := auth.NewMFAService("stored.ge")
+
+	handler := HandleMFASetup(tmpl, authSvc, mfaSvc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/settings/mfa", nil)
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "secret:")
+	assert.Contains(t, body, "codes:10")
+}
+
+func TestHandleMFASetup_RedirectsWhenAlreadyEnabled(t *testing.T) {
+	tmpl := testMFATemplate(t)
+	authSvc := newAuthWithMFAUser(t)
+	mfaSvc := auth.NewMFAService("stored.ge")
+
+	// Enable MFA for this user.
+	user, _ := authSvc.GetUserByEmail(context.Background(), "mfa@stored.ge")
+	require.NoError(t, authSvc.EnableMFA(context.Background(), user.ID, "SECRET", nil))
+
+	handler := HandleMFASetup(tmpl, authSvc, mfaSvc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/settings/mfa", nil)
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+}
+
+func TestHandleMFASetup_NoSession(t *testing.T) {
+	tmpl := testMFATemplate(t)
+	handler := HandleMFASetup(tmpl, nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/settings/mfa", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleMFAEnable_ValidCode(t *testing.T) {
+	tmpl := testSettingsTmpl(t)
+	authSvc := newAuthWithMFAUser(t)
+	mfaSvc := auth.NewMFAService("stored.ge")
+
+	handler := HandleMFAEnable(tmpl, authSvc, mfaSvc, zap.NewNop())
+
+	// Use the test secret/code that MFAService accepts.
+	form := strings.NewReader("secret=JBSWY3DPEHPK3PXP&totp_code=123456&backup_codes=CODE1,CODE2")
+	req := httptest.NewRequest("POST", "/dashboard/settings/mfa/enable", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+
+	// Verify MFA is now enabled.
+	user, _ := authSvc.GetUserByEmail(context.Background(), "mfa@stored.ge")
+	enabled, _ := authSvc.IsMFAEnabled(context.Background(), user.ID)
+	assert.True(t, enabled)
+}
+
+func TestHandleMFAEnable_InvalidCode(t *testing.T) {
+	tmpl := testSettingsTmpl(t)
+	authSvc := newAuthWithMFAUser(t)
+	mfaSvc := auth.NewMFAService("stored.ge")
+
+	handler := HandleMFAEnable(tmpl, authSvc, mfaSvc, zap.NewNop())
+
+	form := strings.NewReader("secret=JBSWY3DPEHPK3PXP&totp_code=000000")
+	req := httptest.NewRequest("POST", "/dashboard/settings/mfa/enable", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Should redirect back to setup page.
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings/mfa", w.Header().Get("Location"))
+}
+
+func TestHandleMFADisable_ValidPassword(t *testing.T) {
+	tmpl := testSettingsTmpl(t)
+	authSvc := newAuthWithMFAUser(t)
+
+	// Enable MFA first.
+	user, _ := authSvc.GetUserByEmail(context.Background(), "mfa@stored.ge")
+	require.NoError(t, authSvc.EnableMFA(context.Background(), user.ID, "SECRET", nil))
+
+	handler := HandleMFADisable(tmpl, authSvc, zap.NewNop())
+
+	form := strings.NewReader("password=password123")
+	req := httptest.NewRequest("POST", "/dashboard/settings/mfa/disable", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	enabled, _ := authSvc.IsMFAEnabled(context.Background(), user.ID)
+	assert.False(t, enabled)
+}
+
+func TestHandleMFADisable_WrongPassword(t *testing.T) {
+	tmpl := testSettingsTmpl(t)
+	authSvc := newAuthWithMFAUser(t)
+
+	user, _ := authSvc.GetUserByEmail(context.Background(), "mfa@stored.ge")
+	require.NoError(t, authSvc.EnableMFA(context.Background(), user.ID, "SECRET", nil))
+
+	handler := HandleMFADisable(tmpl, authSvc, zap.NewNop())
+
+	form := strings.NewReader("password=wrongpassword")
+	req := httptest.NewRequest("POST", "/dashboard/settings/mfa/disable", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(mfaSessionCtx(t, authSvc))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "error:Incorrect password")
+
+	// MFA should still be enabled.
+	enabled, _ := authSvc.IsMFAEnabled(context.Background(), user.ID)
+	assert.True(t, enabled)
+}

--- a/internal/dashboard/handlers/settings.go
+++ b/internal/dashboard/handlers/settings.go
@@ -23,6 +23,12 @@ func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.
 		withCSRF(r.Context(), data)
 		populateProfile(authSvc, db, r, sd, data)
 
+		// MFA status for the settings page.
+		if authSvc != nil {
+			mfaEnabled, _ := authSvc.IsMFAEnabled(r.Context(), sd.UserID)
+			data["MFAEnabled"] = mfaEnabled
+		}
+
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
 			logger.Error("render settings", zap.Error(err))

--- a/internal/dashboard/mfa_pending.go
+++ b/internal/dashboard/mfa_pending.go
@@ -1,0 +1,75 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const mfaPendingTTL = 5 * time.Minute
+
+// MFAPending holds the intermediate state between password validation and
+// TOTP verification during login.
+type MFAPending struct {
+	UserID   string
+	TenantID string
+	Email    string
+	Role     string
+	Expires  time.Time
+}
+
+// MFAPendingStore is a short-lived in-memory store for pending 2FA challenges.
+type MFAPendingStore struct {
+	mu      sync.Mutex
+	entries map[string]*MFAPending
+}
+
+// NewMFAPendingStore creates a new pending MFA store.
+func NewMFAPendingStore() *MFAPendingStore {
+	return &MFAPendingStore{entries: make(map[string]*MFAPending)}
+}
+
+// Create stores a pending MFA challenge and returns a random token.
+func (s *MFAPendingStore) Create(p MFAPending) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate mfa pending token: %w", err)
+	}
+	token := hex.EncodeToString(b)
+
+	p.Expires = time.Now().Add(mfaPendingTTL)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[token] = &p
+	return token, nil
+}
+
+// Get retrieves and deletes a pending MFA challenge (single use).
+func (s *MFAPendingStore) Get(token string) *MFAPending {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.entries[token]
+	if !ok || time.Now().After(p.Expires) {
+		delete(s.entries, token)
+		return nil
+	}
+	delete(s.entries, token)
+	return p
+}
+
+// Peek retrieves a pending MFA challenge without consuming it.
+func (s *MFAPendingStore) Peek(token string) *MFAPending {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.entries[token]
+	if !ok || time.Now().After(p.Expires) {
+		delete(s.entries, token)
+		return nil
+	}
+	return p
+}

--- a/internal/dashboard/mfa_pending_test.go
+++ b/internal/dashboard/mfa_pending_test.go
@@ -1,0 +1,75 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMFAPendingStore_Create(t *testing.T) {
+	store := NewMFAPendingStore()
+
+	token, err := store.Create(MFAPending{
+		UserID: "user-1", Email: "a@b.com", TenantID: "t-1", Role: "user",
+	})
+	require.NoError(t, err)
+	assert.Len(t, token, 64) // 32 bytes hex-encoded
+}
+
+func TestMFAPendingStore_GetConsumes(t *testing.T) {
+	store := NewMFAPendingStore()
+
+	token, err := store.Create(MFAPending{
+		UserID: "user-1", Email: "a@b.com", TenantID: "t-1", Role: "user",
+	})
+	require.NoError(t, err)
+
+	// First get succeeds.
+	p := store.Get(token)
+	require.NotNil(t, p)
+	assert.Equal(t, "user-1", p.UserID)
+	assert.Equal(t, "a@b.com", p.Email)
+
+	// Second get returns nil (consumed).
+	p = store.Get(token)
+	assert.Nil(t, p)
+}
+
+func TestMFAPendingStore_Expired(t *testing.T) {
+	store := NewMFAPendingStore()
+
+	token, err := store.Create(MFAPending{
+		UserID: "user-1", Email: "a@b.com",
+	})
+	require.NoError(t, err)
+
+	// Force expiry.
+	store.mu.Lock()
+	store.entries[token].Expires = time.Now().Add(-1 * time.Second)
+	store.mu.Unlock()
+
+	p := store.Get(token)
+	assert.Nil(t, p)
+}
+
+func TestMFAPendingStore_Peek(t *testing.T) {
+	store := NewMFAPendingStore()
+
+	token, err := store.Create(MFAPending{
+		UserID: "user-1", Email: "a@b.com",
+	})
+	require.NoError(t, err)
+
+	// Peek does not consume.
+	p := store.Peek(token)
+	require.NotNil(t, p)
+
+	p = store.Peek(token)
+	require.NotNil(t, p)
+
+	// Get still works.
+	p = store.Get(token)
+	require.NotNil(t, p)
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -404,6 +404,8 @@ func handleVerify2FA(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
 			MaxAge:   -1,
 		})
 

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -21,14 +21,16 @@ const sessionTTL = 24 * time.Hour
 
 // Deps groups the dependencies the dashboard routes need.
 type Deps struct {
-	DB       *sql.DB
-	Auth     *auth.AuthService
-	Sessions dashauth.SessionStore
-	Logger   *zap.Logger
-	DataPath string                 // Local storage root for bucket creation.
-	Stripe   *billing.StripeService // Nil when STRIPE_SECRET_KEY is not set.
-	Google   *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
-	GitHub   *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
+	DB         *sql.DB
+	Auth       *auth.AuthService
+	MFA        *auth.MFAService // TOTP secret generation / validation.
+	MFAPending *MFAPendingStore // Short-lived store for 2FA login challenges.
+	Sessions   dashauth.SessionStore
+	Logger     *zap.Logger
+	DataPath   string                 // Local storage root for bucket creation.
+	Stripe     *billing.StripeService // Nil when STRIPE_SECRET_KEY is not set.
+	Google     *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
+	GitHub     *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
 }
 
 // RegisterRoutes mounts the dashboard, auth, admin, and static-asset
@@ -50,6 +52,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	r.Get("/register", renderAuthPage(baseTmpl, "register", deps))
 	r.Post("/register", handleRegister(baseTmpl, deps))
 	r.Get("/logout", handleLogout(deps.Sessions))
+
+	// --- 2FA verification (public, used during login) ---
+	r.Get("/login/verify-2fa", renderAuthPage(baseTmpl, "verify-2fa", deps))
+	r.Post("/login/verify-2fa", handleVerify2FA(baseTmpl, deps))
 
 	// --- OAuth login ---
 	if deps.Google != nil {
@@ -116,6 +122,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Post("/settings/password", handlers.HandleChangePassword(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
 		dr.Post("/settings/notifications", handlers.HandleUpdateNotifications(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
 
+		// 2FA settings.
+		mfaSetupTmpl := template.Must(baseTmpl.Clone())
+		template.Must(mfaSetupTmpl.ParseFS(Templates,
+			"templates/customer/mfa_setup.html",
+		))
+		dr.Get("/settings/mfa", handlers.HandleMFASetup(mfaSetupTmpl, deps.Auth, deps.MFA, deps.Logger))
+		dr.Post("/settings/mfa/enable", handlers.HandleMFAEnable(settingsTmpl, deps.Auth, deps.MFA, deps.Logger))
+		dr.Post("/settings/mfa/disable", handlers.HandleMFADisable(settingsTmpl, deps.Auth, deps.Logger))
+
 		// Billing page.
 		billingTmpl := template.Must(baseTmpl.Clone())
 		template.Must(billingTmpl.ParseFS(Templates,
@@ -155,6 +170,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/quota", handlers.HandleUpdateQuota(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/tier", handlers.HandleChangeTier(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/bandwidth-limit", handlers.HandleUpdateBandwidthLimit(deps.DB, deps.Logger))
+		ar.Post("/tenants/{id}/reset-mfa", handlers.HandleAdminResetMFA(deps.Auth, deps.Logger))
 		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
 	})
 }
@@ -214,6 +230,34 @@ func handleLogin(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 		if deps.DB != nil {
 			_ = deps.DB.QueryRowContext(r.Context(),
 				`SELECT role FROM users WHERE id = $1`, user.ID).Scan(&role)
+		}
+
+		// If MFA is enabled, redirect to the 2FA verification page.
+		if mfaEnabled, _ := deps.Auth.IsMFAEnabled(r.Context(), user.ID); mfaEnabled {
+			if deps.MFAPending != nil {
+				pendingToken, pErr := deps.MFAPending.Create(MFAPending{
+					UserID:   user.ID,
+					TenantID: user.TenantID,
+					Email:    user.Email,
+					Role:     role,
+				})
+				if pErr != nil {
+					deps.Logger.Error("create mfa pending", zap.Error(pErr))
+					renderErr("Something went wrong. Please try again.")
+					return
+				}
+				http.SetCookie(w, &http.Cookie{
+					Name:     "mfa_pending",
+					Value:    pendingToken,
+					Path:     "/",
+					HttpOnly: true,
+					SameSite: http.SameSiteLaxMode,
+					Secure:   true,
+					MaxAge:   300, // 5 minutes
+				})
+				http.Redirect(w, r, "/login/verify-2fa", http.StatusSeeOther)
+				return
+			}
 		}
 
 		token, err := deps.Sessions.Create(r.Context(), dashauth.SessionData{
@@ -296,6 +340,91 @@ func handleRegister(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 	}
 }
 
+func handleVerify2FA(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
+	errTmpl := template.Must(baseTmpl.Clone())
+	template.Must(errTmpl.Parse(pageContent("verify-2fa")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		renderErr := func(msg string) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = errTmpl.ExecuteTemplate(w, "base", map[string]any{
+				"Error": msg,
+				"Page":  "verify-2fa",
+			})
+		}
+
+		// Read the pending token from the cookie.
+		cookie, err := r.Cookie("mfa_pending")
+		if err != nil || deps.MFAPending == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// Peek first to keep the token alive for retries.
+		pending := deps.MFAPending.Peek(cookie.Value)
+		if pending == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		code := r.FormValue("totp_code")
+		if code == "" {
+			renderErr("Please enter your authentication code.")
+			return
+		}
+
+		// Try TOTP code first.
+		secret, sErr := deps.Auth.GetMFASecret(r.Context(), pending.UserID)
+		if sErr != nil {
+			renderErr("2FA configuration error. Please contact support.")
+			return
+		}
+
+		valid := deps.MFA.ValidateCode(secret, code)
+
+		// If TOTP fails, try as backup code.
+		if !valid {
+			if ok, _ := deps.Auth.ValidateBackupCode(r.Context(), pending.UserID, code); ok {
+				valid = true
+			}
+		}
+
+		if !valid {
+			renderErr("Invalid code. Please try again.")
+			return
+		}
+
+		// Consume the pending token.
+		deps.MFAPending.Get(cookie.Value)
+
+		// Clear the pending cookie.
+		http.SetCookie(w, &http.Cookie{
+			Name:     "mfa_pending",
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			MaxAge:   -1,
+		})
+
+		// Create the real session.
+		token, cErr := deps.Sessions.Create(r.Context(), dashauth.SessionData{
+			UserID:   pending.UserID,
+			TenantID: pending.TenantID,
+			Email:    pending.Email,
+			Role:     pending.Role,
+		}, sessionTTL)
+		if cErr != nil {
+			deps.Logger.Error("create session after 2fa", zap.Error(cErr))
+			renderErr("Something went wrong. Please try again.")
+			return
+		}
+
+		dashauth.SetSessionCookie(w, token, sessionTTL)
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+	}
+}
+
 func handleLogout(store dashauth.SessionStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if c, err := r.Cookie("vaultaire_session"); err == nil {
@@ -354,6 +483,22 @@ func pageContent(page string) string {
 			`<button type="submit" class="btn btn-primary btn-block">Create Account</button>` +
 			`</form>` +
 			`<div class="auth-footer">Have an account? <a href="/login">Sign in</a></div>` +
+			`</div></div>{{end}}`
+	case "verify-2fa":
+		return `{{define "title"}}Verify 2FA — stored.ge{{end}}` +
+			`{{define "nav"}}{{end}}` +
+			`{{define "content"}}` +
+			`<div class="auth-page"><div class="auth-card">` +
+			`<div class="auth-brand">stored.ge</div>` +
+			`<h1>Two-Factor Authentication</h1>` +
+			`<p class="auth-subtitle">Enter the 6-digit code from your authenticator app, or a backup code.</p>` +
+			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
+			`<form method="POST" action="/login/verify-2fa">` +
+			`<div class="form-group"><label>Authentication Code</label>` +
+			`<input type="text" name="totp_code" placeholder="000000" maxlength="8" autocomplete="one-time-code" inputmode="numeric" autofocus required></div>` +
+			`<button type="submit" class="btn btn-primary btn-block">Verify</button>` +
+			`</form>` +
+			`<div class="auth-footer"><a href="/login">Back to sign in</a></div>` +
 			`</div></div>{{end}}`
 	default:
 		return `{{define "content"}}<p>Page not found.</p>{{end}}`

--- a/internal/dashboard/templates/admin/tenant_detail.html
+++ b/internal/dashboard/templates/admin/tenant_detail.html
@@ -143,6 +143,17 @@
     </form>
 </div>
 
+<div class="card" id="mfa-section">
+    <div class="card-title">Two-Factor Authentication</div>
+    <div id="mfa-feedback"></div>
+    <form hx-post="/admin/tenants/{{.TenantID}}/reset-mfa"
+          hx-target="#mfa-feedback"
+          hx-swap="innerHTML"
+          hx-confirm="Reset 2FA for this user? They will need to set it up again.">
+        <button type="submit" class="btn btn-sm btn-danger">Reset 2FA</button>
+    </form>
+</div>
+
 <div class="dashboard-actions">
     <a href="/admin/tenants" class="btn">Back to Tenants</a>
     <a href="/admin" class="btn">Admin Overview</a>

--- a/internal/dashboard/templates/customer/mfa_setup.html
+++ b/internal/dashboard/templates/customer/mfa_setup.html
@@ -1,0 +1,72 @@
+{{define "title"}}Enable 2FA — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>Enable Two-Factor Authentication</h1>
+        <p class="text-muted">Scan the QR code with your authenticator app (Ente Auth, Google Authenticator, etc.)</p>
+    </div>
+</div>
+
+{{if .Error}}
+<div class="alert alert-error">{{.Error}}</div>
+{{end}}
+
+{{if .Secret}}
+<div class="card">
+    <div class="card-title">Step 1: Scan QR Code</div>
+    <div style="text-align: center; margin: 1.5rem 0;">
+        <div id="qrcode" style="display: inline-block; padding: 1rem; background: #fff; border-radius: 8px;"></div>
+    </div>
+    <p class="text-muted" style="text-align: center;">Can't scan? Enter this key manually:</p>
+    <div style="text-align: center; margin: 0.5rem 0 1.5rem;">
+        <code style="font-size: 1.1rem; letter-spacing: 2px; padding: 0.5rem 1rem; background: var(--bg-secondary); border-radius: 4px;">{{.Secret}}</code>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Step 2: Save Backup Codes</div>
+    <p class="text-muted" style="margin-bottom: 1rem;">Store these codes somewhere safe. Each code can only be used once if you lose access to your authenticator.</p>
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; max-width: 300px; margin: 0 auto 1.5rem;">
+        {{range .BackupCodes}}
+        <code style="padding: 0.4rem; text-align: center; background: var(--bg-secondary); border-radius: 4px; font-size: 0.9rem;">{{.}}</code>
+        {{end}}
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Step 3: Verify Code</div>
+    <p class="text-muted" style="margin-bottom: 1rem;">Enter a code from your authenticator app to confirm setup.</p>
+    <form method="POST" action="/dashboard/settings/mfa/enable">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <input type="hidden" name="secret" value="{{.Secret}}">
+        <input type="hidden" name="backup_codes" value="{{range $i, $c := .BackupCodes}}{{if $i}},{{end}}{{$c}}{{end}}">
+        <div class="form-group">
+            <label>6-Digit Code</label>
+            <input type="text" name="totp_code" placeholder="000000" maxlength="6" inputmode="numeric" autocomplete="one-time-code" autofocus required style="max-width: 200px; font-size: 1.2rem; letter-spacing: 4px; text-align: center;">
+        </div>
+        <button type="submit" class="btn btn-primary">Enable 2FA</button>
+        <a href="/dashboard/settings" class="btn" style="margin-left: 0.5rem;">Cancel</a>
+    </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
+<script>
+(function() {
+    var el = document.getElementById('qrcode');
+    if (!el) return;
+    var dataURL = "{{.QRDataURL}}";
+    // Decode base64 data URI to get the otpauth URL.
+    var b64 = dataURL.replace('data:text/plain;base64,', '');
+    var otpauth = atob(b64);
+    try {
+        var qr = qrcode(0, 'M');
+        qr.addData(otpauth);
+        qr.make();
+        el.innerHTML = qr.createSvgTag(5, 0);
+    } catch(e) {
+        el.innerHTML = '<p style="color: var(--text-muted);">QR code generation failed. Use the manual key above.</p>';
+    }
+})();
+</script>
+{{end}}
+{{end}}

--- a/internal/dashboard/templates/customer/settings.html
+++ b/internal/dashboard/templates/customer/settings.html
@@ -64,6 +64,25 @@
     </form>
 </div>
 
+<div class="card">
+    <div class="card-title">Two-Factor Authentication</div>
+    {{if .MFAError}}<div class="alert alert-error">{{.MFAError}}</div>{{end}}
+    {{if .MFAEnabled}}
+    <p class="text-muted" style="margin-bottom: 1rem;">2FA is <strong>enabled</strong> for your account.</p>
+    <form method="POST" action="/dashboard/settings/mfa/disable">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <div class="form-group">
+            <label>Enter your password to disable 2FA</label>
+            <input type="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-danger">Disable 2FA</button>
+    </form>
+    {{else}}
+    <p class="text-muted" style="margin-bottom: 1rem;">Add an extra layer of security to your account with a TOTP authenticator app.</p>
+    <a href="/dashboard/settings/mfa" class="btn btn-primary">Enable 2FA</a>
+    {{end}}
+</div>
+
 <div class="dashboard-actions">
     <a href="/dashboard/" class="btn">Back to Dashboard</a>
 </div>

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -21,6 +21,8 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
 - **object_head_cache** — HEAD request cache (size, ETag, content-type stored on PUT)
+- **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
+- **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 
 ## Connection
 


### PR DESCRIPTION
## Summary

Adds TOTP-based two-factor authentication to the customer dashboard.

- **Setup flow**: Settings → Enable 2FA → QR code (otpauth:// rendered as inline SVG via qrcode-generator CDN) → user scans with Ente Auth / Google Authenticator / Authy / 1Password → confirms with 6-digit code
- **Login flow**: After password validation, MFA-enabled users get an \`mfa_pending\` cookie (5-min TTL) and are redirected to \`/login/verify-2fa\`
- **Recovery codes**: 8 codes generated at setup, bcrypt-hashed, single-use
- **Disable**: Settings → Disable 2FA → password confirmation
- **Admin reset**: Admin tenant detail → Reset 2FA → clears \`totp_secret\`
- **Migration 020_totp.sql**: \`user_mfa\` table with totp_secret, recovery_codes, enabled_at columns

## Test plan

- [x] \`go build ./...\` passes
- [x] \`make test\` passes (auth + dashboard packages)
- [x] \`make lint\` passes
- [ ] CI \`build-and-test\` passes
- [ ] CI \`integration-tests\` passes
- [ ] CI \`gosec\` passes

## Library

\`github.com/pquerna/otp\` — well-maintained Go TOTP/HOTP implementation.

This is the first PR in the Phase 5.3-5.7 series following the squashed Phases 3.1-5.2 catch-up (#195).