### PR TITLE
fix(s3): atomic LocalDriver.Put + CopyObject correctness fixes [5.10.2 follow-ups]

### DIFF
--- a/internal/api/s3_copy.go
+++ b/internal/api/s3_copy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -20,11 +21,51 @@ type CopyObjectResult struct {
 	LastModified string   `xml:"LastModified"`
 }
 
+// countingReader wraps an io.Reader and tracks the total bytes read.
+// Used during CopyObject so the destination size can be persisted from the
+// authoritative byte count rather than relying on the source's head_cache row
+// (which can be missing or stale for objects written before the cache existed).
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// resolveCopyContentType picks the content-type for a CopyObject destination.
+//
+// Per S3 spec: when x-amz-metadata-directive is "REPLACE" the request's own
+// Content-Type header wins; when "COPY" (the default) the source object's
+// content-type is preserved. Either way we fall back to
+// application/octet-stream if the chosen source is empty.
+func resolveCopyContentType(directive, requestCT, sourceCT string) string {
+	if strings.EqualFold(directive, "REPLACE") {
+		if requestCT != "" {
+			return requestCT
+		}
+		return "application/octet-stream"
+	}
+	if sourceCT != "" {
+		return sourceCT
+	}
+	return "application/octet-stream"
+}
+
 // handleCopyObject handles S3 CopyObject requests.
 //
-// S3 spec: PUT /dest-bucket/dest-key with x-amz-copy-source header.
-// The source object is streamed through an io.Pipe so the entire object
-// is never buffered in memory. The head cache is updated for the new object.
+// S3 spec: PUT /dest-bucket/dest-key with x-amz-copy-source header. The source
+// is streamed through a TeeReader into the destination — never buffered in
+// memory. The byte count from the wrapping countingReader is used as the
+// authoritative size for the destination's head_cache row.
+//
+// x-amz-metadata-directive selects whether to preserve source metadata
+// (default, "COPY") or take it from the request ("REPLACE"). Self-copy is now
+// handled by the same Get→Put streaming path because LocalDriver.Put is atomic
+// (writes via temp+rename) and no longer truncates the source mid-read.
 func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S3Request) {
 	t, err := tenant.FromContext(r.Context())
 	if err != nil || t == nil {
@@ -32,7 +73,6 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 		return
 	}
 
-	// Parse the x-amz-copy-source header: /bucket/key or bucket/key
 	copySource := r.Header.Get("x-amz-copy-source")
 	srcBucket, srcKey, err := parseCopySource(copySource)
 	if err != nil {
@@ -49,24 +89,16 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 	srcContainer := t.NamespaceContainer(srcBucket)
 	destContainer := t.NamespaceContainer(destBucket)
 
+	directive := r.Header.Get("x-amz-metadata-directive")
+
 	s.logger.Debug("CopyObject",
 		zap.String("tenant_id", t.ID),
 		zap.String("src_bucket", srcBucket),
 		zap.String("src_key", srcKey),
 		zap.String("dest_bucket", destBucket),
 		zap.String("dest_key", destKey),
-		zap.String("src_container", srcContainer),
-		zap.String("dest_container", destContainer))
+		zap.String("directive", directive))
 
-	// Self-copy (same bucket + key) is a metadata-only operation in S3.
-	// With local filesystem backends, Put truncates before Get completes,
-	// so we handle this as a no-op: verify source exists, return its ETag.
-	if srcBucket == destBucket && srcKey == destKey {
-		s.handleSelfCopy(w, r, t, srcBucket, srcKey, srcContainer)
-		return
-	}
-
-	// Read source object.
 	reader, err := s.engine.Get(r.Context(), srcContainer, srcKey)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such file or directory") ||
@@ -83,9 +115,11 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 	}
 	defer func() { _ = reader.Close() }()
 
-	// Stream source through MD5 hasher into destination — no buffering.
+	// Stream source → MD5 hasher → destination, tallying bytes as we go so
+	// the persisted size never depends on the source cache row being present.
+	counter := &countingReader{r: reader}
 	hasher := md5.New() // #nosec G401 — S3 spec requires MD5 for ETags
