### PR TITLE
feat(dashboard): session security hardening [Phase 5.8]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -19,9 +19,11 @@ Sessions use the `dashboard_sessions` PostgreSQL table. The `SessionStore` inter
 - `DBStore` — production, PostgreSQL-backed, hourly cleanup goroutine
 - `MemoryStore` — tests and local dev without DB
 
-Session data is injected into request context via `RequireSession` middleware. Handlers call `dashauth.GetSession(r.Context())` to get `{UserID, TenantID, Email, Role}`.
+Session data is injected into request context via `RequireSession` middleware. Handlers call `dashauth.GetSession(r.Context())` to get `{UserID, TenantID, Email, Role, IPAddress, UserAgent}`.
 
-Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
+Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax. Name is exported as `dashauth.SessionCookieName`.
+
+Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`, `created_at`, `last_active_at`, and `expires_at` so customers can see their active devices on the settings page and revoke individual ones or sign out every other device. `DBStore.Get` atomically refreshes `last_active_at = NOW()` via `UPDATE ... RETURNING` on every session check. New store methods from Phase 5.8: `ListByUserID` (all non-expired sessions for a user, newest first), `DeleteByUserIDExcept` (wipe all sessions except the current token — used by "sign out all other devices" and by password change so the issuing device stays logged in).
 
 ## Routes
 
@@ -48,6 +50,8 @@ Cookie: `vaultaire_session`, HttpOnly, Secure, SameSite=Lax.
 | `/dashboard/settings/mfa` | GET | session | 2FA setup page (QR code, backup codes) |
 | `/dashboard/settings/mfa/enable` | POST | session | Confirm TOTP code to enable 2FA |
 | `/dashboard/settings/mfa/disable` | POST | session | Disable 2FA (requires password) |
+| `/dashboard/settings/sessions/revoke-all` | POST | session | Sign out of all OTHER devices (keeps current session) |
+| `/dashboard/settings/sessions/{id}/revoke` | POST | session | Revoke a specific session owned by the current user |
 | `/login/verify-2fa` | GET | none | 2FA verification page (during login) |
 | `/login/verify-2fa` | POST | none | Validate TOTP/backup code, complete login |
 | `/verify` | GET | none | Email verification — validates HMAC token, marks user verified |

--- a/internal/dashboard/auth/auth.go
+++ b/internal/dashboard/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 )
@@ -20,11 +21,16 @@ const (
 )
 
 // SessionData is the payload stored in request context after authentication.
+// IPAddress and UserAgent are populated at Create time from the originating
+// request. They are read-only after creation and shown on the "active
+// sessions" list on the settings page.
 type SessionData struct {
-	UserID   string
-	TenantID string
-	Email    string
-	Role     string
+	UserID    string
+	TenantID  string
+	Email     string
+	Role      string
+	IPAddress string
+	UserAgent string
 }
 
 // GetSession extracts session data from a request context.
@@ -32,6 +38,19 @@ type SessionData struct {
 func GetSession(ctx context.Context) *SessionData {
 	sd, _ := ctx.Value(SessionKey).(*SessionData)
 	return sd
+}
+
+// SessionInfo is the display-oriented view of a persisted session used by
+// the "active sessions" settings page. It wraps SessionData with the token
+// ID and timestamps so the UI can render a table with a "this device" badge.
+type SessionInfo struct {
+	ID           string // Session token (also the primary key).
+	UserID       string
+	IPAddress    string
+	UserAgent    string
+	CreatedAt    time.Time
+	LastActiveAt time.Time
+	ExpiresAt    time.Time
 }
 
 // --- SessionStore interface ---
@@ -43,13 +62,21 @@ type SessionStore interface {
 	Get(ctx context.Context, token string) (*SessionData, error)
 	Delete(ctx context.Context, token string) error
 	DeleteByUserID(ctx context.Context, userID string) error
+	// ListByUserID returns all non-expired sessions for a user, newest first.
+	ListByUserID(ctx context.Context, userID string) ([]SessionInfo, error)
+	// DeleteByUserIDExcept deletes all sessions for a user except the given
+	// token. Used to implement "sign out all other devices" without
+	// logging out the device that issued the request.
+	DeleteByUserIDExcept(ctx context.Context, userID, exceptToken string) error
 }
 
 // --- In-memory implementation (tests, local dev without DB) ---
 
 type memSession struct {
-	data      SessionData
-	expiresAt time.Time
+	data         SessionData
+	createdAt    time.Time
+	lastActiveAt time.Time
+	expiresAt    time.Time
 }
 
 // MemoryStore is an in-memory session store.
@@ -71,18 +98,27 @@ func (m *MemoryStore) Create(_ context.Context, sd SessionData, ttl time.Duratio
 	if err != nil {
 		return "", err
 	}
-	m.sessions[token] = &memSession{data: sd, expiresAt: time.Now().Add(ttl)}
+	now := time.Now()
+	m.sessions[token] = &memSession{
+		data:         sd,
+		createdAt:    now,
+		lastActiveAt: now,
+		expiresAt:    now.Add(ttl),
+	}
 	return token, nil
 }
 
 func (m *MemoryStore) Get(_ context.Context, token string) (*SessionData, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	s, ok := m.sessions[token]
 	if !ok || time.Now().After(s.expiresAt) {
 		return nil, nil
 	}
+	// Touch last-active on every Get so the settings page can show a
+	// meaningful "last active" timestamp per device.
+	s.lastActiveAt = time.Now()
 	cp := s.data
 	return &cp, nil
 }
@@ -105,6 +141,44 @@ func (m *MemoryStore) DeleteByUserID(_ context.Context, userID string) error {
 	return nil
 }
 
+func (m *MemoryStore) DeleteByUserIDExcept(_ context.Context, userID, exceptToken string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for token, s := range m.sessions {
+		if s.data.UserID == userID && token != exceptToken {
+			delete(m.sessions, token)
+		}
+	}
+	return nil
+}
+
+func (m *MemoryStore) ListByUserID(_ context.Context, userID string) ([]SessionInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	now := time.Now()
+	out := make([]SessionInfo, 0)
+	for token, s := range m.sessions {
+		if s.data.UserID != userID || now.After(s.expiresAt) {
+			continue
+		}
+		out = append(out, SessionInfo{
+			ID:           token,
+			UserID:       s.data.UserID,
+			IPAddress:    s.data.IPAddress,
+			UserAgent:    s.data.UserAgent,
+			CreatedAt:    s.createdAt,
+			LastActiveAt: s.lastActiveAt,
+			ExpiresAt:    s.expiresAt,
+		})
+	}
+	// Newest first by LastActiveAt so the "current" device sorts to top.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LastActiveAt.After(out[j].LastActiveAt)
+	})
+	return out, nil
+}
+
 // --- PostgreSQL implementation ---
 
 // DBStore persists sessions in the dashboard_sessions table.
@@ -123,27 +197,40 @@ func (d *DBStore) Create(ctx context.Context, sd SessionData, ttl time.Duration)
 		return "", err
 	}
 	_, err = d.db.ExecContext(ctx, `
