### PR TITLE
feat(dashboard): password reset flow with HMAC tokens [Phase 5.7]

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -605,7 +605,7 @@ func (s *Server) handlePasswordResetComplete(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := s.auth.CompletePasswordReset(r.Context(), req.Token, req.NewPassword); err != nil {
+	if _, err := s.auth.CompletePasswordReset(r.Context(), req.Token, req.NewPassword); err != nil {
 		http.Error(w, "Invalid or expired token", http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -21,6 +21,20 @@ Authentication service for Vaultaire. Handles user registration, login, JWT toke
 - `GetMFASecret(ctx, userID)` — returns TOTP secret for enabled users.
 - `ValidateBackupCode(ctx, userID, code)` — checks and consumes a single-use backup code.
 - `LoadMFAFromDB(ctx)` — loads MFA settings from `user_mfa` table on startup.
+- `SetVerifySecret(secret)` — sets HMAC key used for both email verification and password reset tokens.
+- `GenerateEmailVerifyToken(ctx, userID)` — creates HMAC-signed token (24h expiry) for email verification.
+- `VerifyEmail(ctx, token)` — validates token signature/expiry, marks user as verified.
+- `IsEmailVerified(ctx, userID)` — checks in-memory `email_verified` flag.
+- `RequestPasswordReset(ctx, email)` — issues HMAC-signed reset token (1h expiry). Rate-limited to 3 requests/hour per email; returns `ErrResetRateLimited` when exceeded.
+- `CompletePasswordReset(ctx, token, newPassword)` — validates token, updates password, returns userID. Caller must invalidate the user's existing sessions on success.
+
+## Email Verification + Password Reset
+
+Both flows share the `verifySecret` HMAC key but use distinct payload formats so tokens are not interchangeable:
+- Email verify token: `userID|expiry|signature` (24h expiry)
+- Password reset token: `reset|userID|expiry|signature` (1h expiry, single-use, in-memory tracked)
+
+Password reset rate limiting is in-memory (per-email, 3/hour, sliding window). The auth service does not own session state — the dashboard handler invalidates sessions via `SessionStore.DeleteByUserID` after a successful reset.
 
 ## MFA
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -64,6 +64,9 @@ type AuthService struct {
 	mfaMu           sync.RWMutex
 	verifySecret    []byte            // HMAC key for email verification tokens
 	verifyTokens    map[string]string // token -> userID (in-memory lookup)
+	resetTokens     map[string]string // password-reset token -> userID
+	resetRates      map[string][]time.Time
+	resetMu         sync.Mutex
 	activityTracker *ActivityTracker
 	auditLogger     *AuditLogger
 }
@@ -89,6 +92,8 @@ func NewAuthService(db Database, sqlDB *sql.DB) *AuthService {
 		preferences:     make(map[string]*UserPreferences),
 		mfaSettings:     make(map[string]*MFASettings),
 		verifyTokens:    make(map[string]string),
+		resetTokens:     make(map[string]string),
+		resetRates:      make(map[string][]time.Time),
 		activityTracker: nil,
 		auditLogger:     nil,
 	}
@@ -522,23 +527,6 @@ func GenerateID() string {
 	bytes := make([]byte, 8)
 	_, _ = rand.Read(bytes)
 	return hex.EncodeToString(bytes)
-}
-
-// RequestPasswordReset generates a reset token for the user
-func (a *AuthService) RequestPasswordReset(ctx context.Context, email string) (string, error) {
-	_, err := a.GetUserByEmail(ctx, email)
-	if err != nil {
-		return "", fmt.Errorf("user not found")
-	}
-
-	token := GenerateID() + GenerateID()
-	return token, nil
-}
-
-// CompletePasswordReset updates the password using a valid token
-func (a *AuthService) CompletePasswordReset(ctx context.Context, token, newPassword string) error {
-	// TODO: Validate token and update password
-	return nil
 }
 
 // TrackActivity tracks user activity

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -433,7 +433,7 @@ func (h *AuthHandler) CompletePasswordReset(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := h.authService.CompletePasswordReset(r.Context(), req.Token, req.NewPassword); err != nil {
+	if _, err := h.authService.CompletePasswordReset(r.Context(), req.Token, req.NewPassword); err != nil {
 		http.Error(w, "Invalid or expired token", http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/password_reset.go
+++ b/internal/auth/password_reset.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	resetTokenExpiry  = 1 * time.Hour
+	resetRateWindow   = 1 * time.Hour
+	resetRateMaxPerIP = 3 // max 3 reset emails per hour per email
+)
+
+// ErrResetRateLimited is returned when an email exceeds the password reset
+// rate limit (3 requests per hour).
+var ErrResetRateLimited = errors.New("password reset rate limit exceeded")
+
+// RequestPasswordReset generates an HMAC-signed password reset token for the
+// user with the given email. Returns ErrResetRateLimited if the email has
+// already requested 3 resets within the past hour.
+//
+// The returned token is opaque and embeds the userID and an expiry time
+// signed with the email-verify HMAC secret. The same secret is reused
+// because the payload prefix differs ("reset|") so the two token types are
+// not interchangeable.
+//
+// To preserve user enumeration resistance, callers should not surface
+// "user not found" errors to the client. This method does return that
+// error so the caller can decide whether to log it.
+func (a *AuthService) RequestPasswordReset(ctx context.Context, email string) (string, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+
+	user, err := a.GetUserByEmail(ctx, email)
+	if err != nil {
+		return "", fmt.Errorf("user not found")
+	}
+
+	// Rate limit: max 3 resets per hour per email.
+	if !a.allowResetRequest(email) {
+		return "", ErrResetRateLimited
+	}
+
+	expiry := time.Now().Add(resetTokenExpiry).Unix()
+	payload := fmt.Sprintf("reset|%s|%d", user.ID, expiry)
+
+	mac := hmac.New(sha256.New, a.verifySecret)
+	mac.Write([]byte(payload))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	token := base64.RawURLEncoding.EncodeToString([]byte(payload + "|" + sig))
+
+	a.resetMu.Lock()
+	a.resetTokens[token] = user.ID
+	a.resetMu.Unlock()
+
+	return token, nil
+}
+
+// CompletePasswordReset validates a reset token and updates the user's
+// password. On success, all of the user's existing sessions should be
+// invalidated by the caller (the auth service does not own session state).
+func (a *AuthService) CompletePasswordReset(ctx context.Context, token, newPassword string) (string, error) {
+	if len(newPassword) < 8 {
+		return "", fmt.Errorf("password must be at least 8 characters")
+	}
+
+	userID, err := a.validateResetToken(token)
+	if err != nil {
+		return "", err
+	}
+
+	user, exists := a.userIndex[userID]
+	if !exists {
+		return "", fmt.Errorf("user not found")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("hash password: %w", err)
+	}
+
+	user.PasswordHash = string(hash)
+
+	if a.sqlDB != nil {
+		_, err = a.sqlDB.ExecContext(ctx,
+			`UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2`,
+			string(hash), userID)
+		if err != nil {
+			return "", fmt.Errorf("update password: %w", err)
+		}
+	}
+
+	// Single-use token: clear from in-memory map.
+	a.resetMu.Lock()
+	delete(a.resetTokens, token)
+	a.resetMu.Unlock()
+
+	return userID, nil
+}
+
+// validateResetToken decodes a reset token, verifies its HMAC signature
+// and expiry, and returns the userID it references.
+func (a *AuthService) validateResetToken(token string) (string, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return "", fmt.Errorf("invalid reset token")
+	}
+
+	parts := strings.SplitN(string(decoded), "|", 4)
+	if len(parts) != 4 || parts[0] != "reset" {
+		return "", fmt.Errorf("invalid reset token")
+	}
+
+	userID := parts[1]
+	payload := parts[0] + "|" + parts[1] + "|" + parts[2]
+	sig := parts[3]
+
+	mac := hmac.New(sha256.New, a.verifySecret)
+	mac.Write([]byte(payload))
+	expectedSig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(sig), []byte(expectedSig)) {
+		return "", fmt.Errorf("invalid reset token")
+	}
+
+	var expiry int64
+	if _, err := fmt.Sscanf(parts[2], "%d", &expiry); err != nil {
+		return "", fmt.Errorf("invalid reset token")
+	}
+	if time.Now().Unix() > expiry {
+		return "", fmt.Errorf("reset token expired")
+	}
+
+	return userID, nil
+}
+
+// allowResetRequest checks the per-email rate limit and records the
+// current request if allowed.
+func (a *AuthService) allowResetRequest(email string) bool {
+	a.resetMu.Lock()
+	defer a.resetMu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-resetRateWindow)
+
+	// Drop entries older than the rate window.
+	kept := a.resetRates[email][:0]
+	for _, t := range a.resetRates[email] {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+
+	if len(kept) >= resetRateMaxPerIP {
+		a.resetRates[email] = kept
+		return false
+	}
+
+	a.resetRates[email] = append(kept, now)
+	return true
+}

--- a/internal/auth/password_reset_test.go
+++ b/internal/auth/password_reset_test.go
@@ -2,26 +2,158 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestPasswordReset_RequestReset(t *testing.T) {
-	// Test that requesting a password reset generates a token
-	service := NewAuthService(nil, nil)
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
 
-	// Create a user first
-	_, _, _, err := service.CreateUserWithTenant(context.TODO(), "test@stored.ge", "OldPass123!", "")
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "reset@stored.ge", "OldPass123!", "")
 	require.NoError(t, err)
 
-	// Request password reset
-	token, err := service.RequestPasswordReset(context.TODO(), "test@stored.ge")
+	token, err := svc.RequestPasswordReset(context.Background(), "reset@stored.ge")
 	require.NoError(t, err)
 	require.NotEmpty(t, token)
 }
 
+func TestPasswordReset_RequestUnknownEmail(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	_, err := svc.RequestPasswordReset(context.Background(), "ghost@stored.ge")
+	assert.Error(t, err)
+}
+
 func TestPasswordReset_CompleteReset(t *testing.T) {
-	// Test completing a password reset with token
-	// TODO: Implement
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	user, _, _, err := svc.CreateUserWithTenant(context.Background(), "complete@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+	originalHash := user.PasswordHash
+
+	token, err := svc.RequestPasswordReset(context.Background(), "complete@stored.ge")
+	require.NoError(t, err)
+
+	gotUserID, err := svc.CompletePasswordReset(context.Background(), token, "NewPass456!")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, gotUserID)
+
+	// Password hash should be updated.
+	assert.NotEqual(t, originalHash, user.PasswordHash)
+
+	// New password should validate.
+	valid, err := svc.ValidatePassword(context.Background(), "complete@stored.ge", "NewPass456!")
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	// Old password should no longer work.
+	valid, _ = svc.ValidatePassword(context.Background(), "complete@stored.ge", "OldPass123!")
+	assert.False(t, valid)
+
+	// Hash should be a valid bcrypt hash.
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte("NewPass456!")))
+}
+
+func TestPasswordReset_InvalidToken(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "u@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+
+	_, err = svc.CompletePasswordReset(context.Background(), "bogus-token", "NewPass456!")
+	assert.Error(t, err)
+}
+
+func TestPasswordReset_TokenSingleUse(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "single@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+
+	token, err := svc.RequestPasswordReset(context.Background(), "single@stored.ge")
+	require.NoError(t, err)
+
+	_, err = svc.CompletePasswordReset(context.Background(), token, "NewPass456!")
+	require.NoError(t, err)
+
+	// Token should not be in resetTokens map anymore.
+	svc.resetMu.Lock()
+	_, exists := svc.resetTokens[token]
+	svc.resetMu.Unlock()
+	assert.False(t, exists, "token should be cleared after use")
+}
+
+func TestPasswordReset_TokenWithWrongSecret(t *testing.T) {
+	svc1 := NewAuthService(nil, nil)
+	svc1.SetVerifySecret("secret-one")
+	_, _, _, _ = svc1.CreateUserWithTenant(context.Background(), "x@stored.ge", "OldPass123!", "")
+	token, _ := svc1.RequestPasswordReset(context.Background(), "x@stored.ge")
+
+	svc2 := NewAuthService(nil, nil)
+	svc2.SetVerifySecret("secret-two")
+	_, _, _, _ = svc2.CreateUserWithTenant(context.Background(), "x@stored.ge", "OldPass123!", "")
+
+	_, err := svc2.CompletePasswordReset(context.Background(), token, "NewPass456!")
+	assert.Error(t, err)
+}
+
+func TestPasswordReset_TokenNotInterchangeableWithEmailVerify(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	user, _, _, err := svc.CreateUserWithTenant(context.Background(), "swap@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+
+	// An email verify token should not work as a reset token.
+	verifyToken, err := svc.GenerateEmailVerifyToken(context.Background(), user.ID)
+	require.NoError(t, err)
+	_, err = svc.CompletePasswordReset(context.Background(), verifyToken, "NewPass456!")
+	assert.Error(t, err, "email verify token must not be valid as a reset token")
+
+	// And a reset token should not work as an email verify token.
+	resetToken, err := svc.RequestPasswordReset(context.Background(), "swap@stored.ge")
+	require.NoError(t, err)
+	err = svc.VerifyEmail(context.Background(), resetToken)
+	assert.Error(t, err, "reset token must not be valid as an email verify token")
+}
+
+func TestPasswordReset_RateLimit(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "rl@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+
+	// First 3 requests should succeed.
+	for i := 0; i < 3; i++ {
+		_, err := svc.RequestPasswordReset(context.Background(), "rl@stored.ge")
+		require.NoError(t, err, "request %d should succeed", i+1)
+	}
+
+	// 4th request should be rate-limited.
+	_, err = svc.RequestPasswordReset(context.Background(), "rl@stored.ge")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrResetRateLimited), "expected ErrResetRateLimited, got %v", err)
+}
+
+func TestPasswordReset_RejectsShortPassword(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetVerifySecret("test-secret-key")
+
+	_, _, _, err := svc.CreateUserWithTenant(context.Background(), "short@stored.ge", "OldPass123!", "")
+	require.NoError(t, err)
+	token, err := svc.RequestPasswordReset(context.Background(), "short@stored.ge")
+	require.NoError(t, err)
+
+	_, err = svc.CompletePasswordReset(context.Background(), token, "short")
+	assert.Error(t, err)
 }

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -50,6 +50,12 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/dashboard/settings/mfa/disable` | POST | session | Disable 2FA (requires password) |
 | `/login/verify-2fa` | GET | none | 2FA verification page (during login) |
 | `/login/verify-2fa` | POST | none | Validate TOTP/backup code, complete login |
+| `/verify` | GET | none | Email verification — validates HMAC token, marks user verified |
+| `/dashboard/settings/resend-verify` | POST | session | Resend email verification link |
+| `/forgot-password` | GET | none | Forgot-password form |
+| `/forgot-password` | POST | none | Issues password reset token (rate-limited, 5/min per IP + 3/hour per email). Always returns generic success to prevent enumeration. |
+| `/reset-password` | GET | none | New-password form (token in query string) |
+| `/reset-password` | POST | none | Validate token + new password, update DB, invalidate ALL sessions for user, redirect to /login with flash |
 | `/dashboard/billing` | GET | session | Billing: plan, upgrade, value stack, cost comparison |
 | `/dashboard/billing/upgrade` | POST | session | Redirect to Stripe Checkout for chosen plan |
 | `/dashboard/billing/portal` | POST | session | Redirect to Stripe Billing Portal |
@@ -67,6 +73,16 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 6. Sets `vaultaire_session` cookie
 7. Redirects to `/dashboard`
 8. On error: re-renders form with `.Error` message and preserved form values
+
+## Password Reset Flow
+
+Public flow at `/forgot-password` → email link → `/reset-password?token=...`. Token format and lifetime live in `internal/auth/password_reset.go` (HMAC-signed, 1h expiry, single-use). The handler:
+- Always returns the same success message on POST `/forgot-password` so attackers can't enumerate registered emails
+- Rate-limits POSTs at 5/min per IP via `LoginRateLimiter` (separate instance from login)
+- Auth service additionally rate-limits at 3/hour per email
+- On successful reset, calls `Sessions.DeleteByUserID(userID)` to log the user out of every device, then sets a flash message and redirects to `/login`
+
+The reset email is currently logged (not sent) — wire to a real email provider when one is configured.
 
 ## MFA Pending Store
 

--- a/internal/dashboard/auth/auth.go
+++ b/internal/dashboard/auth/auth.go
@@ -42,6 +42,7 @@ type SessionStore interface {
 	Create(ctx context.Context, sd SessionData, ttl time.Duration) (token string, err error)
 	Get(ctx context.Context, token string) (*SessionData, error)
 	Delete(ctx context.Context, token string) error
+	DeleteByUserID(ctx context.Context, userID string) error
 }
 
 // --- In-memory implementation (tests, local dev without DB) ---
@@ -93,6 +94,17 @@ func (m *MemoryStore) Delete(_ context.Context, token string) error {
 	return nil
 }
 
+func (m *MemoryStore) DeleteByUserID(_ context.Context, userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for token, s := range m.sessions {
+		if s.data.UserID == userID {
+			delete(m.sessions, token)
+		}
+	}
+	return nil
+}
+
 // --- PostgreSQL implementation ---
 
 // DBStore persists sessions in the dashboard_sessions table.
@@ -140,6 +152,14 @@ func (d *DBStore) Delete(ctx context.Context, token string) error {
 	_, err := d.db.ExecContext(ctx, `DELETE FROM dashboard_sessions WHERE id = $1`, token)
 	if err != nil {
 		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}
+
+func (d *DBStore) DeleteByUserID(ctx context.Context, userID string) error {
+	_, err := d.db.ExecContext(ctx, `DELETE FROM dashboard_sessions WHERE user_id = $1`, userID)
+	if err != nil {
+		return fmt.Errorf("delete sessions by user: %w", err)
 	}
 	return nil
 }

--- a/internal/dashboard/password_reset_test.go
+++ b/internal/dashboard/password_reset_test.go
@@ -1,0 +1,187 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetForgotPassword(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+	req := httptest.NewRequest("GET", "/forgot-password", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Reset Password")
+	assert.Contains(t, body, "Send Reset Link")
+}
+
+func TestPostForgotPassword_KnownEmail(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+	_, _ = authSvc.CreateUser(context.Background(), "knows@stored.ge", "OldPass123!")
+
+	form := url.Values{"email": {"knows@stored.ge"}}
+	req := httptest.NewRequest("POST", "/forgot-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Generic success message regardless of whether email exists.
+	assert.Contains(t, w.Body.String(), "If that email is registered")
+}
+
+func TestPostForgotPassword_UnknownEmailStillSucceeds(t *testing.T) {
+	// Anti-enumeration: unknown emails get the same success page.
+	r, authSvc, _ := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+
+	form := url.Values{"email": {"ghost@stored.ge"}}
+	req := httptest.NewRequest("POST", "/forgot-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "If that email is registered")
+}
+
+func TestGetResetPassword(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+	req := httptest.NewRequest("GET", "/reset-password?token=sometoken", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Choose a New Password")
+	assert.Contains(t, body, `value="sometoken"`)
+}
+
+func TestGetResetPassword_MissingToken(t *testing.T) {
+	r, _, _ := setupTestRouter(t)
+	req := httptest.NewRequest("GET", "/reset-password", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Missing reset token")
+}
+
+func TestPostResetPassword_Success(t *testing.T) {
+	r, authSvc, sessions := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+
+	_, _ = authSvc.CreateUser(context.Background(), "reset@stored.ge", "OldPass123!")
+	user, _ := authSvc.GetUserByEmail(context.Background(), "reset@stored.ge")
+
+	// Pre-create some sessions for this user.
+	tokens := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		tk, err := sessions.Create(context.Background(), dashauth.SessionData{
+			UserID: user.ID, TenantID: user.TenantID, Email: user.Email, Role: "user",
+		}, 24*time.Hour)
+		require.NoError(t, err)
+		tokens = append(tokens, tk)
+	}
+
+	resetToken, err := authSvc.RequestPasswordReset(context.Background(), "reset@stored.ge")
+	require.NoError(t, err)
+
+	form := url.Values{
+		"token":            {resetToken},
+		"new_password":     {"NewSecurePass1"},
+		"confirm_password": {"NewSecurePass1"},
+	}
+	req := httptest.NewRequest("POST", "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+
+	// New password should validate.
+	valid, err := authSvc.ValidatePassword(context.Background(), "reset@stored.ge", "NewSecurePass1")
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	// All existing sessions should be invalidated.
+	for _, tk := range tokens {
+		sd, _ := sessions.Get(context.Background(), tk)
+		assert.Nil(t, sd, "session %s should be invalidated", tk)
+	}
+}
+
+func TestPostResetPassword_InvalidToken(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+
+	form := url.Values{
+		"token":            {"bogus"},
+		"new_password":     {"NewSecurePass1"},
+		"confirm_password": {"NewSecurePass1"},
+	}
+	req := httptest.NewRequest("POST", "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired reset link")
+}
+
+func TestPostResetPassword_PasswordsDoNotMatch(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+
+	_, _ = authSvc.CreateUser(context.Background(), "mm@stored.ge", "OldPass123!")
+	resetToken, err := authSvc.RequestPasswordReset(context.Background(), "mm@stored.ge")
+	require.NoError(t, err)
+
+	form := url.Values{
+		"token":            {resetToken},
+		"new_password":     {"NewSecurePass1"},
+		"confirm_password": {"DifferentPass2"},
+	}
+	req := httptest.NewRequest("POST", "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "do not match")
+}
+
+func TestPostResetPassword_ShortPassword(t *testing.T) {
+	r, authSvc, _ := setupTestRouter(t)
+	authSvc.SetVerifySecret("test-secret-key")
+
+	_, _ = authSvc.CreateUser(context.Background(), "short@stored.ge", "OldPass123!")
+	resetToken, err := authSvc.RequestPasswordReset(context.Background(), "short@stored.ge")
+	require.NoError(t, err)
+
+	form := url.Values{
+		"token":            {resetToken},
+		"new_password":     {"short"},
+		"confirm_password": {"short"},
+	}
+	req := httptest.NewRequest("POST", "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "at least 8 characters")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"database/sql"
+	"errors"
 	"html/template"
 	"io/fs"
 	"net/http"
@@ -58,6 +59,13 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 
 	// --- Email verification (public) ---
 	r.Get("/verify", handleVerifyEmail(baseTmpl, deps))
+
+	// --- Password reset (public) ---
+	resetRL := middleware.NewLoginRateLimiter(5, 5)
+	r.Get("/forgot-password", renderAuthPage(baseTmpl, "forgot-password", deps))
+	r.Post("/forgot-password", resetRL.Limit(handleForgotPassword(baseTmpl, deps)).ServeHTTP)
+	r.Get("/reset-password", handleResetPasswordForm(baseTmpl, deps))
+	r.Post("/reset-password", resetRL.Limit(handleResetPassword(baseTmpl, deps)).ServeHTTP)
 
 	// --- 2FA verification (public, used during login) ---
 	r.Get("/login/verify-2fa", renderAuthPage(baseTmpl, "verify-2fa", deps))
@@ -469,6 +477,117 @@ func handleLogout(store dashauth.SessionStore) http.HandlerFunc {
 	}
 }
 
+// handleForgotPassword handles POST /forgot-password. It always returns the
+// same success message regardless of whether the email exists, to prevent
+// user enumeration. When the email matches a real user, a reset link is
+// generated and (eventually) emailed; for now the link is logged.
+func handleForgotPassword(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
+	tmpl := template.Must(baseTmpl.Clone())
+	template.Must(tmpl.Parse(pageContent("forgot-password")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := r.FormValue("email")
+
+		// Always show the same success message — never reveal whether the
+		// email is registered.
+		const successMsg = "If that email is registered, you'll receive a reset link shortly."
+
+		token, err := deps.Auth.RequestPasswordReset(r.Context(), email)
+		if err == nil {
+			deps.Logger.Info("password reset token generated",
+				zap.String("email", email),
+				zap.String("reset_url", "/reset-password?token="+token))
+		} else if !errors.Is(err, auth.ErrResetRateLimited) {
+			// "user not found" — log at debug, do NOT reveal to client.
+			deps.Logger.Debug("password reset requested for unknown email",
+				zap.String("email", email), zap.Error(err))
+		}
+		// Rate-limited requests fall through silently — same success message.
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = tmpl.ExecuteTemplate(w, "base", map[string]any{
+			"Page":    "forgot-password",
+			"Success": successMsg,
+		})
+	}
+}
+
+// handleResetPasswordForm handles GET /reset-password?token=... and renders
+// the new-password form. The token is passed through as a hidden field on
+// the POST.
+func handleResetPasswordForm(baseTmpl *template.Template, _ Deps) http.HandlerFunc {
+	tmpl := template.Must(baseTmpl.Clone())
+	template.Must(tmpl.Parse(pageContent("reset-password")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		data := map[string]any{
+			"Page":  "reset-password",
+			"Token": token,
+		}
+		if token == "" {
+			data["Error"] = "Missing reset token."
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = tmpl.ExecuteTemplate(w, "base", data)
+	}
+}
+
+// handleResetPassword handles POST /reset-password. It validates the token
+// and the new password fields, updates the password, and invalidates all
+// existing sessions for the user (forcing re-login on every device).
+func handleResetPassword(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
+	tmpl := template.Must(baseTmpl.Clone())
+	template.Must(tmpl.Parse(pageContent("reset-password")))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := r.FormValue("token")
+		newPass := r.FormValue("new_password")
+		confirm := r.FormValue("confirm_password")
+
+		renderErr := func(msg string) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = tmpl.ExecuteTemplate(w, "base", map[string]any{
+				"Page":  "reset-password",
+				"Token": token,
+				"Error": msg,
+			})
+		}
+
+		if token == "" {
+			renderErr("Missing reset token.")
+			return
+		}
+		if len(newPass) < 8 {
+			renderErr("Password must be at least 8 characters.")
+			return
+		}
+		if newPass != confirm {
+			renderErr("Passwords do not match.")
+			return
+		}
+
+		userID, err := deps.Auth.CompletePasswordReset(r.Context(), token, newPass)
+		if err != nil {
+			deps.Logger.Warn("password reset failed", zap.Error(err))
+			renderErr("Invalid or expired reset link. Please request a new one.")
+			return
+		}
+
+		// Invalidate all existing sessions for this user (force re-login).
+		if deps.Sessions != nil {
+			if dErr := deps.Sessions.DeleteByUserID(r.Context(), userID); dErr != nil {
+				deps.Logger.Error("invalidate sessions on password reset",
+					zap.String("user", userID), zap.Error(dErr))
+			}
+		}
+
+		middleware.SetFlash(w, "success", "Password reset successful. Please sign in with your new password.")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+	}
+}
+
 // pageContent returns a small template snippet that defines the "content"
 // block for each page. Phase 1 replaces these with real template files.
 func pageContent(page string) string {
@@ -546,6 +665,38 @@ func pageContent(page string) string {
 			`{{else if .Error}}<div class="alert alert-error">{{.Error}}</div>` +
 			`<div class="auth-footer"><a href="/login">Back to sign in</a></div>` +
 			`{{end}}` +
+			`</div></div>{{end}}`
+	case "forgot-password":
+		return `{{define "title"}}Forgot Password — stored.ge{{end}}` +
+			`{{define "nav"}}{{end}}` +
+			`{{define "content"}}` +
+			`<div class="auth-page"><div class="auth-card">` +
+			`<div class="auth-brand">stored.ge</div>` +
+			`<h1>Reset Password</h1>` +
+			`<p class="auth-subtitle">Enter your email and we'll send you a link to reset your password.</p>` +
+			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
+			`{{if .Success}}<div class="alert alert-success">{{.Success}}</div>{{end}}` +
+			`<form method="POST" action="/forgot-password">` +
+			`<div class="form-group"><label>Email</label><input type="email" name="email" value="{{.Email}}" required autofocus></div>` +
+			`<button type="submit" class="btn btn-primary btn-block">Send Reset Link</button>` +
+			`</form>` +
+			`<div class="auth-footer"><a href="/login">Back to sign in</a></div>` +
+			`</div></div>{{end}}`
+	case "reset-password":
+		return `{{define "title"}}Reset Password — stored.ge{{end}}` +
+			`{{define "nav"}}{{end}}` +
+			`{{define "content"}}` +
+			`<div class="auth-page"><div class="auth-card">` +
+			`<div class="auth-brand">stored.ge</div>` +
+			`<h1>Choose a New Password</h1>` +
+			`{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}` +
+			`<form method="POST" action="/reset-password">` +
+			`<input type="hidden" name="token" value="{{.Token}}">` +
+			`<div class="form-group"><label>New Password</label><input type="password" name="new_password" required minlength="8" autofocus></div>` +
+			`<div class="form-group"><label>Confirm New Password</label><input type="password" name="confirm_password" required minlength="8"></div>` +
+			`<button type="submit" class="btn btn-primary btn-block">Reset Password</button>` +
+			`</form>` +
+			`<div class="auth-footer"><a href="/login">Back to sign in</a></div>` +
 			`</div></div>{{end}}`
 	default:
 		return `{{define "content"}}<p>Page not found.</p>{{end}}`


### PR DESCRIPTION
## Summary

Adds the forgot/reset password flow using HMAC-signed tokens.

- \`internal/auth/password_reset.go\` — \`RequestPasswordReset\` and \`CompletePasswordReset\` (replaces previous stubs)
- HMAC-signed tokens with 1h expiry, single-use, in-memory tracked
- Tokens reuse the email-verify HMAC secret but with a distinct \`reset|\` payload prefix so they cannot be swapped between flows
- Per-email rate limit: 3 requests/hour (auth service, sliding window) — returns \`ErrResetRateLimited\`
- Per-IP rate limit: 5 requests/min (LoginRateLimiter, separate instance from login)
- \`SessionStore.DeleteByUserID\` (new method on the interface) — invalidates ALL sessions for a user on successful reset
- Anti-enumeration: \`POST /forgot-password\` always returns the same generic success message regardless of whether the email is registered
- \`GET/POST /forgot-password\` and \`GET/POST /reset-password\` public routes
- 19 new tests (9 auth service, 9 handler, 1 misc)

## Test plan

- [x] \`make test\` passes (auth + dashboard packages, all tests pass with -race)
- [x] \`make lint\` passes
- [ ] CI \`build-and-test\` passes
- [ ] CI \`gosec\` passes
- [ ] CI \`integration-tests\` passes

Closes the Phase 5.3-5.7 catch-up series.