### PR TITLE
feat(dashboard): responsive CSS, error pages, platform polish [Phase 5.9]

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/rbac"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
@@ -190,6 +191,7 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 
 	s.rbacService = NewRBACService(logger)
 
+	s.router.Use(s.requestIDMiddleware)
 	s.router.Use(s.rbacService.InjectUserContext)
 	s.router.Use(s.loggingMiddleware)
 
@@ -369,6 +371,9 @@ func (s *Server) setupRoutes() {
 		s.logger.Info("Registering Stripe webhook route")
 		s.router.Post("/webhook/stripe", s.webhookHandler.ServeHTTP)
 	}
+
+	// Public status page — no auth, renders HTML.
+	s.router.Get("/status", s.handleStatusPage)
 
 	// Dashboard routes must be registered BEFORE the S3 catch-all so that
 	// /login, /dashboard/*, /admin/*, and /static/* are matched first.
@@ -664,6 +669,61 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleStatusPage(w http.ResponseWriter, r *http.Request) {
+	status, healthy, total := s.healthChecker.GetOverallStatus()
+	uptime := time.Since(s.startTime).Truncate(time.Second)
+
+	statusLabel := "All Systems Operational"
+	statusClass := "operational"
+	if status != "healthy" {
+		statusLabel = "Degraded"
+		statusClass = "degraded"
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprintf(w, statusPageHTML, statusClass, statusLabel, "0.1.0", uptime, healthy, total)
+}
+
+const statusPageHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Status — stored.ge</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.card{background:#1e293b;border-radius:12px;padding:2.5rem;max-width:480px;width:100%%;text-align:center}
+h1{font-size:1.5rem;margin:0 0 1.5rem;color:#e2e8f0}
+.brand{font-size:1.1rem;color:#94a3b8;margin-bottom:1rem}
+.status{font-size:1.25rem;font-weight:700;padding:0.5rem 1rem;border-radius:8px;display:inline-block;margin-bottom:1.5rem}
+.operational{background:#065f46;color:#6ee7b7}
+.degraded{background:#78350f;color:#fcd34d}
+.detail{color:#94a3b8;font-size:0.9rem;margin:0.4rem 0}
+a{color:#60a5fa;text-decoration:none}
+a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="card">
+<div class="brand">stored.ge</div>
+<h1>System Status</h1>
+<div class="status %s">%s</div>
+<p class="detail">Version: %s</p>
+<p class="detail">Uptime: %s</p>
+<p class="detail">Backends: %d / %d healthy</p>
+<p class="detail" style="margin-top:1.5rem"><a href="/health?details=true">JSON health endpoint</a></p>
+</div>
+</body>
+</html>`
+
+func (s *Server) requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", uuid.New().String())
+		w.Header().Set("Server", "stored.ge")
+		next.ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&s.requestCount, 1)
@@ -672,6 +732,7 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		s.logger.Info("request",
 			zap.String("method", r.Method),
 			zap.String("path", r.URL.Path),
+			zap.String("request_id", w.Header().Get("X-Request-Id")),
 			zap.Duration("latency", time.Since(start)),
 		)
 	})

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusPage_Healthy(t *testing.T) {
+	// Arrange
+	s := newTestServerWithHealthChecker(t)
+	s.healthChecker.RegisterBackend("quotaless")
+	s.healthChecker.UpdateHealth("quotaless", true, 5*time.Millisecond, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.handleStatusPage(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	body := rec.Body.String()
+	assert.Contains(t, body, "All Systems Operational")
+	assert.Contains(t, body, "stored.ge")
+	assert.Contains(t, body, "0.1.0")
+	assert.Contains(t, body, "1 / 1 healthy")
+}
+
+func TestStatusPage_Degraded(t *testing.T) {
+	// Arrange
+	s := newTestServerWithHealthChecker(t)
+	s.healthChecker.RegisterBackend("quotaless")
+	s.healthChecker.UpdateHealth("quotaless", false, 0, assert.AnError)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	s.handleStatusPage(rec, req)
+
+	// Assert
+	body := rec.Body.String()
+	assert.Contains(t, body, "Degraded")
+}
+
+func TestRequestIDMiddleware_SetsHeaders(t *testing.T) {
+	// Arrange
+	s := newTestServerWithHealthChecker(t)
+	handler := s.requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.NotEmpty(t, rec.Header().Get("X-Request-Id"))
+	assert.Equal(t, "stored.ge", rec.Header().Get("Server"))
+
+	// Verify the request ID looks like a UUID (36 chars with dashes).
+	rid := rec.Header().Get("X-Request-Id")
+	assert.Len(t, rid, 36)
+}

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -7,11 +7,20 @@ Web dashboard for stored.ge customers and admins. Uses htmx + Go templates, embe
 - **embed.go** — `//go:embed` bundles `templates/` and `static/` into the binary
 - **router.go** — `RegisterRoutes(r, deps)` mounts all dashboard routes on the chi router. Must be called BEFORE the S3 catch-all in `server.go`.
 - **auth/** — session management (PostgreSQL-backed `DBStore` or in-memory `MemoryStore`)
-- **handlers/** — HTTP handlers (`overview.go` renders dashboard with real data from DB)
+- **handlers/** — HTTP handlers (`overview.go` renders dashboard with real data from DB, `errors.go` = branded 404)
 - **templates/layouts/** — shared HTML layouts (`base.html`, `admin.html`)
 - **templates/customer/** — customer page templates (`dashboard.html` = overview)
 - **static/css/** — `style.css`
 - **static/js/** — `htmx.min.js` (v2.0.4, vendored)
+- **middleware/recovery.go** — panic recovery middleware, renders self-contained 500 HTML (no template dependency)
+
+## Error Handling (Phase 5.9)
+
+- `/dashboard/*` and `/admin/*` subrouters have `chi.NotFound` handlers that render a branded 404 HTML page (`handlers/errors.go`).
+- Recovery middleware catches panics, logs the stack trace, and renders a self-contained 500 page. Wired into both subrouters.
+- Top-level unknown paths still fall through to the S3 catch-all handler (returns XML errors for API clients). No top-level HTML 404.
+- Every response gets `X-Request-Id` (UUID) and `Server: stored.ge` headers via middleware in `server.go`.
+- `GET /status` is a public (no auth) HTML status page showing operational status, uptime, version, and backend health.
 
 ## Session Auth
 

--- a/internal/dashboard/handlers/errors.go
+++ b/internal/dashboard/handlers/errors.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// HandleNotFound returns a handler that renders a branded 404 page for
+// unknown paths under /dashboard or /admin.
+func HandleNotFound(logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger.Debug("dashboard 404", zap.String("path", r.URL.Path))
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(errorPage404HTML))
+	}
+}
+
+// errorPage404HTML is a self-contained HTML page — no template dependency.
+const errorPage404HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>404 — stored.ge</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.card{background:#1e293b;border-radius:12px;padding:2.5rem;max-width:420px;text-align:center}
+h1{font-size:3rem;margin:0 0 0.5rem;color:#fbbf24}
+p{color:#94a3b8;line-height:1.6}
+a{color:#60a5fa;text-decoration:none}
+a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="card">
+<h1>404</h1>
+<h2>Page not found</h2>
+<p>The page you're looking for doesn't exist or has been moved.</p>
+<p><a href="/dashboard">Back to Dashboard</a></p>
+</div>
+</body>
+</html>`

--- a/internal/dashboard/handlers/errors_test.go
+++ b/internal/dashboard/handlers/errors_test.go
@@ -1,0 +1,29 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestHandleNotFound_Returns404HTML(t *testing.T) {
+	// Arrange
+	handler := handlers.HandleNotFound(zap.NewNop())
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/does-not-exist", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	body := rec.Body.String()
+	assert.Contains(t, body, "404")
+	assert.Contains(t, body, "Page not found")
+	assert.Contains(t, body, "Back to Dashboard")
+}

--- a/internal/dashboard/middleware/recovery.go
+++ b/internal/dashboard/middleware/recovery.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"net/http"
+	"runtime/debug"
+
+	"go.uber.org/zap"
+)
+
+// Recovery catches panics in downstream handlers, logs the stack trace,
+// and renders a branded 500 page. The stack is NOT included in the response
+// body — it would leak internal structure to the client.
+func Recovery(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					logger.Error("panic recovered",
+						zap.Any("panic", rec),
+						zap.String("path", r.URL.Path),
+						zap.String("method", r.Method),
+						zap.ByteString("stack", debug.Stack()))
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(errorPage500HTML))
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// errorPage500HTML is a self-contained HTML page that does NOT depend on
+// templates (if the template engine panicked we can't trust it).
+const errorPage500HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>500 — stored.ge</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.card{background:#1e293b;border-radius:12px;padding:2.5rem;max-width:420px;text-align:center}
+h1{font-size:3rem;margin:0 0 0.5rem;color:#f87171}
+p{color:#94a3b8;line-height:1.6}
+a{color:#60a5fa;text-decoration:none}
+a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="card">
+<h1>500</h1>
+<h2>Something went wrong</h2>
+<p>We hit an unexpected error. Please try again in a moment.</p>
+<p><a href="/dashboard">Back to Dashboard</a></p>
+</div>
+</body>
+</html>`

--- a/internal/dashboard/middleware/recovery_test.go
+++ b/internal/dashboard/middleware/recovery_test.go
@@ -1,0 +1,88 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestRecovery_PanicReturns500(t *testing.T) {
+	// Arrange
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	handler := middleware.Recovery(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/explode", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	body := rec.Body.String()
+	assert.Contains(t, body, "500")
+	assert.Contains(t, body, "Something went wrong")
+	assert.NotContains(t, body, "goroutine", "stack trace must not leak to client")
+
+	// Verify the panic was logged with stack trace.
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	assert.Equal(t, "panic recovered", entry.Message)
+}
+
+func TestRecovery_NoPanic_Passthrough(t *testing.T) {
+	// Arrange
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	handler := middleware.Recovery(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+	assert.Equal(t, 0, logs.Len(), "no errors should be logged on normal request")
+}
+
+func TestRecovery_PanicWithNonStringValue(t *testing.T) {
+	// Arrange — panics with a non-string value (e.g. int).
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	handler := middleware.Recovery(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(42)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/boom", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, 1, logs.Len())
+	// Verify the body does not contain any Go source file paths.
+	assert.False(t, strings.Contains(rec.Body.String(), ".go:"),
+		"response must not contain Go source paths")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -87,9 +87,11 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
+		dr.Use(middleware.Recovery(deps.Logger))
 		dr.Use(dashauth.RequireSession(deps.Sessions))
 		dr.Use(middleware.CSRF)
 		dr.Use(middleware.Flash)
+		dr.NotFound(handlers.HandleNotFound(deps.Logger))
 
 		// Overview: parse the real template from embedded FS.
 		overviewTmpl := template.Must(baseTmpl.Clone())
@@ -182,8 +184,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	))
 
 	r.Route("/admin", func(ar chi.Router) {
+		ar.Use(middleware.Recovery(deps.Logger))
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
 		ar.Use(middleware.CSRF)
+		ar.NotFound(handlers.HandleNotFound(deps.Logger))
 		ar.Get("/", handlers.HandleAdminOverview(adminTmpl, deps.DB, deps.Logger))
 		ar.Get("/tenants", handlers.HandleTenantList(tenantListTmpl, deps.DB, deps.Logger))
 		ar.Get("/tenants/{id}", handlers.HandleTenantDetail(tenantDetailTmpl, deps.DB, deps.Logger))

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -421,9 +421,41 @@ th {
 .htmx-indicator { opacity: 0; transition: opacity 0.2s; }
 .htmx-request .htmx-indicator { opacity: 1; }
 
+/* Zero-egress callout */
+.egress-callout {
+    display: inline-block;
+    background: var(--success);
+    color: #fff;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .admin-layout { flex-direction: column; }
     .admin-sidebar { width: 100%; }
     .card-grid { grid-template-columns: 1fr; }
+
+    /* Containers: tighter padding */
+    .container { padding: 1rem 0.75rem; }
+
+    /* Navbar: stack links, use flex-wrap */
+    .navbar { flex-wrap: wrap; gap: 0.5rem; }
+    .nav-links { flex-direction: column; width: 100%; }
+
+    /* Page header: stack title and action button */
+    .page-header { flex-direction: column; align-items: flex-start; gap: 1rem; }
+
+    /* Dashboard actions row: wrap buttons */
+    .dashboard-actions { flex-wrap: wrap; }
+    .dashboard-actions .btn { flex: 1 1 calc(50% - 0.75rem); }
+
+    /* Comparison grid: 3 cols → 1 col */
+    .comparison-grid { grid-template-columns: 1fr; }
+
+    /* Form groups: reduce vertical spacing */
+    .form-group { margin-bottom: 1rem; }
 }

--- a/internal/dashboard/templates/customer/billing.html
+++ b/internal/dashboard/templates/customer/billing.html
@@ -15,6 +15,8 @@
 
 {{if .Upgraded}}<div class="alert alert-success">Plan upgraded successfully.</div>{{end}}
 
+<div class="egress-callout">Egress: $0.00 — always free</div>
+
 <div class="card-grid">
     <div class="card">
         <div class="card-title">Current Plan</div>

--- a/internal/dashboard/templates/customer/usage.html
+++ b/internal/dashboard/templates/customer/usage.html
@@ -7,6 +7,8 @@
     </div>
 </div>
 
+<div class="egress-callout">Egress: $0.00 — always free</div>
+
 <div class="card-grid">
     <div class="card">
         <div class="card-title">Storage Used</div>


### PR DESCRIPTION
## Summary

- **Responsive CSS**: Mobile-friendly breakpoints at 768px — navbar flex-wrap, stacked page headers, wrapped dashboard action buttons, single-column comparison grid. Tables keep horizontal scroll via existing `.table-wrap`.
- **404 error pages**: Branded HTML 404 for `/dashboard/*` and `/admin/*` via chi `NotFound` handlers. Top-level unknown paths still route to S3 catch-all (correct for API clients).
- **Recovery middleware**: Catches panics in dashboard/admin handlers, logs full stack trace, serves a self-contained 500 page. Stack trace is NOT leaked to the client.
- **X-Request-Id + Server headers**: Every response gets a UUID `X-Request-Id` and `Server: stored.ge` header via top-level middleware.
- **Public /status page**: `GET /status` renders an HTML page showing operational status (healthy/degraded), uptime, version, and backend count. No auth required.
- **Zero-egress callout**: Green badge "Egress: $0.00 — always free" on billing and usage pages.

## Scope decisions

- No hamburger menu (flex-wrap is sufficient for MVP)
- No table → card reflow (`.table-wrap` horizontal scroll is acceptable)
- No top-level HTML 404 (keeps S3 API compatibility clean)
- 500 page is self-contained HTML (no template dependency — if templates panicked we can't trust them)

## Test plan

- [x] 3 recovery middleware tests (panic → 500, normal passthrough, non-string panic value)
- [x] 1 error handler test (404 returns HTML with "Page not found" and "Back to Dashboard" link)
- [x] 2 status page tests (healthy → "All Systems Operational", degraded → "Degraded")
- [x] 1 request-ID middleware test (UUID in X-Request-Id header, Server: stored.ge)
- [x] `make lint` clean (0 issues)
- [x] Pre-commit hooks pass (go fmt, go test, golangci-lint)