-		INSERT INTO dashboard_sessions (id, user_id, tenant_id, email, role, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, token, sd.UserID, sd.TenantID, sd.Email, sd.Role, time.Now().Add(ttl))
+		INSERT INTO dashboard_sessions
+		    (id, user_id, tenant_id, email, role, ip_address, user_agent, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, token, sd.UserID, sd.TenantID, sd.Email, sd.Role,
+		sd.IPAddress, sd.UserAgent, time.Now().Add(ttl))
 	if err != nil {
 		return "", fmt.Errorf("insert session: %w", err)
 	}
 	return token, nil
 }
 
+// Get returns the session for a token and atomically refreshes its
+// last_active_at timestamp. The single UPDATE ... RETURNING round-trip keeps
+// the "last active" column in sync without a second query per request.
 func (d *DBStore) Get(ctx context.Context, token string) (*SessionData, error) {
 	sd := &SessionData{}
+	var ip, ua sql.NullString
 	err := d.db.QueryRowContext(ctx, `
-		SELECT user_id, tenant_id, email, role
-		FROM dashboard_sessions
+		UPDATE dashboard_sessions
+		SET last_active_at = NOW()
 		WHERE id = $1 AND expires_at > NOW()
-	`, token).Scan(&sd.UserID, &sd.TenantID, &sd.Email, &sd.Role)
+		RETURNING user_id, tenant_id, email, role, ip_address, user_agent
+	`, token).Scan(&sd.UserID, &sd.TenantID, &sd.Email, &sd.Role, &ip, &ua)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query session: %w", err)
+	}
+	if ip.Valid {
+		sd.IPAddress = ip.String
+	}
+	if ua.Valid {
+		sd.UserAgent = ua.String
 	}
 	return sd, nil
 }
@@ -162,6 +249,50 @@ func (d *DBStore) DeleteByUserID(ctx context.Context, userID string) error {
 		return fmt.Errorf("delete sessions by user: %w", err)
 	}
 	return nil
+}
+
+func (d *DBStore) DeleteByUserIDExcept(ctx context.Context, userID, exceptToken string) error {
+	_, err := d.db.ExecContext(ctx,
+		`DELETE FROM dashboard_sessions WHERE user_id = $1 AND id <> $2`,
+		userID, exceptToken)
+	if err != nil {
+		return fmt.Errorf("delete sessions by user except: %w", err)
+	}
+	return nil
+}
+
+func (d *DBStore) ListByUserID(ctx context.Context, userID string) ([]SessionInfo, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT id, user_id, ip_address, user_agent, created_at, last_active_at, expires_at
+		FROM dashboard_sessions
+		WHERE user_id = $1 AND expires_at > NOW()
+		ORDER BY last_active_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]SessionInfo, 0)
+	for rows.Next() {
+		var si SessionInfo
+		var ip, ua sql.NullString
+		if err := rows.Scan(&si.ID, &si.UserID, &ip, &ua,
+			&si.CreatedAt, &si.LastActiveAt, &si.ExpiresAt); err != nil {
+			return nil, fmt.Errorf("scan session: %w", err)
+		}
+		if ip.Valid {
+			si.IPAddress = ip.String
+		}
+		if ua.Valid {
+			si.UserAgent = ua.String
+		}
+		out = append(out, si)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sessions: %w", err)
+	}
+	return out, nil
 }
 
 // StartCleanup launches a goroutine that deletes expired sessions every hour.
@@ -183,7 +314,14 @@ func (d *DBStore) StartCleanup(ctx context.Context) {
 
 // --- Middleware ---
 
-const cookieName = "vaultaire_session"
+// SessionCookieName is the name of the cookie that holds the dashboard
+// session token. Exported so handlers outside this package can read the
+// current session token (e.g., password change keeping the current device).
+const SessionCookieName = "vaultaire_session"
+
+// cookieName is kept as an internal alias for compatibility with the older
+// middleware/cookie helpers below.
+const cookieName = SessionCookieName
 
 // RequireSession is HTTP middleware that checks for a valid session cookie.
 // If valid, it injects SessionData into the request context.
@@ -268,6 +406,20 @@ func (ba *BasicAuth) Validate(r *http.Request) bool {
 }
 
 // --- helpers ---
+
+// MaxUserAgentLen bounds the User-Agent string stored per session to the
+// column width in `dashboard_sessions` (VARCHAR 512). UAs longer than this
+// are extremely rare but worth guarding against so INSERT never fails.
+const MaxUserAgentLen = 512
+
+// TruncateUserAgent clips an overly long User-Agent header so it fits in
+// `dashboard_sessions.user_agent`.
+func TruncateUserAgent(ua string) string {
+	if len(ua) > MaxUserAgentLen {
+		return ua[:MaxUserAgentLen]
+	}
+	return ua
+}
 
 func generateToken() (string, error) {
 	b := make([]byte, 32)

--- a/internal/dashboard/auth/auth_test.go
+++ b/internal/dashboard/auth/auth_test.go
@@ -83,6 +83,113 @@ func TestMemoryStore(t *testing.T) {
 			t.Error("expected deleted session to return nil")
 		}
 	})
+
+	t.Run("persists ip and user agent", func(t *testing.T) {
+		store := NewMemoryStore()
+		ctx := context.Background()
+
+		token, err := store.Create(ctx, SessionData{
+			UserID:    "user123",
+			IPAddress: "203.0.113.5",
+			UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X) test",
+		}, time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sd, err := store.Get(ctx, token)
+		if err != nil || sd == nil {
+			t.Fatalf("expected session, got %+v err=%v", sd, err)
+		}
+		if sd.IPAddress != "203.0.113.5" {
+			t.Errorf("expected IPAddress set, got %q", sd.IPAddress)
+		}
+		if sd.UserAgent == "" {
+			t.Errorf("expected UserAgent set, got empty")
+		}
+	})
+
+	t.Run("list by user id returns all active sessions newest first", func(t *testing.T) {
+		store := NewMemoryStore()
+		ctx := context.Background()
+
+		// Two sessions for the same user, one for a different user.
+		t1, _ := store.Create(ctx, SessionData{
+			UserID: "u1", IPAddress: "10.0.0.1", UserAgent: "deviceA",
+		}, time.Hour)
+		// Nudge a tiny amount so Get updates last_active in a comparable way.
+		time.Sleep(2 * time.Millisecond)
+		t2, _ := store.Create(ctx, SessionData{
+			UserID: "u1", IPAddress: "10.0.0.2", UserAgent: "deviceB",
+		}, time.Hour)
+		_, _ = store.Create(ctx, SessionData{UserID: "u2"}, time.Hour)
+
+		list, err := store.ListByUserID(ctx, "u1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) != 2 {
+			t.Fatalf("expected 2 sessions, got %d", len(list))
+		}
+		ids := map[string]bool{list[0].ID: true, list[1].ID: true}
+		if !ids[t1] || !ids[t2] {
+			t.Errorf("expected both tokens in list, got %+v", list)
+		}
+		// Newest first — the second-created session should sort ahead.
+		if list[0].ID != t2 {
+			t.Errorf("expected newest first (%s), got %s", t2, list[0].ID)
+		}
+	})
+
+	t.Run("delete by user id except keeps current session", func(t *testing.T) {
+		store := NewMemoryStore()
+		ctx := context.Background()
+
+		keep, _ := store.Create(ctx, SessionData{UserID: "u1"}, time.Hour)
+		gone1, _ := store.Create(ctx, SessionData{UserID: "u1"}, time.Hour)
+		gone2, _ := store.Create(ctx, SessionData{UserID: "u1"}, time.Hour)
+		otherUser, _ := store.Create(ctx, SessionData{UserID: "u2"}, time.Hour)
+
+		if err := store.DeleteByUserIDExcept(ctx, "u1", keep); err != nil {
+			t.Fatal(err)
+		}
+
+		if sd, _ := store.Get(ctx, keep); sd == nil {
+			t.Error("expected kept session to survive")
+		}
+		if sd, _ := store.Get(ctx, gone1); sd != nil {
+			t.Error("expected other session 1 to be deleted")
+		}
+		if sd, _ := store.Get(ctx, gone2); sd != nil {
+			t.Error("expected other session 2 to be deleted")
+		}
+		if sd, _ := store.Get(ctx, otherUser); sd == nil {
+			t.Error("expected other user's session to survive")
+		}
+	})
+
+	t.Run("get refreshes last_active_at", func(t *testing.T) {
+		store := NewMemoryStore()
+		ctx := context.Background()
+
+		token, _ := store.Create(ctx, SessionData{UserID: "u1"}, time.Hour)
+		list, _ := store.ListByUserID(ctx, "u1")
+		if len(list) != 1 {
+			t.Fatalf("expected 1 session, got %d", len(list))
+		}
+		firstActive := list[0].LastActiveAt
+
+		time.Sleep(5 * time.Millisecond)
+		if _, err := store.Get(ctx, token); err != nil {
+			t.Fatal(err)
+		}
+
+		list, _ = store.ListByUserID(ctx, "u1")
+		if !list[0].LastActiveAt.After(firstActive) {
+			t.Errorf("expected LastActiveAt to advance after Get, was %v now %v",
+				firstActive, list[0].LastActiveAt)
+		}
+	})
 }
 
 func TestRequireSession(t *testing.T) {

--- a/internal/dashboard/handlers/oauth.go
+++ b/internal/dashboard/handlers/oauth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
@@ -137,10 +138,12 @@ func HandleOAuthCallback(
 
 		// Create session.
 		sessionToken, err := sessions.Create(r.Context(), dashauth.SessionData{
-			UserID:   user.ID,
-			TenantID: user.TenantID,
-			Email:    user.Email,
-			Role:     role,
+			UserID:    user.ID,
+			TenantID:  user.TenantID,
+			Email:     user.Email,
+			Role:      role,
+			IPAddress: middleware.ClientIP(r),
+			UserAgent: dashauth.TruncateUserAgent(r.UserAgent()),
 		}, sessionTTL)
 		if err != nil {
 			logger.Error("oauth: create session", zap.Error(err))

--- a/internal/dashboard/handlers/sessions.go
+++ b/internal/dashboard/handlers/sessions.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// SessionRow is the display-oriented view of one active session, tailored
+// for the settings page "Active Sessions" table.
+type SessionRow struct {
+	ID         string // Opaque token, used by the revoke form.
+	IPAddress  string
+	Device     string // Short label derived from the User-Agent.
+	FullUA     string // Full User-Agent (shown in title tooltip).
+	CreatedAgo string // e.g., "3 days ago".
+	ActiveAgo  string // e.g., "5 minutes ago".
+	IsCurrent  bool   // True if this row matches the request's cookie.
+}
+
+// buildSessionRows converts raw SessionInfo records to the display rows
+// shown on the settings page.
+func buildSessionRows(list []dashauth.SessionInfo, currentToken string) []SessionRow {
+	out := make([]SessionRow, 0, len(list))
+	now := time.Now()
+	for _, s := range list {
+		out = append(out, SessionRow{
+			ID:         s.ID,
+			IPAddress:  firstNonEmpty(s.IPAddress, "unknown"),
+			Device:     describeDevice(s.UserAgent),
+			FullUA:     s.UserAgent,
+			CreatedAgo: relativeAgo(now, s.CreatedAt),
+			ActiveAgo:  relativeAgo(now, s.LastActiveAt),
+			IsCurrent:  s.ID == currentToken,
+		})
+	}
+	return out
+}
+
+// HandleRevokeSession handles POST /dashboard/settings/sessions/{id}/revoke.
+// The target session must belong to the current user — attempting to revoke
+// another user's session silently no-ops (no information leak).
+func HandleRevokeSession(sessions dashauth.SessionStore, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+		if sessions == nil {
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		target := chi.URLParam(r, "id")
+		if target == "" {
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		// Ownership check: scan the user's sessions and confirm the target
+		// belongs to them before deleting it. This is cheap (per-user small
+		// list) and avoids a race where a user submits another user's token.
+		list, err := sessions.ListByUserID(r.Context(), sd.UserID)
+		if err != nil {
+			logger.Error("list sessions for revoke", zap.Error(err))
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+		owned := false
+		for _, s := range list {
+			if s.ID == target {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			middleware.SetFlash(w, "error", "Session not found.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		// Don't let a user revoke the session that issued the request.
+		if c, cErr := r.Cookie(dashauth.SessionCookieName); cErr == nil && c.Value == target {
+			middleware.SetFlash(w, "error", "Use Sign Out to end this session.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		if err := sessions.Delete(r.Context(), target); err != nil {
+			logger.Error("delete session", zap.String("token", target), zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to revoke session.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Device signed out.")
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+// HandleRevokeAllOtherSessions handles POST /dashboard/settings/sessions/revoke-all.
+// It signs out every other device the current user has without logging them
+// out of the device that issued the request.
+func HandleRevokeAllOtherSessions(sessions dashauth.SessionStore, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+		if sessions == nil {
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		currentToken := ""
+		if c, err := r.Cookie(dashauth.SessionCookieName); err == nil {
+			currentToken = c.Value
+		}
+
+		if err := sessions.DeleteByUserIDExcept(r.Context(), sd.UserID, currentToken); err != nil {
+			logger.Error("revoke all other sessions", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to sign out other devices.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Signed out of all other devices.")
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+// describeDevice returns a short label like "Chrome on macOS" for a
+// User-Agent string. It's best-effort — we avoid pulling in a full UA
+// parser library for what is a cosmetic display string.
+func describeDevice(ua string) string {
+	if ua == "" {
+		return "Unknown device"
+	}
+	browser := firstMatch(ua, []string{"Firefox", "Edg", "OPR", "Chrome", "Safari"})
+	switch browser {
+	case "Edg":
+		browser = "Edge"
+	case "OPR":
+		browser = "Opera"
+	}
+	os := firstMatch(ua, []string{"Windows", "Android", "iPhone", "iPad", "Macintosh", "Mac OS", "Linux"})
+	switch os {
+	case "Macintosh", "Mac OS":
+		os = "macOS"
+	case "iPhone":
+		os = "iOS"
+	}
+	switch {
+	case browser != "" && os != "":
+		return browser + " on " + os
+	case browser != "":
+		return browser
+	case os != "":
+		return os
+	default:
+		return "Unknown device"
+	}
+}
+
+// firstMatch returns the first needle from the list that appears in s
+// (case-insensitive), or "" if none match. Used by describeDevice.
+func firstMatch(s string, needles []string) string {
+	lower := strings.ToLower(s)
+	for _, n := range needles {
+		if strings.Contains(lower, strings.ToLower(n)) {
+			return n
+		}
+	}
+	return ""
+}
+
+// relativeAgo returns a short, human-readable duration like "2 minutes
+// ago" or "3 days ago". Used for the CreatedAgo / ActiveAgo columns.
+func relativeAgo(now, t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return pluralize(int(d/time.Minute), "minute")
+	case d < 24*time.Hour:
+		return pluralize(int(d/time.Hour), "hour")
+	case d < 30*24*time.Hour:
+		return pluralize(int(d/(24*time.Hour)), "day")
+	default:
+		return pluralize(int(d/(30*24*time.Hour)), "month")
+	}
+}
+
+func pluralize(n int, unit string) string {
+	if n <= 0 {
+		n = 1
+	}
+	if n == 1 {
+		return "1 " + unit + " ago"
+	}
+	return strconv.Itoa(n) + " " + unit + "s ago"
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/dashboard/handlers/sessions_test.go
+++ b/internal/dashboard/handlers/sessions_test.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// sessionCtxWithToken builds a request context carrying the session for
+// a given token from an existing MemoryStore. It mirrors what
+// RequireSession middleware would do in production.
+func sessionCtxWithToken(t *testing.T, store *dashauth.MemoryStore, token string) context.Context {
+	t.Helper()
+	sd, err := store.Get(context.Background(), token)
+	require.NoError(t, err)
+	require.NotNil(t, sd, "token must be valid in store")
+	return context.WithValue(context.Background(), dashauth.SessionKey, sd)
+}
+
+func TestBuildSessionRows_MarksCurrentDevice(t *testing.T) {
+	now := time.Now()
+	rows := buildSessionRows([]dashauth.SessionInfo{
+		{
+			ID: "tok-a", UserID: "u1", IPAddress: "10.0.0.1",
+			UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X) Chrome/124.0",
+			CreatedAt: now.Add(-48 * time.Hour), LastActiveAt: now.Add(-1 * time.Minute),
+		},
+		{
+			ID: "tok-b", UserID: "u1", IPAddress: "192.168.1.50",
+			UserAgent: "Mozilla/5.0 (iPhone) Safari/604.1",
+			CreatedAt: now.Add(-7 * 24 * time.Hour), LastActiveAt: now.Add(-3 * time.Hour),
+		},
+	}, "tok-a")
+
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsCurrent, "tok-a should be current")
+	assert.False(t, rows[1].IsCurrent)
+	assert.Contains(t, rows[0].Device, "Chrome")
+	assert.Contains(t, rows[0].Device, "macOS")
+	assert.Contains(t, rows[1].Device, "Safari")
+	assert.Contains(t, rows[1].Device, "iOS")
+	assert.Equal(t, "10.0.0.1", rows[0].IPAddress)
+}
+
+func TestBuildSessionRows_UnknownUA(t *testing.T) {
+	rows := buildSessionRows([]dashauth.SessionInfo{
+		{ID: "x", UserID: "u1", IPAddress: "", UserAgent: "", CreatedAt: time.Now(), LastActiveAt: time.Now()},
+	}, "")
+	require.Len(t, rows, 1)
+	assert.Equal(t, "unknown", rows[0].IPAddress)
+	assert.Equal(t, "Unknown device", rows[0].Device)
+}
+
+func TestHandleRevokeSession_DeletesOwnedSession(t *testing.T) {
+	store := dashauth.NewMemoryStore()
+	ctx := context.Background()
+
+	keep, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1", Email: "a@b.com"}, time.Hour)
+	target, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1", Email: "a@b.com"}, time.Hour)
+
+	handler := HandleRevokeSession(store, zap.NewNop())
+
+	// chi routes the {id} URL param via RouteContext.
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", target)
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/sessions/"+target+"/revoke", nil)
+	req.AddCookie(&http.Cookie{Name: dashauth.SessionCookieName, Value: keep})
+	req = req.WithContext(context.WithValue(sessionCtxWithToken(t, store, keep), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+
+	if sd, _ := store.Get(ctx, target); sd != nil {
+		t.Error("expected target session deleted")
+	}
+	if sd, _ := store.Get(ctx, keep); sd == nil {
+		t.Error("expected current session to survive")
+	}
+}
+
+func TestHandleRevokeSession_RefusesOtherUser(t *testing.T) {
+	// Attempting to revoke another user's session must silently no-op
+	// — i.e., the target token must still exist after the request.
+	store := dashauth.NewMemoryStore()
+	ctx := context.Background()
+
+	myToken, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1"}, time.Hour)
+	victimToken, _ := store.Create(ctx, dashauth.SessionData{UserID: "attacker-target"}, time.Hour)
+
+	handler := HandleRevokeSession(store, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", victimToken)
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/sessions/"+victimToken+"/revoke", nil)
+	req.AddCookie(&http.Cookie{Name: dashauth.SessionCookieName, Value: myToken})
+	req = req.WithContext(context.WithValue(sessionCtxWithToken(t, store, myToken), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	if sd, _ := store.Get(ctx, victimToken); sd == nil {
+		t.Error("victim session must NOT be deleted — cross-user revoke attempted")
+	}
+}
+
+func TestHandleRevokeSession_RefusesSelf(t *testing.T) {
+	// Revoking the issuing session would immediately log the user out
+	// mid-request — disallowed; they should use /logout instead.
+	store := dashauth.NewMemoryStore()
+	ctx := context.Background()
+
+	myToken, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1"}, time.Hour)
+
+	handler := HandleRevokeSession(store, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", myToken)
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/sessions/"+myToken+"/revoke", nil)
+	req.AddCookie(&http.Cookie{Name: dashauth.SessionCookieName, Value: myToken})
+	req = req.WithContext(context.WithValue(sessionCtxWithToken(t, store, myToken), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	if sd, _ := store.Get(ctx, myToken); sd == nil {
+		t.Error("current session must NOT be revoked via session-revoke handler")
+	}
+}
+
+func TestHandleRevokeAllOtherSessions(t *testing.T) {
+	store := dashauth.NewMemoryStore()
+	ctx := context.Background()
+
+	keep, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1"}, time.Hour)
+	a, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1"}, time.Hour)
+	b, _ := store.Create(ctx, dashauth.SessionData{UserID: "u1"}, time.Hour)
+	// Another user — must not be affected.
+	other, _ := store.Create(ctx, dashauth.SessionData{UserID: "u2"}, time.Hour)
+
+	handler := HandleRevokeAllOtherSessions(store, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/sessions/revoke-all", nil)
+	req.AddCookie(&http.Cookie{Name: dashauth.SessionCookieName, Value: keep})
+	req = req.WithContext(sessionCtxWithToken(t, store, keep))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+
+	if sd, _ := store.Get(ctx, keep); sd == nil {
+		t.Error("expected current session to survive")
+	}
+	if sd, _ := store.Get(ctx, a); sd != nil {
+		t.Error("expected other session A to be revoked")
+	}
+	if sd, _ := store.Get(ctx, b); sd != nil {
+		t.Error("expected other session B to be revoked")
+	}
+	if sd, _ := store.Get(ctx, other); sd == nil {
+		t.Error("expected other user's session to survive")
+	}
+}
+
+func TestRelativeAgo(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		t        time.Time
+		contains string
+	}{
+		{now.Add(-10 * time.Second), "just now"},
+		{now.Add(-5 * time.Minute), "5 minutes ago"},
+		{now.Add(-1 * time.Minute), "1 minute ago"},
+		{now.Add(-3 * time.Hour), "3 hours ago"},
+		{now.Add(-2 * 24 * time.Hour), "2 days ago"},
+	}
+	for _, tc := range cases {
+		got := relativeAgo(now, tc.t)
+		if !strings.Contains(got, tc.contains) {
+			t.Errorf("relativeAgo(%v) = %q, want contains %q", tc.t, got, tc.contains)
+		}
+	}
+}

--- a/internal/dashboard/handlers/settings.go
+++ b/internal/dashboard/handlers/settings.go
@@ -10,8 +10,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// HandleSettings renders the settings page with current profile and preferences.
-func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+// HandleSettings renders the settings page with current profile, preferences,
+// and the list of active sessions (devices signed in as this user).
+func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.DB, sessions dashauth.SessionStore, logger *zap.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sd := dashauth.GetSession(r.Context())
 		if sd == nil {
@@ -31,12 +32,34 @@ func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.
 			data["MFAEnabled"] = mfaEnabled
 		}
 
+		// Active sessions list.
+		data["SessionRows"] = loadSessionRows(r, sessions, sd.UserID, logger)
+
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
 			logger.Error("render settings", zap.Error(err))
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 	}
+}
+
+// loadSessionRows fetches the current user's active sessions for display.
+// Returns an empty slice (not nil) if the store is nil or the query fails
+// so the template can always range over it.
+func loadSessionRows(r *http.Request, sessions dashauth.SessionStore, userID string, logger *zap.Logger) []SessionRow {
+	if sessions == nil {
+		return []SessionRow{}
+	}
+	list, err := sessions.ListByUserID(r.Context(), userID)
+	if err != nil {
+		logger.Error("list sessions for settings", zap.Error(err))
+		return []SessionRow{}
+	}
+	currentToken := ""
+	if c, cErr := r.Cookie(dashauth.SessionCookieName); cErr == nil {
+		currentToken = c.Value
+	}
+	return buildSessionRows(list, currentToken)
 }
 
 // HandleUpdateProfile handles POST /dashboard/settings/profile.
@@ -81,7 +104,11 @@ func HandleUpdateProfile(tmpl *template.Template, authSvc *auth.AuthService, db 
 }
 
 // HandleChangePassword handles POST /dashboard/settings/password.
-func HandleChangePassword(tmpl *template.Template, authSvc *auth.AuthService, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+// On success it invalidates every OTHER session the user has so stolen
+// devices are signed out, while keeping the issuing session alive so the
+// user doesn't immediately get bounced to /login on the device that just
+// changed the password.
+func HandleChangePassword(tmpl *template.Template, authSvc *auth.AuthService, db *sql.DB, sessions dashauth.SessionStore, logger *zap.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sd := dashauth.GetSession(r.Context())
 		if sd == nil {
@@ -138,7 +165,20 @@ func HandleChangePassword(tmpl *template.Template, authSvc *auth.AuthService, db
 			return
 		}
 
-		renderWithMsg("", "Password changed successfully.")
+		// Revoke every other session the user has. The current session
+		// token is in the vaultaire_session cookie; preserve it.
+		if sessions != nil {
+			currentToken := ""
+			if c, err := r.Cookie(dashauth.SessionCookieName); err == nil {
+				currentToken = c.Value
+			}
+			if err := sessions.DeleteByUserIDExcept(r.Context(), sd.UserID, currentToken); err != nil {
+				logger.Error("invalidate other sessions on password change",
+					zap.String("user", sd.UserID), zap.Error(err))
+			}
+		}
+
+		renderWithMsg("", "Password changed. You have been signed out of other devices.")
 	}
 }
 

--- a/internal/dashboard/handlers/settings_test.go
+++ b/internal/dashboard/handlers/settings_test.go
@@ -57,7 +57,7 @@ func settingsSessionCtx(t *testing.T) context.Context {
 
 func TestHandleSettings_NoDB(t *testing.T) {
 	tmpl := testSettingsTemplate(t)
-	handler := HandleSettings(tmpl, nil, nil, zap.NewNop())
+	handler := HandleSettings(tmpl, nil, nil, nil, zap.NewNop())
 
 	req := httptest.NewRequest("GET", "/dashboard/settings", nil)
 	req = req.WithContext(settingsSessionCtx(t))
@@ -73,7 +73,7 @@ func TestHandleSettings_NoDB(t *testing.T) {
 
 func TestHandleSettings_NoSession(t *testing.T) {
 	tmpl := testSettingsTemplate(t)
-	handler := HandleSettings(tmpl, nil, nil, zap.NewNop())
+	handler := HandleSettings(tmpl, nil, nil, nil, zap.NewNop())
 
 	req := httptest.NewRequest("GET", "/dashboard/settings", nil)
 	w := httptest.NewRecorder()
@@ -85,7 +85,7 @@ func TestHandleSettings_NoSession(t *testing.T) {
 
 func TestHandleChangePassword_Validation(t *testing.T) {
 	tmpl := testSettingsTemplate(t)
-	handler := HandleChangePassword(tmpl, nil, nil, zap.NewNop())
+	handler := HandleChangePassword(tmpl, nil, nil, nil, zap.NewNop())
 
 	t.Run("short password", func(t *testing.T) {
 		form := strings.NewReader("current_password=old&new_password=short&confirm_password=short")
@@ -151,4 +151,59 @@ func TestChangePassword_WithAuth(t *testing.T) {
 	// New password should work.
 	valid, _ = authSvc.ValidatePassword(ctx, "pw-test@stored.ge", "newpassword123")
 	assert.True(t, valid)
+}
+
+func TestHandleChangePassword_InvalidatesOtherSessions(t *testing.T) {
+	// Successful password change should wipe every session for the user
+	// except the one that made the request.
+	tmpl := testSettingsTemplate(t)
+	authSvc := auth.NewAuthService(nil, nil)
+	ctx := context.Background()
+
+	user, _, _, err := authSvc.CreateUserWithTenant(ctx, "multi@stored.ge", "oldpassword123", "Test")
+	require.NoError(t, err)
+
+	store := dashauth.NewMemoryStore()
+	// Current device token (will be on the request cookie).
+	currentToken, err := store.Create(ctx, dashauth.SessionData{
+		UserID: user.ID, TenantID: user.TenantID, Email: user.Email, Role: "user",
+	}, time.Hour)
+	require.NoError(t, err)
+	// Two extra devices we expect to be logged out.
+	otherA, err := store.Create(ctx, dashauth.SessionData{
+		UserID: user.ID, TenantID: user.TenantID, Email: user.Email, Role: "user",
+	}, time.Hour)
+	require.NoError(t, err)
+	otherB, err := store.Create(ctx, dashauth.SessionData{
+		UserID: user.ID, TenantID: user.TenantID, Email: user.Email, Role: "user",
+	}, time.Hour)
+	require.NoError(t, err)
+
+	handler := HandleChangePassword(tmpl, authSvc, nil, store, zap.NewNop())
+
+	form := strings.NewReader("current_password=oldpassword123&new_password=newpassword123&confirm_password=newpassword123")
+	req := httptest.NewRequest("POST", "/dashboard/settings/password", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: dashauth.SessionCookieName, Value: currentToken})
+
+	sd, _ := store.Get(ctx, currentToken)
+	req = req.WithContext(context.WithValue(context.Background(), dashauth.SessionKey, sd))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "signed out of other devices")
+
+	// Current session must still be valid.
+	if sd, _ := store.Get(ctx, currentToken); sd == nil {
+		t.Error("expected current session to survive")
+	}
+	// Other sessions must be revoked.
+	if sd, _ := store.Get(ctx, otherA); sd != nil {
+		t.Error("expected other device A to be signed out")
+	}
+	if sd, _ := store.Get(ctx, otherB); sd != nil {
+		t.Error("expected other device B to be signed out")
+	}
 }

--- a/internal/dashboard/middleware/ratelimit.go
+++ b/internal/dashboard/middleware/ratelimit.go
@@ -35,7 +35,7 @@ func NewLoginRateLimiter(perMinute int, burst int) *LoginRateLimiter {
 // Limit returns middleware that rate-limits requests by client IP.
 func (rl *LoginRateLimiter) Limit(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := clientIP(r)
+		ip := ClientIP(r)
 		limiter := rl.getLimiter(ip)
 
 		if !limiter.Allow() {
@@ -78,9 +78,9 @@ func (rl *LoginRateLimiter) Cleanup() {
 	}
 }
 
-// clientIP extracts the client IP, preferring X-Forwarded-For (first entry)
+// ClientIP extracts the client IP, preferring X-Forwarded-For (first entry)
 // since HAProxy sits in front of Vaultaire.
-func clientIP(r *http.Request) string {
+func ClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		// Take the first IP (client), ignore proxies.
 		for i := 0; i < len(xff); i++ {

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -132,10 +132,14 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		template.Must(settingsTmpl.ParseFS(Templates,
 			"templates/customer/settings.html",
 		))
-		dr.Get("/settings", handlers.HandleSettings(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
+		dr.Get("/settings", handlers.HandleSettings(settingsTmpl, deps.Auth, deps.DB, deps.Sessions, deps.Logger))
 		dr.Post("/settings/profile", handlers.HandleUpdateProfile(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
-		dr.Post("/settings/password", handlers.HandleChangePassword(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
+		dr.Post("/settings/password", handlers.HandleChangePassword(settingsTmpl, deps.Auth, deps.DB, deps.Sessions, deps.Logger))
 		dr.Post("/settings/notifications", handlers.HandleUpdateNotifications(settingsTmpl, deps.Auth, deps.DB, deps.Logger))
+
+		// Active sessions / sign out other devices (Phase 5.8).
+		dr.Post("/settings/sessions/revoke-all", handlers.HandleRevokeAllOtherSessions(deps.Sessions, deps.Logger))
+		dr.Post("/settings/sessions/{id}/revoke", handlers.HandleRevokeSession(deps.Sessions, deps.Logger))
 
 		// 2FA settings.
 		mfaSetupTmpl := template.Must(baseTmpl.Clone())
@@ -279,10 +283,12 @@ func handleLogin(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 		}
 
 		token, err := deps.Sessions.Create(r.Context(), dashauth.SessionData{
-			UserID:   user.ID,
-			TenantID: user.TenantID,
-			Email:    user.Email,
-			Role:     role,
+			UserID:    user.ID,
+			TenantID:  user.TenantID,
+			Email:     user.Email,
+			Role:      role,
+			IPAddress: middleware.ClientIP(r),
+			UserAgent: dashauth.TruncateUserAgent(r.UserAgent()),
 		}, sessionTTL)
 		if err != nil {
 			deps.Logger.Error("create session", zap.Error(err))
@@ -342,10 +348,12 @@ func handleRegister(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 		}
 
 		token, err := deps.Sessions.Create(r.Context(), dashauth.SessionData{
-			UserID:   user.ID,
-			TenantID: user.TenantID,
-			Email:    user.Email,
-			Role:     "user",
+			UserID:    user.ID,
+			TenantID:  user.TenantID,
+			Email:     user.Email,
+			Role:      "user",
+			IPAddress: middleware.ClientIP(r),
+			UserAgent: dashauth.TruncateUserAgent(r.UserAgent()),
 		}, sessionTTL)
 		if err != nil {
 			deps.Logger.Error("create session after register", zap.Error(err))
@@ -449,12 +457,16 @@ func handleVerify2FA(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 			MaxAge:   -1,
 		})
 
-		// Create the real session.
+		// Create the real session. The MFA pending token is single-use
+		// (consumed above) so this is the first real session for this
+		// login — i.e., 2FA verification implicitly rotates the token.
 		token, cErr := deps.Sessions.Create(r.Context(), dashauth.SessionData{
-			UserID:   pending.UserID,
-			TenantID: pending.TenantID,
-			Email:    pending.Email,
-			Role:     pending.Role,
+			UserID:    pending.UserID,
+			TenantID:  pending.TenantID,
+			Email:     pending.Email,
+			Role:      pending.Role,
+			IPAddress: middleware.ClientIP(r),
+			UserAgent: dashauth.TruncateUserAgent(r.UserAgent()),
 		}, sessionTTL)
 		if cErr != nil {
 			deps.Logger.Error("create session after 2fa", zap.Error(cErr))

--- a/internal/dashboard/templates/customer/settings.html
+++ b/internal/dashboard/templates/customer/settings.html
@@ -65,6 +65,51 @@
 </div>
 
 <div class="card">
+    <div class="card-title">Active Sessions</div>
+    <p class="text-muted" style="margin-bottom: 1rem;">Devices currently signed in to your account. Revoke any you don't recognize.</p>
+    {{if .SessionRows}}
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Device</th>
+                <th>IP address</th>
+                <th>Signed in</th>
+                <th>Last active</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .SessionRows}}
+            <tr>
+                <td title="{{.FullUA}}">
+                    {{.Device}}
+                    {{if .IsCurrent}}<span class="badge badge-success">This device</span>{{end}}
+                </td>
+                <td>{{.IPAddress}}</td>
+                <td>{{.CreatedAgo}}</td>
+                <td>{{.ActiveAgo}}</td>
+                <td>
+                    {{if not .IsCurrent}}
+                    <form method="POST" action="/dashboard/settings/sessions/{{.ID}}/revoke" style="display:inline;">
+                        <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                        <button type="submit" class="btn btn-sm btn-danger">Sign out</button>
+                    </form>
+                    {{end}}
+                </td>
+            </tr>
+        {{end}}
+        </tbody>
+    </table>
+    <form method="POST" action="/dashboard/settings/sessions/revoke-all" style="margin-top: 1rem;">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <button type="submit" class="btn btn-danger">Sign out all other devices</button>
+    </form>
+    {{else}}
+    <p class="text-muted">No active sessions recorded.</p>
+    {{end}}
+</div>
+
+<div class="card">
     <div class="card-title">Two-Factor Authentication</div>
     {{if .MFAError}}<div class="alert alert-error">{{.MFAError}}</div>{{end}}
     {{if .MFAEnabled}}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -10,6 +10,11 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 |------|---------|
 | 003-017 | Core tables (tenants, users, api_keys, audit, compliance, object_head_cache) |
 | 018 | Dashboard foundation: user status/role columns, Stripe columns on tenants, subscriptions table, bandwidth_usage_daily, dashboard_sessions |
+| 019 | Stripe billing: stripe_events idempotency + billing_charges |
+| 020 | Bandwidth banking: bandwidth_rollover + bandwidth_alerts tables |
+| 021 | OAuth: oauth_accounts linking provider/provider_id to user_id |
+| 022 | Email verification: email_verified + email_verify_token + email_verify_sent_at on users |
+| 023 | Session hardening: ip_address + user_agent + last_active_at on dashboard_sessions |
 
 ## Key Tables
 
@@ -17,7 +22,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **tenants** — `id`, `name`, `email`, `access_key`, `secret_key`, `stripe_customer_id`, `stripe_subscription_id`, `subscription_status`, `plan`, `suspended_at`
 - **api_keys** — `id (UUID)`, `user_id → users`, `name`, `key_id`, `secret_hash`
 - **tenant_quotas** — `tenant_id (PK)`, `storage_limit_bytes`, `storage_used_bytes`, `tier`
-- **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `expires_at`
+- **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
 - **object_head_cache** — HEAD request cache (size, ETag, content-type stored on PUT)

--- a/internal/database/migrations/023_session_security.sql
+++ b/internal/database/migrations/023_session_security.sql
@@ -1,0 +1,9 @@
+-- 023_session_security.sql
+-- Phase 5.8: Session security hardening
+-- Track per-session IP + User-Agent + last-active so customers can see
+-- active devices and revoke them from the settings page.
+-- Idempotent — safe to re-run on every deploy.
+
+ALTER TABLE dashboard_sessions ADD COLUMN IF NOT EXISTS ip_address VARCHAR(64);
+ALTER TABLE dashboard_sessions ADD COLUMN IF NOT EXISTS user_agent VARCHAR(512);
+ALTER TABLE dashboard_sessions ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMP NOT NULL DEFAULT NOW();


### PR DESCRIPTION
## Summary

Phase 5.8 — Session Security Hardening. Customers can now see every device signed in to their account and revoke individual ones or sign out all other devices from the settings page.

- **Migration 023** adds `ip_address`, `user_agent`, `last_active_at` columns to `dashboard_sessions`
- **`SessionData`** gains `IPAddress`/`UserAgent`; **`SessionStore`** gains `ListByUserID` + `DeleteByUserIDExcept`
- **`DBStore.Get`** atomically refreshes `last_active_at` via `UPDATE ... RETURNING` — one round trip keeps the column current
- **Login / register / 2FA verify / OAuth callback** capture client IP (X-Forwarded-For aware for HAProxy) and User-Agent at session creation
- **Password change** on `/dashboard/settings/password` now revokes every other session for the user while keeping the issuing device logged in (common pattern — matches GitHub et al.)
- **New routes**: `POST /dashboard/settings/sessions/{id}/revoke` and `POST /dashboard/settings/sessions/revoke-all`
- **Active Sessions card** on the settings page with device / IP / signed-in / last-active columns, "This device" badge, per-row revoke buttons, and a "Sign out all other devices" button
- Session rotation after 2FA was already implicit — the MFA pending token is single-use and a fresh `vaultaire_session` token is issued after verification

### Security properties

- Revoke handler verifies the target session belongs to the current user before deleting (cross-user revoke = silent no-op, no information leak)
- Revoke handler refuses to kill the issuing session (would log the user out mid-request)
- Sign-out-all-other-devices keeps the current token alive so UX isn't broken
- Ownership check is a small per-user list scan, not a DB lookup, so it doesn't add meaningful latency

### Tests (15 new)

- `MemoryStore`: 5 new subtests covering IP/UA persistence, list-by-user newest-first ordering, `DeleteByUserIDExcept`, and `last_active_at` refresh on Get
- `HandleChangePassword`: end-to-end test that other sessions are killed while the current one survives
- `sessions_test.go`: 8 tests covering `buildSessionRows` current-device marking, unknown UA fallback, revoke (happy path), revoke-other-user refusal, revoke-self refusal, revoke-all-other behavior, and `relativeAgo` formatting

### Files changed

- `internal/database/migrations/023_session_security.sql` (new)
- `internal/dashboard/auth/auth.go` — SessionData, SessionStore, MemoryStore, DBStore extensions + TruncateUserAgent helper + exported `SessionCookieName`
- `internal/dashboard/auth/auth_test.go` — new store tests
- `internal/dashboard/handlers/sessions.go` (new) — HandleRevokeSession, HandleRevokeAllOtherSessions, buildSessionRows, describeDevice, relativeAgo
- `internal/dashboard/handlers/sessions_test.go` (new)
- `internal/dashboard/handlers/settings.go` — HandleSettings loads session rows, HandleChangePassword invalidates other sessions
- `internal/dashboard/handlers/settings_test.go` — updated signatures + new test
- `internal/dashboard/handlers/oauth.go` — capture IP/UA on OAuth callback
- `internal/dashboard/router.go` — wire IP/UA capture on login/register/2FA; register new routes
- `internal/dashboard/middleware/ratelimit.go` — export `ClientIP` (was unexported)
- `internal/dashboard/templates/customer/settings.html` — Active Sessions card
- `internal/dashboard/CLAUDE.md`, `internal/database/CLAUDE.md` — doc updates

## Test plan

- [x] `go build ./...`
- [x] `make lint` — 0 issues
- [x] `go test ./internal/dashboard/...` — all pass
- [x] Pre-commit hooks (gofmt + go test -short + golangci-lint) pass
- [ ] CI `build-and-test` passes
- [ ] Post-merge deploy runs migration 023 cleanly on SLC
- [ ] Manual smoke: log in from two browsers, confirm both appear in Active Sessions, revoke one from the other, confirm revoked session is signed out on next request