### PR TITLE
feat(s3): multipart upload with DB persistence [Phase 5.10.1]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -114,7 +114,11 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 	if req.Object == "" {
 		switch method {
 		case "GET":
-			req.Operation = "ListObjects"
+			if _, ok := req.Query["uploads"]; ok {
+				req.Operation = "ListMultipartUploads"
+			} else {
+				req.Operation = "ListObjects"
+			}
 		case "PUT":
 			req.Operation = "CreateBucket"
 		case "DELETE":
@@ -378,6 +382,8 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleAbortMultipartUpload(cw, r, s3Req.Bucket, s3Req.Object)
 	case "ListParts":
 		s.handleListParts(cw, r, s3Req.Bucket, s3Req.Object)
+	case "ListMultipartUploads":
+		s.handleListMultipartUploads(cw, r, s3Req.Bucket)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -38,6 +38,11 @@ const (
 	ErrSignatureDoesNotMatch = "SignatureDoesNotMatch"
 	ErrAccountSuspended      = "AccountSuspended"
 	ErrSlowDown              = "SlowDown"
+	ErrNoSuchUpload          = "NoSuchUpload"
+	ErrInvalidPart           = "InvalidPart"
+	ErrInvalidPartOrder      = "InvalidPartOrder"
+	ErrEntityTooSmall        = "EntityTooSmall"
+	ErrInvalidPartNumber     = "InvalidPartNumber"
 )
 
 // Error messages
@@ -62,6 +67,11 @@ var errorMessages = map[string]string{
 	ErrSignatureDoesNotMatch: "The request signature we calculated does not match the signature you provided",
 	ErrAccountSuspended:      "Your account has been suspended. Contact support for assistance.",
 	ErrSlowDown:              "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
+	ErrNoSuchUpload:          "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+	ErrInvalidPart:           "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+	ErrInvalidPartOrder:      "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+	ErrEntityTooSmall:        "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
+	ErrInvalidPartNumber:     "Part number must be an integer between 1 and 10000, inclusive.",
 }
 
 // HTTP status codes for errors
@@ -86,6 +96,11 @@ var errorStatusCodes = map[string]int{
 	ErrSignatureDoesNotMatch: http.StatusForbidden,
 	ErrAccountSuspended:      http.StatusForbidden,
 	ErrSlowDown:              http.StatusTooManyRequests,
+	ErrNoSuchUpload:          http.StatusNotFound,
+	ErrInvalidPart:           http.StatusBadRequest,
+	ErrInvalidPartOrder:      http.StatusBadRequest,
+	ErrEntityTooSmall:        http.StatusBadRequest,
+	ErrInvalidPartNumber:     http.StatusBadRequest,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_multipart.go
+++ b/internal/api/s3_multipart.go
@@ -1,424 +1,656 @@
 package api
 
 import (
-	"context"
 	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
+	"database/sql"
+	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/FairForge/vaultaire/internal/common"
+	"github.com/FairForge/vaultaire/internal/tenant"
 
 	"go.uber.org/zap"
 )
 
-// MultipartUpload tracks an in-progress multipart upload
-type MultipartUpload struct {
-	UploadID string
-	Bucket   string
-	Key      string
-	TenantID string
-	Parts    map[int]*Part
-	mu       sync.Mutex
-
-	// Idempotency fields
-	Completed     bool
-	CompletedETag string
-	CompletedAt   time.Time
-}
-
-// Part represents a single part of a multipart upload
-type Part struct {
-	PartNumber int
-	ETag       string
-	Size       int64
-	Data       []byte
-}
-
-// Global storage for active uploads (in production, use database)
-var (
-	activeUploads = make(map[string]*MultipartUpload)
-	uploadsMu     sync.RWMutex
+const (
+	multipartTempBase = "/tmp/vaultaire-multipart"
+	maxPartNumber     = 10000
 )
 
+// In-memory fallback for when DB is not available (test mode).
+// Production always uses PostgreSQL.
+var (
+	memUploads   = make(map[string]*memUpload)
+	memUploadsMu sync.RWMutex
+)
+
+type memUpload struct {
+	TenantID string
+	Bucket   string
+	Key      string
+	Status   string // "active", "completed", "aborted"
+	Parts    map[int]memPart
+	Created  time.Time
+}
+
+type memPart struct {
+	ETag string
+	Size int64
+}
+
+// multipartDir returns the temp directory for a specific upload's parts.
+func multipartDir(uploadID string) string {
+	return filepath.Join(multipartTempBase, uploadID)
+}
+
+// partFilePath returns the temp file path for a specific part.
+func partFilePath(uploadID string, partNumber int) string {
+	return filepath.Join(multipartTempBase, uploadID, fmt.Sprintf("part-%05d", partNumber))
+}
+
 func (s *Server) handleInitiateMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
 	uploadID := fmt.Sprintf("upload-%d-%d", time.Now().Unix(), time.Now().Nanosecond())
 
-	// Get tenant from context
-	tenantID := "default"
-
-	// DEBUG: Check what's actually in the context
-	ctxValue := r.Context().Value(common.TenantIDKey)
-	s.logger.Info("multipart init context check",
-		zap.Any("raw_value", ctxValue),
-		zap.String("type", fmt.Sprintf("%T", ctxValue)))
-
-	if t := r.Context().Value(common.TenantIDKey); t != nil {
-		if tid, ok := t.(string); ok {
-			tenantID = tid
-			s.logger.Info("extracted tenant", zap.String("tenant", tenantID))
-		} else {
-			s.logger.Info("failed to cast tenant", zap.Any("value", t))
+	// Persist upload record
+	if s.db != nil {
+		_, err := s.db.ExecContext(r.Context(), `
+			INSERT INTO multipart_uploads (upload_id, tenant_id, bucket, object_key, status)
+			VALUES ($1, $2, $3, $4, 'active')
+		`, uploadID, t.ID, bucket, object)
+		if err != nil {
+			s.logger.Error("failed to create multipart upload record", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
 		}
 	} else {
-		s.logger.Info("no tenant in context")
+		memUploadsMu.Lock()
+		memUploads[uploadID] = &memUpload{
+			TenantID: t.ID,
+			Bucket:   bucket,
+			Key:      object,
+			Status:   "active",
+			Parts:    make(map[int]memPart),
+			Created:  time.Now(),
+		}
+		memUploadsMu.Unlock()
 	}
 
-	// Store the upload session
-	upload := &MultipartUpload{
-		UploadID: uploadID,
-		Bucket:   bucket,
-		Key:      object,
-		TenantID: tenantID,
-		Parts:    make(map[int]*Part),
+	// Create temp directory for part files
+	if err := os.MkdirAll(multipartDir(uploadID), 0700); err != nil {
+		s.logger.Error("failed to create multipart temp dir", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
 	}
-
-	uploadsMu.Lock()
-	activeUploads[uploadID] = upload
-	uploadsMu.Unlock()
 
 	s.logger.Info("initiated multipart upload",
 		zap.String("bucket", bucket),
 		zap.String("key", object),
-		zap.String("uploadID", uploadID))
+		zap.String("uploadID", uploadID),
+		zap.String("tenant_id", t.ID))
 
-	response := InitiateMultipartUploadResult{
+	w.Header().Set("Content-Type", "application/xml")
+	if err := xml.NewEncoder(w).Encode(InitiateMultipartUploadResult{
 		Bucket:   bucket,
 		Key:      object,
 		UploadID: uploadID,
-	}
-
-	w.Header().Set("Content-Type", "application/xml")
-	if err := xml.NewEncoder(w).Encode(response); err != nil {
+	}); err != nil {
 		s.logger.Error("failed to encode initiate response", zap.Error(err))
-		return
 	}
 }
 
 func (s *Server) handleUploadPart(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
 	uploadID := r.URL.Query().Get("uploadId")
 	partNumberStr := r.URL.Query().Get("partNumber")
 
 	partNumber, err := strconv.Atoi(partNumberStr)
+	if err != nil || partNumber < 1 || partNumber > maxPartNumber {
+		WriteS3Error(w, ErrInvalidPartNumber, r.URL.Path, generateRequestID())
+		return
+	}
+
+	// Verify upload exists, is active, and belongs to this tenant
+	if s.db != nil {
+		var status string
+		err := s.db.QueryRowContext(r.Context(), `
+			SELECT status FROM multipart_uploads
+			WHERE upload_id = $1 AND tenant_id = $2
+		`, uploadID, t.ID).Scan(&status)
+		if err == sql.ErrNoRows || (err == nil && status != "active") {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
+		if err != nil {
+			s.logger.Error("failed to query multipart upload", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.RLock()
+		mu, ok := memUploads[uploadID]
+		memUploadsMu.RUnlock()
+		if !ok || mu.TenantID != t.ID || mu.Status != "active" {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
+	}
+
+	// Stream part data to temp file while computing MD5 ETag
+	pp := partFilePath(uploadID, partNumber)
+	f, err := os.Create(pp) // #nosec G304 — path derived from validated uploadID + partNumber
 	if err != nil {
-		http.Error(w, "Invalid part number", http.StatusBadRequest)
+		s.logger.Error("failed to create part temp file", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
 	}
 
-	// Find the upload session
-	uploadsMu.RLock()
-	upload, exists := activeUploads[uploadID]
-	uploadsMu.RUnlock()
-
-	if !exists {
-		s.logger.Error("upload not found", zap.String("uploadID", uploadID))
-		http.Error(w, "Upload not found", http.StatusNotFound)
-		return
+	hasher := md5.New() // #nosec G401 — S3 spec requires MD5 for ETags
+	size, err := io.Copy(f, io.TeeReader(r.Body, hasher))
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
-
-	// Read the part data
-	data, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "Failed to read part", http.StatusInternalServerError)
+		_ = os.Remove(pp)
+		s.logger.Error("failed to write part data", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
 	}
 
-	// Generate ETag using MD5
-	hash := md5.Sum(data) // #nosec G401 — S3 spec requires MD5 for ETags
-	etag := fmt.Sprintf("\"%x\"", hash)
+	etag := fmt.Sprintf("\"%x\"", hasher.Sum(nil))
 
-	// Store the part
-	part := &Part{
-		PartNumber: partNumber,
-		ETag:       etag,
-		Size:       int64(len(data)),
-		Data:       data,
+	// Record part metadata
+	if s.db != nil {
+		_, err := s.db.ExecContext(r.Context(), `
+			INSERT INTO multipart_parts (upload_id, part_number, etag, size_bytes)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (upload_id, part_number) DO UPDATE SET
+				etag       = EXCLUDED.etag,
+				size_bytes = EXCLUDED.size_bytes,
+				created_at = NOW()
+		`, uploadID, partNumber, etag, size)
+		if err != nil {
+			s.logger.Error("failed to record part metadata", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.Lock()
+		if mu, ok := memUploads[uploadID]; ok {
+			mu.Parts[partNumber] = memPart{ETag: etag, Size: size}
+		}
+		memUploadsMu.Unlock()
 	}
-
-	upload.mu.Lock()
-	upload.Parts[partNumber] = part
-	upload.mu.Unlock()
 
 	s.logger.Debug("uploaded part",
 		zap.String("bucket", bucket),
 		zap.String("key", object),
 		zap.String("uploadID", uploadID),
 		zap.Int("partNumber", partNumber),
-		zap.Int("size", len(data)))
+		zap.Int64("size", size),
+		zap.String("etag", etag))
 
-	// Return ETag header
 	w.Header().Set("ETag", etag)
 	w.WriteHeader(http.StatusOK)
 }
 
+// partRecord holds part metadata from either DB or in-memory store.
+type partRecord struct {
+	PartNumber int
+	ETag       string
+	Size       int64
+}
+
 func (s *Server) handleCompleteMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {
-	startTime := time.Now()
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
 	uploadID := r.URL.Query().Get("uploadId")
 
-	s.logger.Info("completing multipart upload",
-		zap.String("bucket", bucket),
-		zap.String("key", object),
-		zap.String("uploadID", uploadID))
-
-	// Find the upload session
-	uploadsMu.RLock()
-	upload, exists := activeUploads[uploadID]
-	uploadsMu.RUnlock()
-
-	if !exists {
-		s.logger.Error("upload not found for completion", zap.String("uploadID", uploadID))
-		http.Error(w, "Upload not found", http.StatusNotFound)
-		return
-	}
-
-	// Check if already completed (idempotency)
-	upload.mu.Lock()
-	if upload.Completed {
-		upload.mu.Unlock()
-		s.logger.Info("upload already completed, returning cached response",
-			zap.String("uploadID", uploadID))
-
-		// Return the same success response
-		location := fmt.Sprintf("http://%s/%s/%s", r.Host, bucket, object)
-		response := CompleteMultipartUploadResult{
-			Location: location,
-			Bucket:   bucket,
-			Key:      object,
-			ETag:     upload.CompletedETag,
-		}
-		w.Header().Set("Content-Type", "application/xml")
-		if err := xml.NewEncoder(w).Encode(response); err != nil {
-			s.logger.Error("failed to encode cached response", zap.Error(err))
+	// Verify upload is active and belongs to this tenant
+	if s.db != nil {
+		var status string
+		err := s.db.QueryRowContext(r.Context(), `
+			SELECT status FROM multipart_uploads
+			WHERE upload_id = $1 AND tenant_id = $2
+		`, uploadID, t.ID).Scan(&status)
+		if err == sql.ErrNoRows || (err == nil && status != "active") {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
 			return
 		}
-		return
-	}
-	upload.mu.Unlock()
-
-	// Parse the request body to get part list (AWS sends this)
-	var completeRequest CompleteMultipartUploadRequest
-	if r.Body != nil {
-		if err := xml.NewDecoder(r.Body).Decode(&completeRequest); err != nil {
-			s.logger.Debug("no complete request body, using all parts",
-				zap.Error(err))
+		if err != nil {
+			s.logger.Error("failed to query multipart upload", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.RLock()
+		mu, ok := memUploads[uploadID]
+		memUploadsMu.RUnlock()
+		if !ok || mu.TenantID != t.ID || mu.Status != "active" {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
 		}
 	}
 
-	// Sort parts by part number
-	upload.mu.Lock()
-	partNumbers := make([]int, 0, len(upload.Parts))
-	totalSize := int64(0)
-	for partNum := range upload.Parts {
-		partNumbers = append(partNumbers, partNum)
-		totalSize += upload.Parts[partNum].Size
+	// Parse the CompleteMultipartUpload XML body (AWS clients send this)
+	var completeReq CompleteMultipartUploadRequest
+	if r.Body != nil {
+		if decErr := xml.NewDecoder(r.Body).Decode(&completeReq); decErr != nil {
+			s.logger.Debug("no complete request body, using all uploaded parts", zap.Error(decErr))
+		}
 	}
-	sort.Ints(partNumbers)
 
-	// Copy parts for assembly
-	partsToAssemble := make([]*Part, len(partNumbers))
-	for i, partNum := range partNumbers {
-		partsToAssemble[i] = upload.Parts[partNum]
-	}
-	upload.mu.Unlock()
-
-	// Use streaming assembly with pipe
-	pr, pw := io.Pipe()
-
-	// IMPORTANT FIX: Use just the bucket name, not tenant_bucket
-	// The engine/driver will handle tenant isolation internally
-	containerName := fmt.Sprintf("%s_%s", upload.TenantID, bucket)
-
-	var assemblyErr error
-	var uploadErr error
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	// Goroutine 1: Write parts to pipe
-	go func() {
-		defer wg.Done()
-		defer func() {
-			if err := pw.Close(); err != nil {
-				s.logger.Error("failed to close pipe writer", zap.Error(err))
+	// Load all uploaded parts, ordered by part number
+	var parts []partRecord
+	if s.db != nil {
+		rows, err := s.db.QueryContext(r.Context(), `
+			SELECT part_number, etag, size_bytes FROM multipart_parts
+			WHERE upload_id = $1
+			ORDER BY part_number ASC
+		`, uploadID)
+		if err != nil {
+			s.logger.Error("failed to query parts", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var p partRecord
+			if err := rows.Scan(&p.PartNumber, &p.ETag, &p.Size); err != nil {
+				s.logger.Error("failed to scan part row", zap.Error(err))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
 			}
-		}()
+			parts = append(parts, p)
+		}
+		if err := rows.Err(); err != nil {
+			s.logger.Error("parts iteration error", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.RLock()
+		mu := memUploads[uploadID]
+		for pn, mp := range mu.Parts {
+			parts = append(parts, partRecord{PartNumber: pn, ETag: mp.ETag, Size: mp.Size})
+		}
+		memUploadsMu.RUnlock()
+		// Sort by part number (map iteration is random)
+		sortParts(parts)
+	}
 
-		for i, part := range partsToAssemble {
-			if _, err := pw.Write(part.Data); err != nil {
-				assemblyErr = fmt.Errorf("failed to write part %d: %w", partNumbers[i], err)
-				pw.CloseWithError(assemblyErr)
+	if len(parts) == 0 {
+		WriteS3Error(w, ErrInvalidPart, r.URL.Path, generateRequestID())
+		return
+	}
+
+	// If the client sent a specific part list, validate and select those parts
+	if len(completeReq.Parts) > 0 {
+		// Validate ascending order
+		for i := 1; i < len(completeReq.Parts); i++ {
+			if completeReq.Parts[i].PartNumber <= completeReq.Parts[i-1].PartNumber {
+				WriteS3Error(w, ErrInvalidPartOrder, r.URL.Path, generateRequestID())
 				return
 			}
 		}
+		// Build lookup of uploaded parts
+		uploaded := make(map[int]partRecord, len(parts))
+		for _, p := range parts {
+			uploaded[p.PartNumber] = p
+		}
+		// Match requested parts against uploaded parts
+		selected := make([]partRecord, 0, len(completeReq.Parts))
+		for _, rp := range completeReq.Parts {
+			up, ok := uploaded[rp.PartNumber]
+			if !ok {
+				WriteS3Error(w, ErrInvalidPart, r.URL.Path, generateRequestID())
+				return
+			}
+			if strings.Trim(rp.ETag, "\"") != strings.Trim(up.ETag, "\"") {
+				WriteS3Error(w, ErrInvalidPart, r.URL.Path, generateRequestID())
+				return
+			}
+			selected = append(selected, up)
+		}
+		parts = selected
+	}
 
-		s.logger.Info("parts assembled",
-			zap.Int64("total_size", totalSize),
-			zap.Int("parts", len(partNumbers)))
-	}()
+	// Compute total size and S3-compatible multipart ETag:
+	// ETag = MD5(concat(MD5_part1 + MD5_part2 + ...))-N
+	var totalSize int64
+	etagHasher := md5.New() // #nosec G401 — S3 spec requires MD5 for multipart ETags
+	for _, p := range parts {
+		totalSize += p.Size
+		raw := strings.Trim(p.ETag, "\"")
+		if decoded, err := hex.DecodeString(raw); err == nil {
+			etagHasher.Write(decoded)
+		}
+	}
+	finalETag := fmt.Sprintf("\"%x-%d\"", etagHasher.Sum(nil), len(parts))
 
-	// Goroutine 2: Upload from pipe to backend
+	// Stream assembled parts to backend via pipe
+	pr, pw := io.Pipe()
+	containerName := t.NamespaceContainer(bucket)
+
+	errCh := make(chan error, 1)
+
+	// Writer goroutine: read temp files in order, write into pipe
 	go func() {
-		defer wg.Done()
 		defer func() {
-			if err := pr.Close(); err != nil {
-				s.logger.Error("failed to close pipe reader", zap.Error(err))
+			if err := pw.Close(); err != nil {
+				s.logger.Debug("pipe writer close", zap.Error(err))
 			}
 		}()
-
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
-		defer cancel()
-
-		// Add tenant to context for the engine
-		ctx = context.WithValue(ctx, common.TenantIDKey, upload.TenantID)
-
-		// Store to backend
-		_, uploadErr = s.engine.Put(ctx, containerName, object, pr)
-
-		if uploadErr != nil {
-			s.logger.Error("failed to store to backend",
-				zap.Error(uploadErr),
-				zap.String("container", containerName),
-				zap.String("key", object))
-		} else {
-			s.logger.Info("stored to backend successfully",
-				zap.String("container", containerName),
-				zap.String("key", object),
-				zap.Int64("size", totalSize))
+		for _, p := range parts {
+			pp := partFilePath(uploadID, p.PartNumber)
+			f, err := os.Open(pp) // #nosec G304 — path derived from validated uploadID
+			if err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("open part %d: %w", p.PartNumber, err))
+				return
+			}
+			_, copyErr := io.Copy(pw, f)
+			_ = f.Close()
+			if copyErr != nil {
+				_ = pw.CloseWithError(fmt.Errorf("stream part %d: %w", p.PartNumber, copyErr))
+				return
+			}
 		}
 	}()
 
-	// Wait for both operations to complete
-	wg.Wait()
+	// Upload assembled stream to backend
+	go func() {
+		_, putErr := s.engine.Put(r.Context(), containerName, object, pr)
+		_ = pr.Close()
+		errCh <- putErr
+	}()
 
-	// Check for errors
-	if assemblyErr != nil {
-		s.logger.Error("assembly failed",
-			zap.Error(assemblyErr),
-			zap.String("bucket", bucket),
-			zap.String("key", object))
-		http.Error(w, "Failed to assemble upload", http.StatusInternalServerError)
-		return
-	}
-
-	if uploadErr != nil {
-		s.logger.Error("storage failed",
+	if uploadErr := <-errCh; uploadErr != nil {
+		s.logger.Error("multipart backend storage failed",
 			zap.Error(uploadErr),
 			zap.String("bucket", bucket),
 			zap.String("key", object))
-		http.Error(w, "Failed to store upload", http.StatusInternalServerError)
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
 	}
 
-	// Generate final ETag
-	finalETag := fmt.Sprintf("\"multipart-%d\"", len(partNumbers))
+	// Mark completed and update head cache
+	etagValue := strings.Trim(finalETag, "\"")
+	if s.db != nil {
+		_, _ = s.db.ExecContext(r.Context(), `
+			UPDATE multipart_uploads SET status = 'completed' WHERE upload_id = $1
+		`, uploadID)
 
-	// Mark as completed
-	upload.mu.Lock()
-	upload.Completed = true
-	upload.CompletedETag = finalETag
-	upload.CompletedAt = time.Now()
-	upload.mu.Unlock()
+		contentType := r.Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		_, dbErr := s.db.ExecContext(r.Context(), `
+			INSERT INTO object_head_cache
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, NOW())
+			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+				size_bytes   = EXCLUDED.size_bytes,
+				etag         = EXCLUDED.etag,
+				content_type = EXCLUDED.content_type,
+				updated_at   = NOW()
+		`, t.ID, bucket, object, totalSize, etagValue, contentType)
+		if dbErr != nil {
+			s.logger.Error("failed to update head cache after multipart complete", zap.Error(dbErr))
+		}
+	} else {
+		memUploadsMu.Lock()
+		if mu, ok := memUploads[uploadID]; ok {
+			mu.Status = "completed"
+		}
+		memUploadsMu.Unlock()
+	}
 
-	// Schedule cleanup
-	go func() {
-		time.Sleep(5 * time.Minute)
-		uploadsMu.Lock()
-		delete(activeUploads, uploadID)
-		uploadsMu.Unlock()
-		s.logger.Debug("cleaned up completed upload", zap.String("uploadID", uploadID))
-	}()
+	// Clean up temp files
+	_ = os.RemoveAll(multipartDir(uploadID))
 
 	s.logger.Info("multipart upload completed",
 		zap.String("bucket", bucket),
 		zap.String("key", object),
 		zap.String("uploadID", uploadID),
 		zap.Int64("totalSize", totalSize),
-		zap.Int("parts", len(partNumbers)),
-		zap.Duration("total_time", time.Since(startTime)))
+		zap.Int("parts", len(parts)),
+		zap.String("etag", finalETag))
 
-	// Return success response
 	location := fmt.Sprintf("http://%s/%s/%s", r.Host, bucket, object)
-	response := CompleteMultipartUploadResult{
+	w.Header().Set("Content-Type", "application/xml")
+	if err := xml.NewEncoder(w).Encode(CompleteMultipartUploadResult{
 		Location: location,
 		Bucket:   bucket,
 		Key:      object,
 		ETag:     finalETag,
-	}
-
-	w.Header().Set("Content-Type", "application/xml")
-	if err := xml.NewEncoder(w).Encode(response); err != nil {
+	}); err != nil {
 		s.logger.Error("failed to encode complete response", zap.Error(err))
-		return
 	}
 }
 
 func (s *Server) handleAbortMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
 	uploadID := r.URL.Query().Get("uploadId")
 
-	// Log the abort operation
-	s.logger.Info("aborting multipart upload",
+	if s.db != nil {
+		result, err := s.db.ExecContext(r.Context(), `
+			UPDATE multipart_uploads SET status = 'aborted'
+			WHERE upload_id = $1 AND tenant_id = $2 AND status = 'active'
+		`, uploadID, t.ID)
+		if err != nil {
+			s.logger.Error("failed to abort multipart upload", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		if rows, _ := result.RowsAffected(); rows == 0 {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.Lock()
+		mu, ok := memUploads[uploadID]
+		if !ok || mu.TenantID != t.ID || mu.Status != "active" {
+			memUploadsMu.Unlock()
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
+		mu.Status = "aborted"
+		memUploadsMu.Unlock()
+	}
+
+	_ = os.RemoveAll(multipartDir(uploadID))
+
+	s.logger.Info("aborted multipart upload",
 		zap.String("bucket", bucket),
 		zap.String("object", object),
 		zap.String("uploadID", uploadID))
-
-	// Clean up the upload session
-	uploadsMu.Lock()
-	delete(activeUploads, uploadID)
-	uploadsMu.Unlock()
 
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleListParts(w http.ResponseWriter, r *http.Request, bucket, object string) {
-	uploadID := r.URL.Query().Get("uploadId")
-
-	uploadsMu.RLock()
-	upload, exists := activeUploads[uploadID]
-	uploadsMu.RUnlock()
-
-	if !exists {
-		http.Error(w, "Upload not found", http.StatusNotFound)
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
 		return
 	}
 
-	// Build parts list
-	upload.mu.Lock()
-	parts := make([]ListPartItem, 0, len(upload.Parts))
-	for _, part := range upload.Parts {
-		parts = append(parts, ListPartItem{
-			PartNumber:   part.PartNumber,
-			ETag:         part.ETag,
-			Size:         part.Size,
-			LastModified: time.Now().Format(time.RFC3339),
-		})
+	uploadID := r.URL.Query().Get("uploadId")
+
+	// Verify upload exists and is active
+	if s.db != nil {
+		var status string
+		err := s.db.QueryRowContext(r.Context(), `
+			SELECT status FROM multipart_uploads
+			WHERE upload_id = $1 AND tenant_id = $2
+		`, uploadID, t.ID).Scan(&status)
+		if err == sql.ErrNoRows || (err == nil && status != "active") {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
+		if err != nil {
+			s.logger.Error("failed to query multipart upload for list parts", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		memUploadsMu.RLock()
+		mu, ok := memUploads[uploadID]
+		memUploadsMu.RUnlock()
+		if !ok || mu.TenantID != t.ID || mu.Status != "active" {
+			WriteS3Error(w, ErrNoSuchUpload, r.URL.Path, generateRequestID())
+			return
+		}
 	}
-	upload.mu.Unlock()
 
-	// Sort by part number
-	sort.Slice(parts, func(i, j int) bool {
-		return parts[i].PartNumber < parts[j].PartNumber
-	})
-
-	response := ListPartsResult{
-		Bucket:   bucket,
-		Key:      object,
-		UploadID: uploadID,
-		Parts:    parts,
+	// Fetch parts
+	var items []ListPartItem
+	if s.db != nil {
+		rows, err := s.db.QueryContext(r.Context(), `
+			SELECT part_number, etag, size_bytes, created_at FROM multipart_parts
+			WHERE upload_id = $1
+			ORDER BY part_number ASC
+		`, uploadID)
+		if err != nil {
+			s.logger.Error("failed to list parts", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var item ListPartItem
+			var createdAt time.Time
+			if err := rows.Scan(&item.PartNumber, &item.ETag, &item.Size, &createdAt); err != nil {
+				continue
+			}
+			item.LastModified = createdAt.UTC().Format(time.RFC3339)
+			items = append(items, item)
+		}
+	} else {
+		memUploadsMu.RLock()
+		mu := memUploads[uploadID]
+		for pn, mp := range mu.Parts {
+			items = append(items, ListPartItem{
+				PartNumber:   pn,
+				ETag:         mp.ETag,
+				Size:         mp.Size,
+				LastModified: time.Now().UTC().Format(time.RFC3339),
+			})
+		}
+		memUploadsMu.RUnlock()
+		sortPartItems(items)
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
-	if err := xml.NewEncoder(w).Encode(response); err != nil {
+	if err := xml.NewEncoder(w).Encode(ListPartsResult{
+		Bucket:   bucket,
+		Key:      object,
+		UploadID: uploadID,
+		Parts:    items,
+	}); err != nil {
 		s.logger.Error("failed to encode list parts response", zap.Error(err))
-		return
 	}
 }
 
-// XML structures for requests and responses
+func (s *Server) handleListMultipartUploads(w http.ResponseWriter, r *http.Request, bucket string) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var uploads []ListMultipartUploadItem
+	if s.db != nil {
+		rows, err := s.db.QueryContext(r.Context(), `
+			SELECT upload_id, object_key, created_at FROM multipart_uploads
+			WHERE tenant_id = $1 AND bucket = $2 AND status = 'active'
+			ORDER BY created_at ASC
+		`, t.ID, bucket)
+		if err != nil {
+			s.logger.Error("failed to list multipart uploads", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var item ListMultipartUploadItem
+			var createdAt time.Time
+			if err := rows.Scan(&item.UploadID, &item.Key, &createdAt); err != nil {
+				continue
+			}
+			item.Initiated = createdAt.UTC().Format(time.RFC3339)
+			uploads = append(uploads, item)
+		}
+	} else {
+		memUploadsMu.RLock()
+		for uid, mu := range memUploads {
+			if mu.TenantID == t.ID && mu.Bucket == bucket && mu.Status == "active" {
+				uploads = append(uploads, ListMultipartUploadItem{
+					UploadID:  uid,
+					Key:       mu.Key,
+					Initiated: mu.Created.UTC().Format(time.RFC3339),
+				})
+			}
+		}
+		memUploadsMu.RUnlock()
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	if err := xml.NewEncoder(w).Encode(ListMultipartUploadsResult{
+		Bucket:  bucket,
+		Uploads: uploads,
+	}); err != nil {
+		s.logger.Error("failed to encode list uploads response", zap.Error(err))
+	}
+}
+
+// sortParts sorts partRecord slices by PartNumber ascending.
+func sortParts(parts []partRecord) {
+	for i := 1; i < len(parts); i++ {
+		for j := i; j > 0 && parts[j].PartNumber < parts[j-1].PartNumber; j-- {
+			parts[j], parts[j-1] = parts[j-1], parts[j]
+		}
+	}
+}
+
+// sortPartItems sorts ListPartItem slices by PartNumber ascending.
+func sortPartItems(items []ListPartItem) {
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && items[j].PartNumber < items[j-1].PartNumber; j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+}
+
+// XML structures for multipart upload requests and responses.
+
 type InitiateMultipartUploadResult struct {
 	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
 	Bucket   string   `xml:"Bucket"`
@@ -455,4 +687,16 @@ type ListPartItem struct {
 	ETag         string `xml:"ETag"`
 	Size         int64  `xml:"Size"`
 	LastModified string `xml:"LastModified"`
+}
+
+type ListMultipartUploadsResult struct {
+	XMLName xml.Name                  `xml:"ListMultipartUploadsResult"`
+	Bucket  string                    `xml:"Bucket"`
+	Uploads []ListMultipartUploadItem `xml:"Upload"`
+}
+
+type ListMultipartUploadItem struct {
+	Key       string `xml:"Key"`
+	UploadID  string `xml:"UploadId"`
+	Initiated string `xml:"Initiated"`
 }

--- a/internal/api/s3_multipart_test.go
+++ b/internal/api/s3_multipart_test.go
@@ -1,0 +1,406 @@
+package api
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newTestMultipartServer creates a test server with local driver for multipart tests.
+func newTestMultipartServer(t *testing.T) (*Server, *tenant.Tenant, string) {
+	t.Helper()
+	logger := zap.NewNop()
+	eng := engine.NewEngine(nil, logger, nil)
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-multipart-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	testTenant := &tenant.Tenant{
+		ID:        "test-tenant",
+		Namespace: "tenant/test-tenant/",
+	}
+
+	// Pre-create the namespaced bucket directory
+	bucketDir := filepath.Join(tempDir, "test-tenant_test-bucket")
+	require.NoError(t, os.MkdirAll(bucketDir, 0755))
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		testMode: true,
+	}
+	srv.router.HandleFunc("/*", srv.handleS3Request)
+
+	// Clean in-memory state between tests
+	memUploadsMu.Lock()
+	memUploads = make(map[string]*memUpload)
+	memUploadsMu.Unlock()
+
+	return srv, testTenant, tempDir
+}
+
+// doS3Request executes an S3 request against the test server with tenant context.
+func doS3Request(srv *Server, t *tenant.Tenant, method, path string, body io.Reader) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, body)
+	ctx := tenant.WithTenant(req.Context(), t)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	srv.handleS3Request(w, req)
+	return w
+}
+
+func TestMultipart_InitiateUpload(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Act
+	w := doS3Request(srv, tnt, "POST", "/test-bucket/large-file.bin?uploads", nil)
+
+	// Assert
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+	assert.Equal(t, "test-bucket", result.Bucket)
+	assert.Equal(t, "large-file.bin", result.Key)
+	assert.NotEmpty(t, result.UploadID)
+	assert.True(t, strings.HasPrefix(result.UploadID, "upload-"))
+}
+
+func TestMultipart_UploadPart_InvalidPartNumber(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	t.Run("zero", func(t *testing.T) {
+		w := doS3Request(srv, tnt, "PUT", "/test-bucket/file?partNumber=0&uploadId=fake", bytes.NewReader([]byte("data")))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		w := doS3Request(srv, tnt, "PUT", "/test-bucket/file?partNumber=10001&uploadId=fake", bytes.NewReader([]byte("data")))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("non-numeric", func(t *testing.T) {
+		w := doS3Request(srv, tnt, "PUT", "/test-bucket/file?partNumber=abc&uploadId=fake", bytes.NewReader([]byte("data")))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestMultipart_UploadPart_NoSuchUpload(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	w := doS3Request(srv, tnt, "PUT", "/test-bucket/file?partNumber=1&uploadId=nonexistent", bytes.NewReader([]byte("data")))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "NoSuchUpload")
+}
+
+func TestMultipart_FullLifecycle(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange: initiate upload
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/assembled.txt?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	// Act: upload 3 parts
+	part1Data := []byte("Hello, ")
+	part2Data := []byte("multipart ")
+	part3Data := []byte("world!")
+
+	part1W := doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/assembled.txt?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader(part1Data))
+	require.Equal(t, http.StatusOK, part1W.Code)
+	etag1 := part1W.Header().Get("ETag")
+	assert.NotEmpty(t, etag1)
+
+	part2W := doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/assembled.txt?uploadId=%s&partNumber=2", uploadID),
+		bytes.NewReader(part2Data))
+	require.Equal(t, http.StatusOK, part2W.Code)
+	etag2 := part2W.Header().Get("ETag")
+
+	part3W := doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/assembled.txt?uploadId=%s&partNumber=3", uploadID),
+		bytes.NewReader(part3Data))
+	require.Equal(t, http.StatusOK, part3W.Code)
+	etag3 := part3W.Header().Get("ETag")
+
+	// Act: list parts
+	listW := doS3Request(srv, tnt, "GET",
+		fmt.Sprintf("/test-bucket/assembled.txt?uploadId=%s", uploadID), nil)
+	require.Equal(t, http.StatusOK, listW.Code)
+
+	var listResult ListPartsResult
+	require.NoError(t, xml.Unmarshal(listW.Body.Bytes(), &listResult))
+	assert.Len(t, listResult.Parts, 3)
+	assert.Equal(t, 1, listResult.Parts[0].PartNumber)
+	assert.Equal(t, 2, listResult.Parts[1].PartNumber)
+	assert.Equal(t, 3, listResult.Parts[2].PartNumber)
+
+	// Act: complete upload with part manifest
+	completeBody := fmt.Sprintf(`<CompleteMultipartUpload>
+		<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
+		<Part><PartNumber>2</PartNumber><ETag>%s</ETag></Part>
+		<Part><PartNumber>3</PartNumber><ETag>%s</ETag></Part>
+	</CompleteMultipartUpload>`, etag1, etag2, etag3)
+
+	completeW := doS3Request(srv, tnt, "POST",
+		fmt.Sprintf("/test-bucket/assembled.txt?uploadId=%s", uploadID),
+		strings.NewReader(completeBody))
+	require.Equal(t, http.StatusOK, completeW.Code)
+
+	var completeResult CompleteMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(completeW.Body.Bytes(), &completeResult))
+	assert.Equal(t, "test-bucket", completeResult.Bucket)
+	assert.Equal(t, "assembled.txt", completeResult.Key)
+	assert.NotEmpty(t, completeResult.ETag)
+	// Multipart ETag format: "hex-N"
+	assert.Contains(t, completeResult.ETag, "-3")
+
+	// Verify: GET the assembled object
+	getW := doS3Request(srv, tnt, "GET", "/test-bucket/assembled.txt", nil)
+	require.Equal(t, http.StatusOK, getW.Code)
+	assert.Equal(t, "Hello, multipart world!", getW.Body.String())
+
+	// Verify: temp files cleaned up
+	_, err := os.Stat(multipartDir(uploadID))
+	assert.True(t, os.IsNotExist(err), "temp dir should be cleaned up after complete")
+}
+
+func TestMultipart_Abort(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange: initiate and upload a part
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/aborted.txt?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/aborted.txt?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("some data")))
+
+	// Act: abort
+	abortW := doS3Request(srv, tnt, "DELETE",
+		fmt.Sprintf("/test-bucket/aborted.txt?uploadId=%s", uploadID), nil)
+	assert.Equal(t, http.StatusNoContent, abortW.Code)
+
+	// Assert: upload part should fail after abort
+	partW := doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/aborted.txt?uploadId=%s&partNumber=2", uploadID),
+		bytes.NewReader([]byte("more data")))
+	assert.Equal(t, http.StatusNotFound, partW.Code)
+	assert.Contains(t, partW.Body.String(), "NoSuchUpload")
+
+	// Assert: temp files cleaned up
+	_, err := os.Stat(multipartDir(uploadID))
+	assert.True(t, os.IsNotExist(err), "temp dir should be cleaned up after abort")
+}
+
+func TestMultipart_Abort_NonexistentUpload(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	w := doS3Request(srv, tnt, "DELETE", "/test-bucket/file?uploadId=does-not-exist", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "NoSuchUpload")
+}
+
+func TestMultipart_Complete_InvalidPartOrder(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/file?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/file?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("part1")))
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/file?uploadId=%s&partNumber=2", uploadID),
+		bytes.NewReader([]byte("part2")))
+
+	// Act: send parts in wrong order
+	completeBody := `<CompleteMultipartUpload>
+		<Part><PartNumber>2</PartNumber><ETag>"x"</ETag></Part>
+		<Part><PartNumber>1</PartNumber><ETag>"y"</ETag></Part>
+	</CompleteMultipartUpload>`
+
+	w := doS3Request(srv, tnt, "POST",
+		fmt.Sprintf("/test-bucket/file?uploadId=%s", uploadID),
+		strings.NewReader(completeBody))
+
+	// Assert
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidPartOrder")
+}
+
+func TestMultipart_Complete_MismatchedETag(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/file?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/file?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("part1")))
+
+	// Act: complete with wrong ETag
+	completeBody := `<CompleteMultipartUpload>
+		<Part><PartNumber>1</PartNumber><ETag>"wrong-etag"</ETag></Part>
+	</CompleteMultipartUpload>`
+
+	w := doS3Request(srv, tnt, "POST",
+		fmt.Sprintf("/test-bucket/file?uploadId=%s", uploadID),
+		strings.NewReader(completeBody))
+
+	// Assert
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidPart")
+}
+
+func TestMultipart_ListMultipartUploads(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange: create two uploads
+	init1 := doS3Request(srv, tnt, "POST", "/test-bucket/file1.bin?uploads", nil)
+	require.Equal(t, http.StatusOK, init1.Code)
+
+	init2 := doS3Request(srv, tnt, "POST", "/test-bucket/file2.bin?uploads", nil)
+	require.Equal(t, http.StatusOK, init2.Code)
+
+	// Act: list uploads for bucket
+	listW := doS3Request(srv, tnt, "GET", "/test-bucket?uploads", nil)
+	require.Equal(t, http.StatusOK, listW.Code)
+
+	var result ListMultipartUploadsResult
+	require.NoError(t, xml.Unmarshal(listW.Body.Bytes(), &result))
+	assert.Equal(t, "test-bucket", result.Bucket)
+	assert.Len(t, result.Uploads, 2)
+}
+
+func TestMultipart_TenantIsolation(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Tenant A initiates upload
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/secret.txt?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	// Tenant B tries to upload a part to tenant A's upload
+	otherTenant := &tenant.Tenant{
+		ID:        "other-tenant",
+		Namespace: "tenant/other-tenant/",
+	}
+
+	partW := doS3Request(srv, otherTenant, "PUT",
+		fmt.Sprintf("/test-bucket/secret.txt?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("evil data")))
+	assert.Equal(t, http.StatusNotFound, partW.Code)
+	assert.Contains(t, partW.Body.String(), "NoSuchUpload")
+}
+
+func TestMultipart_PartOverwrite(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/overwrite.txt?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	// Upload part 1 with initial data
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/overwrite.txt?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("original")))
+
+	// Overwrite part 1 with new data
+	part1W := doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/overwrite.txt?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("updated")))
+	require.Equal(t, http.StatusOK, part1W.Code)
+	etag1 := part1W.Header().Get("ETag")
+
+	// Complete with the overwritten part
+	completeBody := fmt.Sprintf(`<CompleteMultipartUpload>
+		<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
+	</CompleteMultipartUpload>`, etag1)
+
+	completeW := doS3Request(srv, tnt, "POST",
+		fmt.Sprintf("/test-bucket/overwrite.txt?uploadId=%s", uploadID),
+		strings.NewReader(completeBody))
+	require.Equal(t, http.StatusOK, completeW.Code)
+
+	// Verify the object has the updated content
+	getW := doS3Request(srv, tnt, "GET", "/test-bucket/overwrite.txt", nil)
+	require.Equal(t, http.StatusOK, getW.Code)
+	assert.Equal(t, "updated", getW.Body.String())
+}
+
+func TestMultipart_ETag_S3Compatible(t *testing.T) {
+	srv, tnt, _ := newTestMultipartServer(t)
+
+	// Arrange
+	initW := doS3Request(srv, tnt, "POST", "/test-bucket/etag-test.bin?uploads", nil)
+	require.Equal(t, http.StatusOK, initW.Code)
+	var initResult InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+
+	// Upload 2 parts
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/etag-test.bin?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader([]byte("aaaa")))
+	doS3Request(srv, tnt, "PUT",
+		fmt.Sprintf("/test-bucket/etag-test.bin?uploadId=%s&partNumber=2", uploadID),
+		bytes.NewReader([]byte("bbbb")))
+
+	// Complete without explicit part list
+	completeW := doS3Request(srv, tnt, "POST",
+		fmt.Sprintf("/test-bucket/etag-test.bin?uploadId=%s", uploadID),
+		nil)
+	require.Equal(t, http.StatusOK, completeW.Code)
+
+	var result CompleteMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(completeW.Body.Bytes(), &result))
+
+	// S3 multipart ETag format: "hex-N" where N is part count
+	assert.True(t, strings.HasPrefix(result.ETag, "\""), "ETag should start with quote")
+	assert.True(t, strings.HasSuffix(result.ETag, "\""), "ETag should end with quote")
+	assert.Contains(t, result.ETag, "-2", "ETag should contain -2 for 2 parts")
+}

--- a/internal/database/migrations/024_multipart_uploads.sql
+++ b/internal/database/migrations/024_multipart_uploads.sql
@@ -1,0 +1,29 @@
+-- 024_multipart_uploads.sql
+-- Phase 5.10.1: Database-backed multipart upload tracking
+-- Replaces in-memory activeUploads map with persistent storage
+
+CREATE TABLE IF NOT EXISTS multipart_uploads (
+    upload_id   TEXT        NOT NULL,
+    tenant_id   TEXT        NOT NULL,
+    bucket      TEXT        NOT NULL,
+    object_key  TEXT        NOT NULL,
+    status      TEXT        NOT NULL DEFAULT 'active',  -- active, completed, aborted
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (upload_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_multipart_uploads_tenant
+    ON multipart_uploads (tenant_id, bucket, status);
+
+CREATE INDEX IF NOT EXISTS idx_multipart_uploads_cleanup
+    ON multipart_uploads (status, created_at)
+    WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS multipart_parts (
+    upload_id   TEXT    NOT NULL REFERENCES multipart_uploads(upload_id) ON DELETE CASCADE,
+    part_number INT     NOT NULL,
+    etag        TEXT    NOT NULL,
+    size_bytes  BIGINT  NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (upload_id, part_number)
+);


### PR DESCRIPTION
## Summary
- Replace in-memory multipart upload tracking with PostgreSQL-backed state (migration 024: `multipart_uploads` + `multipart_parts` tables)
- Stream part data to temp files instead of holding `[]byte` in RAM — enables uploads >5GB
- Generate S3-compatible multipart ETags (MD5-of-MD5s format, e.g. `"abc123-3"`)
- Add `ListMultipartUploads` endpoint (`GET /{bucket}?uploads`)
- Add proper S3 error codes: `NoSuchUpload`, `InvalidPart`, `InvalidPartOrder`, `EntityTooSmall`, `InvalidPartNumber`
- Enforce tenant isolation on all multipart operations
- Update `object_head_cache` on `CompleteMultipartUpload` so HEAD works for multipart objects

## Test plan
- [x] 12 new tests covering full lifecycle, abort, tenant isolation, part overwrite, ETag format, error cases
- [x] `make lint` — 0 issues
- [x] All existing API tests still pass
- [ ] CI `build-and-test` passes