-	tee := io.TeeReader(reader, hasher)
+	tee := io.TeeReader(counter, hasher)
 
 	backendName, err := s.engine.Put(r.Context(), destContainer, destKey, tee)
 	if err != nil {
@@ -102,19 +136,16 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 
 	// Update object_head_cache for the copied object.
 	if s.db != nil {
-		// Look up source metadata for size and content type.
-		var sizeBytes int64
-		var contentType string
-		err := s.db.QueryRowContext(r.Context(), `
-			SELECT size_bytes, content_type
+		// Look up source content-type (for COPY directive). Size is now
+		// authoritative from counter.n — no fallback path needed.
+		var sourceCT string
+		_ = s.db.QueryRowContext(r.Context(), `
+			SELECT content_type
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-		`, t.ID, srcBucket, srcKey).Scan(&sizeBytes, &contentType)
-		if err != nil {
-			// Fallback: we don't know size/content-type from source cache.
-			sizeBytes = 0
-			contentType = "application/octet-stream"
-		}
+		`, t.ID, srcBucket, srcKey).Scan(&sourceCT)
+
+		contentType := resolveCopyContentType(directive, r.Header.Get("Content-Type"), sourceCT)
 
 		_, dbErr := s.db.ExecContext(r.Context(), `
 			INSERT INTO object_head_cache
@@ -126,7 +157,7 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 				content_type = EXCLUDED.content_type,
 				backend_name = EXCLUDED.backend_name,
 				updated_at   = EXCLUDED.updated_at
-		`, t.ID, destBucket, destKey, sizeBytes, etag, contentType, backendName, now)
+		`, t.ID, destBucket, destKey, counter.n, etag, contentType, backendName, now)
 		if dbErr != nil {
 			s.logger.Error("copy: failed to cache object metadata",
 				zap.Error(dbErr),
@@ -136,7 +167,6 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 		}
 	}
 
-	// Return CopyObjectResult XML.
 	result := CopyObjectResult{
 		ETag:         fmt.Sprintf(`"%s"`, etag),
 		LastModified: now.Format("2006-01-02T15:04:05.000Z"),
@@ -160,73 +190,23 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 		zap.String("src", srcBucket+"/"+srcKey),
 		zap.String("dest", destBucket+"/"+destKey),
 		zap.String("backend", backendName),
-		zap.String("etag", etag))
-}
-
-// handleSelfCopy handles the special case where source and destination are
-// the same object. In S3 this is a metadata-refresh no-op. We verify the
-// source exists and return its existing ETag.
-func (s *Server) handleSelfCopy(w http.ResponseWriter, r *http.Request, t *tenant.Tenant, bucket, key, container string) {
-	// Verify the source object exists by reading and computing ETag.
-	reader, err := s.engine.Get(r.Context(), container, key)
-	if err != nil {
-		if strings.Contains(err.Error(), "no such file or directory") ||
-			strings.Contains(err.Error(), "not found") {
-			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, generateRequestID())
-		} else {
-			s.logger.Error("self-copy: get failed", zap.Error(err))
-			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
-		}
-		return
-	}
-	defer func() { _ = reader.Close() }()
-
-	hasher := md5.New() // #nosec G401 — S3 spec requires MD5 for ETags
-	if _, err := io.Copy(hasher, reader); err != nil {
-		s.logger.Error("self-copy: read failed", zap.Error(err))
-		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
-		return
-	}
-
-	etag := fmt.Sprintf("%x", hasher.Sum(nil))
-	now := time.Now().UTC()
-
-	result := CopyObjectResult{
-		ETag:         fmt.Sprintf(`"%s"`, etag),
-		LastModified: now.Format("2006-01-02T15:04:05.000Z"),
-	}
-
-	xmlData, err := xml.MarshalIndent(result, "", "  ")
-	if err != nil {
-		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/xml")
-	w.Header().Set("x-amz-request-id", generateRequestID())
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(xml.Header))
-	_, _ = w.Write(xmlData)
-
-	s.logger.Info("self-copy (no-op)",
-		zap.String("tenant_id", t.ID),
-		zap.String("bucket", bucket),
-		zap.String("key", key),
+		zap.String("directive", directive),
+		zap.Int64("size", counter.n),
 		zap.String("etag", etag))
 }
 
 // parseCopySource parses the x-amz-copy-source header value.
-// Accepts formats: /bucket/key, bucket/key, /bucket/key?versionId=xxx
-// Returns source bucket and key. URL-encoded keys are not decoded (not yet needed).
+//
+// Accepts: /bucket/key, bucket/key, /bucket/key?versionId=xxx. The key portion
+// is percent-decoded per AWS spec, so x-amz-copy-source: /b/foo%20bar resolves
+// to source key "foo bar" (and %2F resolves to a literal '/' inside the key).
 func parseCopySource(source string) (bucket, key string, err error) {
 	if source == "" {
 		return "", "", fmt.Errorf("empty copy source")
 	}
 
-	// Strip leading slash.
 	source = strings.TrimPrefix(source, "/")
 
-	// Strip query string (e.g. ?versionId=...).
 	if idx := strings.IndexByte(source, '?'); idx >= 0 {
 		source = source[:idx]
 	}
@@ -236,5 +216,10 @@ func parseCopySource(source string) (bucket, key string, err error) {
 		return "", "", fmt.Errorf("invalid copy source format: %q", source)
 	}
 
-	return parts[0], parts[1], nil
+	decodedKey, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("invalid percent-encoding in copy source key: %w", err)
+	}
+
+	return parts[0], decodedKey, nil
 }

--- a/internal/api/s3_copy_test.go
+++ b/internal/api/s3_copy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/drivers"
@@ -313,6 +314,12 @@ func TestParseCopySource(t *testing.T) {
 		{"bucket/key.txt", "bucket", "key.txt", false},
 		{"/bucket/path/to/key.txt", "bucket", "path/to/key.txt", false},
 		{"/bucket/key?versionId=123", "bucket", "key", false},
+		// URL-decoded keys (AWS spec compliance).
+		{"/bucket/foo%20bar", "bucket", "foo bar", false},
+		{"/bucket/with%2Fslash", "bucket", "with/slash", false},
+		{"/bucket/path/sub%20dir/file.txt", "bucket", "path/sub dir/file.txt", false},
+		// Invalid percent-encoding.
+		{"/bucket/bad%ZZ", "", "", true},
 		{"", "", "", true},
 		{"/", "", "", true},
 		{"/bucket", "", "", true},
@@ -332,4 +339,100 @@ func TestParseCopySource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveCopyContentType(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		requestCT string
+		sourceCT  string
+		want      string
+	}{
+		{"COPY preserves source", "COPY", "text/plain", "image/png", "image/png"},
+		{"default (empty) preserves source", "", "text/plain", "image/png", "image/png"},
+		{"COPY falls back when source empty", "COPY", "text/plain", "", "application/octet-stream"},
+		{"REPLACE uses request", "REPLACE", "image/jpeg", "text/plain", "image/jpeg"},
+		{"REPLACE case-insensitive", "replace", "image/jpeg", "text/plain", "image/jpeg"},
+		{"REPLACE falls back when request empty", "REPLACE", "", "text/plain", "application/octet-stream"},
+		{"both empty falls back", "COPY", "", "", "application/octet-stream"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveCopyContentType(tc.directive, tc.requestCT, tc.sourceCT)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCountingReader_TracksBytes(t *testing.T) {
+	src := strings.NewReader("hello world")
+	c := &countingReader{r: src}
+	buf := make([]byte, 4)
+
+	n, err := c.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, int64(4), c.n)
+
+	rest, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, "o world", string(rest))
+	assert.Equal(t, int64(11), c.n, "should match total bytes of source")
+}
+
+// TestCopyObject_SelfCopy_LargeFile guards the regression that motivated
+// the self-copy short-circuit removal: with the atomic LocalDriver.Put,
+// self-copying a multi-MB object via the regular Get→Put streaming path
+// must preserve every byte. (Pre-fix, os.Create truncated the source
+// mid-read, leaving the destination empty.)
+func TestCopyObject_SelfCopy_LargeFile(t *testing.T) {
+	server, tnt, tempDir, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	// 2 MiB of repeating bytes — large enough to ensure streaming, small
+	// enough to keep the test fast.
+	original := strings.Repeat("ABCDEFGH", 256*1024)
+	putObject(t, server, tnt, tempDir, "bucket1", "self.bin", original)
+
+	req := httptest.NewRequest("PUT", "/bucket1/self.bin", nil)
+	req.Header.Set("x-amz-copy-source", "/bucket1/self.bin")
+	ctx := tenant.WithTenant(req.Context(), tnt)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	server.handleS3Request(w, req)
+	require.Equal(t, 200, w.Code, "self-copy must succeed: %s", w.Body.String())
+
+	code, body := getObject(t, server, tnt, "bucket1", "self.bin")
+	require.Equal(t, 200, code)
+	assert.Equal(t, len(original), len(body),
+		"self-copy must preserve exact byte count")
+	assert.Equal(t, original, body)
+}
+
+// TestCopyObject_URLEncodedSourceKey verifies a copy source with
+// percent-encoded characters resolves to the literal key on disk.
+func TestCopyObject_URLEncodedSourceKey(t *testing.T) {
+	server, tnt, tempDir, cleanup := setupCopyTestServer(t)
+	defer cleanup()
+
+	// Write the source object directly so we can use a key that contains
+	// a literal space (HTTP request URLs can't carry one unescaped).
+	bucketPath := filepath.Join(tempDir, tnt.NamespaceContainer("bucket1"))
+	require.NoError(t, os.MkdirAll(bucketPath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(bucketPath, "my file.txt"), []byte("spaced content"), 0644))
+
+	req := httptest.NewRequest("PUT", "/bucket1/dest.txt", nil)
+	req.Header.Set("x-amz-copy-source", "/bucket1/my%20file.txt")
+	ctx := tenant.WithTenant(req.Context(), tnt)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	server.handleS3Request(w, req)
+	require.Equal(t, 200, w.Code, "encoded copy-source must resolve: %s", w.Body.String())
+
+	code, body := getObject(t, server, tnt, "bucket1", "dest.txt")
+	assert.Equal(t, 200, code)
+	assert.Equal(t, "spaced content", body)
 }

--- a/internal/drivers/local.go
+++ b/internal/drivers/local.go
@@ -80,17 +80,18 @@ func (d *LocalDriver) Get(ctx context.Context, container, artifact string) (io.R
 	return os.Open(fullPath)
 }
 
-// Put stores an artifact in a container
+// Put stores an artifact in a container.
+//
+// Writes go to a sibling temp file then atomically rename onto the final
+// path. This preserves the inode of any in-flight reader (an `os.Create`
+// would O_TRUNC the live file and corrupt concurrent reads) and gives
+// crash-safety: the destination either has the old bytes or the new ones,
+// never a half-written tail.
 func (d *LocalDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error {
 	// Apply options (but don't use them yet)
 	var options engine.PutOptions
 	for _, opt := range opts {
 		opt(&options)
-	}
-
-	containerPath := filepath.Join(d.basePath, container)
-	if err := os.MkdirAll(containerPath, 0750); err != nil {
-		return fmt.Errorf("create container: %w", err)
 	}
 
 	fullPath := filepath.Join(d.basePath, container, artifact)
@@ -99,24 +100,7 @@ func (d *LocalDriver) Put(ctx context.Context, container, artifact string, data 
 		return fmt.Errorf("path traversal detected: %s", artifact)
 	}
 
-	parentDir := filepath.Dir(fullPath)
-	if err := os.MkdirAll(parentDir, 0750); err != nil {
-		return fmt.Errorf("create parent directory: %w", err)
-	}
-
-	file, err := os.Create(fullPath)
-	if err != nil {
-		return fmt.Errorf("create file: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	// Copy data
-	_, err = io.Copy(file, data)
-	if err != nil {
-		return fmt.Errorf("write data: %w", err)
-	}
-
-	return nil
+	return d.AtomicWrite(ctx, container, artifact, data)
 }
 
 // Delete removes an artifact from a container

--- a/internal/drivers/local_test.go
+++ b/internal/drivers/local_test.go
@@ -1,10 +1,14 @@
 package drivers
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -28,4 +32,57 @@ func TestLocalDriver_HealthCheck(t *testing.T) {
 		assert.Error(t, err, "Health check should fail for invalid path")
 		assert.Contains(t, err.Error(), "health check failed")
 	})
+}
+
+// TestLocalDriver_Put_AtomicWithConcurrentReader verifies that writing to a key
+// while a reader is mid-stream does not corrupt the in-flight read. Direct
+// os.Create truncates the destination file in-place, which corrupts any open
+// reader against the same inode. The write-to-temp-then-rename pattern keeps
+// the original inode intact for existing FDs.
+func TestLocalDriver_Put_AtomicWithConcurrentReader(t *testing.T) {
+	ctx := context.Background()
+	driver := NewLocalDriver(t.TempDir(), zap.NewNop())
+
+	original := strings.Repeat("ORIGINAL", 1024) // 8 KiB
+	require.NoError(t, driver.Put(ctx, "c", "k", strings.NewReader(original)))
+
+	// Open a reader against the original content but do not consume it yet.
+	reader, err := driver.Get(ctx, "c", "k")
+	require.NoError(t, err)
+	defer func() { _ = reader.Close() }()
+
+	// Overwrite the key with new content while the reader is held open.
+	require.NoError(t, driver.Put(ctx, "c", "k", strings.NewReader("X")))
+
+	// Now drain the reader. With the atomic Put it must still see the
+	// original bytes; with truncate-in-place the read returns 0 bytes.
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got),
+		"reader must see the original content; got %d bytes", len(got))
+
+	// Confirm the new content is what a fresh Get returns.
+	fresh, err := driver.Get(ctx, "c", "k")
+	require.NoError(t, err)
+	defer func() { _ = fresh.Close() }()
+	freshBytes, err := io.ReadAll(fresh)
+	require.NoError(t, err)
+	assert.Equal(t, "X", string(freshBytes))
+}
+
+// TestLocalDriver_Put_OverwritesExisting confirms basic overwrite still works
+// — a regression check for the atomic Put refactor.
+func TestLocalDriver_Put_OverwritesExisting(t *testing.T) {
+	ctx := context.Background()
+	driver := NewLocalDriver(t.TempDir(), zap.NewNop())
+
+	require.NoError(t, driver.Put(ctx, "c", "k", bytes.NewReader([]byte("first"))))
+	require.NoError(t, driver.Put(ctx, "c", "k", bytes.NewReader([]byte("second"))))
+
+	r, err := driver.Get(ctx, "c", "k")
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(got))
 }


### PR DESCRIPTION
## Summary
Resolves 3 of the 5 tradeoffs documented for the initial Phase 5.10.2 CopyObject implementation. Cross-tenant copy and native backend-copy fast-path remain deferred for separate work.

### Changes
- **`LocalDriver.Put`** now delegates to the existing `AtomicWrite` (temp-file + rename). `os.Create` previously truncated the destination file in-place, corrupting any concurrent reader against the same inode. This eliminates the `handleSelfCopy` workaround — self-copy now flows through the regular Get→Put streaming path.
- **`CopyObject` size** is persisted from a streaming `countingReader` instead of the source's `head_cache` row. Prior code silently wrote `size=0` when the source had no cache entry.
- **`parseCopySource`** URL-decodes the key per AWS spec (`url.PathUnescape`). `x-amz-copy-source: /b/foo%20bar` → key `foo bar`.
- **`x-amz-metadata-directive: REPLACE`** is honored — the request's `Content-Type` wins over the source's. Default (`COPY` / unset) still preserves source metadata.

## Test plan
- [x] `go test -race ./internal/api/ -run 'TestCopyObject|TestParseCopySource|TestResolveCopyContentType|TestCountingReader'` — passes
- [x] `go test -race ./internal/drivers/ -run TestLocalDriver_Put` — passes (regression test for atomic Put with concurrent reader)
- [x] `go test -race -short ./internal/api/ ./internal/drivers/` — full suites green
- [x] `golangci-lint run ./internal/api/... ./internal/drivers/...` — 0 issues
- [ ] CI `build-and-test` passes