### PR TITLE
feat(s3): batch DeleteObjects [Phase 5.10.3]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -125,6 +125,12 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 			req.Operation = "DeleteBucket"
 		case "HEAD":
 			req.Operation = "HeadBucket"
+		case "POST":
+			if _, ok := req.Query["delete"]; ok {
+				req.Operation = "DeleteObjects"
+			} else {
+				req.Operation = "Unknown"
+			}
 		default:
 			req.Operation = "Unknown"
 		}
@@ -368,6 +374,8 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		}
 	case "DeleteObject":
 		s.handleDeleteObject(cw, r, s3Req)
+	case "DeleteObjects":
+		s.handleDeleteObjects(cw, r, s3Req)
 	case "ListObjects":
 		s.handleListObjects(cw, r, s3Req)
 	case "ListBuckets":

--- a/internal/api/s3_batch.go
+++ b/internal/api/s3_batch.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+// maxBatchDeleteKeys is the S3 spec limit per DeleteObjects request.
+const maxBatchDeleteKeys = 1000
+
+// maxBatchDeleteBodyBytes caps the request body size to avoid unbounded
+// memory use. 1000 keys × ~1KB per <Object> entry fits comfortably in 2 MiB.
+const maxBatchDeleteBodyBytes = 2 * 1024 * 1024
+
+// DeleteRequest is the inbound XML body for POST /{bucket}?delete.
+type DeleteRequest struct {
+	XMLName xml.Name           `xml:"Delete"`
+	Quiet   bool               `xml:"Quiet"`
+	Objects []DeleteRequestKey `xml:"Object"`
+}
+
+// DeleteRequestKey is a single key entry in a DeleteRequest.
+type DeleteRequestKey struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId,omitempty"`
+}
+
+// DeleteResult is the outbound XML response for DeleteObjects.
+type DeleteResult struct {
+	XMLName xml.Name      `xml:"DeleteResult"`
+	Xmlns   string        `xml:"xmlns,attr"`
+	Deleted []DeletedItem `xml:"Deleted,omitempty"`
+	Errors  []DeleteError `xml:"Error,omitempty"`
+}
+
+// DeletedItem reports a successfully deleted key.
+type DeletedItem struct {
+	Key string `xml:"Key"`
+}
+
+// DeleteError reports a per-key failure within a batch delete.
+type DeleteError struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+// handleDeleteObjects handles POST /{bucket}?delete — the S3 batch delete API.
+//
+// S3 DeleteObjects is idempotent per key: a missing key is reported as
+// "Deleted" (not an error), matching AWS behavior. When <Quiet>true</Quiet>
+// is set, only errors are returned.
+func (s *Server) handleDeleteObjects(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBatchDeleteBodyBytes+1))
+	if err != nil {
+		s.logger.Warn("batch delete: body read failed", zap.Error(err))
+		WriteS3Error(w, ErrIncompleteBody, r.URL.Path, generateRequestID())
+		return
+	}
+	if len(body) > maxBatchDeleteBodyBytes {
+		WriteS3Error(w, ErrEntityTooLarge, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var delReq DeleteRequest
+	if err := xml.Unmarshal(body, &delReq); err != nil {
+		s.logger.Warn("batch delete: malformed XML", zap.Error(err))
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if len(delReq.Objects) == 0 {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+	if len(delReq.Objects) > maxBatchDeleteKeys {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	bucket := req.Bucket
+	container := t.NamespaceContainer(bucket)
+
+	result := DeleteResult{Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/"}
+
+	for _, obj := range delReq.Objects {
+		key := obj.Key
+		if key == "" {
+			if !delReq.Quiet {
+				result.Errors = append(result.Errors, DeleteError{
+					Key:     key,
+					Code:    ErrInvalidRequest,
+					Message: "Key is required",
+				})
+			} else {
+				result.Errors = append(result.Errors, DeleteError{
+					Code:    ErrInvalidRequest,
+					Message: "Key is required",
+				})
+			}
+			continue
+		}
+
+		delErr := s.engine.Delete(r.Context(), container, key)
+		isMissing := delErr != nil && (strings.Contains(delErr.Error(), "no such file or directory") ||
+			strings.Contains(delErr.Error(), "not found"))
+
+		if delErr != nil && !isMissing {
+			s.logger.Error("batch delete: engine delete failed",
+				zap.Error(delErr),
+				zap.String("container", container),
+				zap.String("key", key))
+			result.Errors = append(result.Errors, DeleteError{
+				Key:     key,
+				Code:    ErrInternalError,
+				Message: "Internal error while deleting",
+			})
+			continue
+		}
+
+		// Success (or idempotent miss) — clear head cache and record as Deleted.
+		if s.db != nil {
+			_, _ = s.db.ExecContext(r.Context(), `
+				DELETE FROM object_head_cache
+				WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
+			`, t.ID, bucket, key)
+		}
+
+		if !delReq.Quiet {
+			result.Deleted = append(result.Deleted, DeletedItem{Key: key})
+		}
+	}
+
+	xmlData, err := xml.MarshalIndent(result, "", "  ")
+	if err != nil {
+		s.logger.Error("batch delete: XML marshal failed", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("x-amz-request-id", generateRequestID())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_, _ = w.Write(xmlData)
+
+	s.logger.Info("batch delete",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", bucket),
+		zap.Int("requested", len(delReq.Objects)),
+		zap.Int("deleted", len(result.Deleted)),
+		zap.Int("errors", len(result.Errors)),
+		zap.Bool("quiet", delReq.Quiet))
+}

--- a/internal/api/s3_batch_test.go
+++ b/internal/api/s3_batch_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"bytes"
+	"encoding/xml"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// deleteObjects is a helper that POSTs a batch delete request.
+func deleteObjects(t *testing.T, server *Server, tnt *tenant.Tenant, bucket string, body string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/"+bucket+"?delete", strings.NewReader(body))
+	ctx := tenant.WithTenant(req.Context(), tnt)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	server.handleS3Request(w, req)
+	return w.Code, w.Body.String()
+}
+
+func TestDeleteObjects_MultipleExisting(t *testing.T) {
+	server, tnt, tempDir, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	putObject(t, server, tnt, tempDir, "bucket1", "a.txt", "alpha")
+	putObject(t, server, tnt, tempDir, "bucket1", "b.txt", "beta")
+	putObject(t, server, tnt, tempDir, "bucket1", "c.txt", "gamma")
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<Delete>
+  <Object><Key>a.txt</Key></Object>
+  <Object><Key>b.txt</Key></Object>
+  <Object><Key>c.txt</Key></Object>
+</Delete>`
+
+	code, respBody := deleteObjects(t, server, tnt, "bucket1", body)
+	require.Equal(t, 200, code, "batch delete should succeed: %s", respBody)
+
+	var result DeleteResult
+	require.NoError(t, xml.Unmarshal([]byte(respBody), &result))
+	assert.Len(t, result.Deleted, 3)
+	assert.Empty(t, result.Errors)
+
+	// Verify all three keys are gone.
+	for _, k := range []string{"a.txt", "b.txt", "c.txt"} {
+		code, _ := getObject(t, server, tnt, "bucket1", k)
+		assert.Equal(t, 404, code, "%s should be deleted", k)
+	}
+}
+
+func TestDeleteObjects_MixedExistingAndMissing(t *testing.T) {
+	// S3 DELETE is idempotent — deleting a missing key is not an error.
+	server, tnt, tempDir, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	putObject(t, server, tnt, tempDir, "bucket1", "exists.txt", "hi")
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<Delete>
+  <Object><Key>exists.txt</Key></Object>
+  <Object><Key>missing.txt</Key></Object>
+</Delete>`
+
+	code, respBody := deleteObjects(t, server, tnt, "bucket1", body)
+	require.Equal(t, 200, code)
+
+	var result DeleteResult
+	require.NoError(t, xml.Unmarshal([]byte(respBody), &result))
+	assert.Len(t, result.Deleted, 2, "both keys reported as deleted (idempotent)")
+	assert.Empty(t, result.Errors)
+}
+
+func TestDeleteObjects_QuietMode(t *testing.T) {
+	server, tnt, tempDir, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	putObject(t, server, tnt, tempDir, "bucket1", "q1.txt", "q1")
+	putObject(t, server, tnt, tempDir, "bucket1", "q2.txt", "q2")
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<Delete>
+  <Quiet>true</Quiet>
+  <Object><Key>q1.txt</Key></Object>
+  <Object><Key>q2.txt</Key></Object>
+</Delete>`
+
+	code, respBody := deleteObjects(t, server, tnt, "bucket1", body)
+	require.Equal(t, 200, code)
+
+	var result DeleteResult
+	require.NoError(t, xml.Unmarshal([]byte(respBody), &result))
+	assert.Empty(t, result.Deleted, "quiet mode: no Deleted entries")
+	assert.Empty(t, result.Errors)
+}
+
+func TestDeleteObjects_MalformedXML(t *testing.T) {
+	server, tnt, _, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	code, body := deleteObjects(t, server, tnt, "bucket1", "not xml at all")
+	assert.Equal(t, 400, code)
+	assert.Contains(t, body, "MalformedXML")
+}
+
+func TestDeleteObjects_EmptyObjectList(t *testing.T) {
+	server, tnt, _, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<Delete></Delete>`
+
+	code, respBody := deleteObjects(t, server, tnt, "bucket1", body)
+	assert.Equal(t, 400, code, "empty object list is invalid: %s", respBody)
+	assert.Contains(t, respBody, "MalformedXML")
+}
+
+func TestDeleteObjects_TooManyKeys(t *testing.T) {
+	server, tnt, _, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?><Delete>`)
+	for i := 0; i < 1001; i++ {
+		buf.WriteString("<Object><Key>k</Key></Object>")
+	}
+	buf.WriteString(`</Delete>`)
+
+	code, respBody := deleteObjects(t, server, tnt, "bucket1", buf.String())
+	assert.Equal(t, 400, code, "1001 keys exceeds max: %s", respBody)
+	assert.Contains(t, respBody, "MalformedXML")
+}
+
+func TestDeleteObjects_OperationDetection(t *testing.T) {
+	// Verify the S3 parser classifies POST /{bucket}?delete as DeleteObjects.
+	logger, _ := zap.NewDevelopment()
+	parser := NewS3Parser(logger)
+
+	req := httptest.NewRequest("POST", "/mybucket?delete", nil)
+	s3Req, err := parser.ParseRequest(req)
+	require.NoError(t, err)
+	assert.Equal(t, "DeleteObjects", s3Req.Operation)
+	assert.Equal(t, "mybucket", s3Req.Bucket)
+}


### PR DESCRIPTION
## Summary
- Implements `POST /{bucket}?delete` — the S3 batch delete API used by JuiceFS, `aws s3 rm --recursive`, and rclone sync.
- Accepts up to 1000 keys per request in the standard XML body; returns `DeleteResult` with per-key `Deleted`/`Error` entries; supports Quiet mode.
- Per S3 spec, deletes are idempotent — missing keys are reported as `Deleted` rather than as errors. Body size capped at 2 MiB.

## Test plan
- [x] `go test -race ./internal/api/ -run TestDeleteObjects` — 7 tests pass (multi-delete, mixed existing/missing, quiet mode, malformed XML, empty list, >1000 keys, operation detection)
- [x] `go test -race -short ./internal/api/` — full api suite passes
- [x] `golangci-lint run ./internal/api/...` — 0 issues
- [ ] CI `build-and-test` passes