### PR TITLE
feat(dashboard): login rate limiting at 5 attempts/min per IP [Phase 5.5]

### DIFF
--- a/internal/dashboard/middleware/ratelimit.go
+++ b/internal/dashboard/middleware/ratelimit.go
@@ -1,0 +1,98 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// LoginRateLimiter limits login attempts per IP address.
+type LoginRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*visitorLimiter
+	rps      rate.Limit // tokens per second
+	burst    int
+}
+
+type visitorLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// NewLoginRateLimiter creates a rate limiter allowing perMinute attempts
+// with the given burst size per IP.
+func NewLoginRateLimiter(perMinute int, burst int) *LoginRateLimiter {
+	return &LoginRateLimiter{
+		limiters: make(map[string]*visitorLimiter),
+		rps:      rate.Limit(float64(perMinute) / 60.0),
+		burst:    burst,
+	}
+}
+
+// Limit returns middleware that rate-limits requests by client IP.
+func (rl *LoginRateLimiter) Limit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r)
+		limiter := rl.getLimiter(ip)
+
+		if !limiter.Allow() {
+			w.Header().Set("Retry-After", "60")
+			http.Error(w, "Too many login attempts. Please try again in a minute.", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (rl *LoginRateLimiter) getLimiter(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	v, exists := rl.limiters[ip]
+	if !exists {
+		v = &visitorLimiter{
+			limiter:  rate.NewLimiter(rl.rps, rl.burst),
+			lastSeen: time.Now(),
+		}
+		rl.limiters[ip] = v
+	}
+	v.lastSeen = time.Now()
+	return v.limiter
+}
+
+// Cleanup removes entries not seen in the last 5 minutes.
+// Call periodically from a goroutine.
+func (rl *LoginRateLimiter) Cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-5 * time.Minute)
+	for ip, v := range rl.limiters {
+		if v.lastSeen.Before(cutoff) {
+			delete(rl.limiters, ip)
+		}
+	}
+}
+
+// clientIP extracts the client IP, preferring X-Forwarded-For (first entry)
+// since HAProxy sits in front of Vaultaire.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP (client), ignore proxies.
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/internal/dashboard/middleware/ratelimit_test.go
+++ b/internal/dashboard/middleware/ratelimit_test.go
@@ -1,0 +1,114 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoginRateLimit_AllowsUnderLimit(t *testing.T) {
+	rl := NewLoginRateLimiter(5, 1) // 5 per minute, burst 1
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/login", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestLoginRateLimit_BlocksOverLimit(t *testing.T) {
+	rl := NewLoginRateLimiter(2, 2) // 2 per minute, burst 2
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Exhaust the burst.
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("POST", "/login", nil)
+		req.RemoteAddr = "10.0.0.1:9999"
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Next request should be rate limited.
+	req := httptest.NewRequest("POST", "/login", nil)
+	req.RemoteAddr = "10.0.0.1:9999"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Body.String(), "Too many login attempts")
+}
+
+func TestLoginRateLimit_DifferentIPsIndependent(t *testing.T) {
+	rl := NewLoginRateLimiter(1, 1) // 1 per minute, burst 1
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First IP uses its token.
+	req1 := httptest.NewRequest("POST", "/login", nil)
+	req1.RemoteAddr = "10.0.0.1:1111"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Second IP should still be allowed.
+	req2 := httptest.NewRequest("POST", "/login", nil)
+	req2.RemoteAddr = "10.0.0.2:2222"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+}
+
+func TestLoginRateLimit_XForwardedFor(t *testing.T) {
+	rl := NewLoginRateLimiter(1, 1)
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request from forwarded IP.
+	req1 := httptest.NewRequest("POST", "/login", nil)
+	req1.RemoteAddr = "127.0.0.1:8000"
+	req1.Header.Set("X-Forwarded-For", "203.0.113.50")
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Second request from same forwarded IP should be blocked.
+	req2 := httptest.NewRequest("POST", "/login", nil)
+	req2.RemoteAddr = "127.0.0.1:8000"
+	req2.Header.Set("X-Forwarded-For", "203.0.113.50")
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+}
+
+func TestLoginRateLimit_CleanupRemovesStaleEntries(t *testing.T) {
+	rl := NewLoginRateLimiter(5, 5)
+
+	// Add some entries.
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest("POST", "/login", nil)
+		req.RemoteAddr = "10.0.0." + string(rune('0'+i)) + ":1234"
+		w := httptest.NewRecorder()
+		rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(w, req)
+	}
+
+	// Cleanup should not panic.
+	rl.Cleanup()
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -46,16 +46,19 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/base.html",
 	))
 
+	// Rate limiter: 5 attempts/min per IP for login and 2FA.
+	loginRL := middleware.NewLoginRateLimiter(5, 5)
+
 	// --- Public auth routes ---
 	r.Get("/login", renderAuthPage(baseTmpl, "login", deps))
-	r.Post("/login", handleLogin(baseTmpl, deps))
+	r.Post("/login", loginRL.Limit(handleLogin(baseTmpl, deps)).ServeHTTP)
 	r.Get("/register", renderAuthPage(baseTmpl, "register", deps))
 	r.Post("/register", handleRegister(baseTmpl, deps))
 	r.Get("/logout", handleLogout(deps.Sessions))
 
 	// --- 2FA verification (public, used during login) ---
 	r.Get("/login/verify-2fa", renderAuthPage(baseTmpl, "verify-2fa", deps))
-	r.Post("/login/verify-2fa", handleVerify2FA(baseTmpl, deps))
+	r.Post("/login/verify-2fa", loginRL.Limit(handleVerify2FA(baseTmpl, deps)).ServeHTTP)
 
 	// --- OAuth login ---
 	if deps.Google != nil {


### PR DESCRIPTION
## Summary

Adds per-IP rate limiting to the login and 2FA verification endpoints to defend against brute-force attacks.

- \`LoginRateLimiter\` (token bucket via \`golang.org/x/time/rate\`) — 5 attempts/min per IP, burst 5
- Wrapped around \`POST /login\` and \`POST /login/verify-2fa\`
- Failed 2FA attempts count toward the lockout
- IP detection: \`X-Forwarded-For\` first entry (HAProxy fronts the service), falls back to \`r.RemoteAddr\`
- Returns 429 with \`Retry-After: 60\` when limit exceeded
- \`Cleanup()\` method to drop entries older than 5 minutes (call from a background goroutine if memory growth becomes a concern)

## Test plan

- [x] \`make test\` passes (rate-limit unit tests cover allow/deny, IP isolation, X-Forwarded-For parsing)
- [x] \`make lint\` passes
- [ ] CI \`build-and-test\` passes
- [ ] CI \`gosec\` passes
- [ ] CI \`integration-tests\` passes