### PR TITLE
feat(dashboard): bucket settings page [Phase 5.10.5]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -48,6 +48,8 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/dashboard/buckets` | GET | session | Bucket list with counts + sizes |
 | `/dashboard/buckets` | POST | session | Create new bucket (validates name, creates directory) |
 | `/dashboard/buckets/{name}` | GET | session | Object browser with prefix navigation |
+| `/dashboard/buckets/{name}/settings` | GET | session | Bucket settings: visibility, CDN URL, cache, CORS |
+| `/dashboard/buckets/{name}/settings` | POST | session | Update bucket visibility, cache TTL, CORS origins |
 | `/dashboard/apikeys` | GET | session | List API keys with status |
 | `/dashboard/apikeys` | POST | session | Generate new API key (shows secret once) |
 | `/dashboard/apikeys/{id}/revoke` | POST | session | Revoke an API key |

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -23,6 +23,14 @@ Bucket name validation: `^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$` + path traversal c
 
 Shared helpers in `context.go`: `sessionData(sd, page)` builds the base template data map, `formatBytes`, `relativeTime`.
 
+## Bucket Settings (`bucket_settings.go`)
+
+Two handlers:
+- `HandleBucketSettings(tmpl, db, logger)` — GET renders bucket settings page: visibility toggle (private/public-read), CDN URL card with tabbed code examples, cache TTL, CORS origins. Checks `CanEnablePublicRead(tier)` for archive-tier restriction.
+- `HandleUpdateBucketSettings(tmpl, db, logger)` — POST updates visibility, CORS origins, and cache_max_age_secs in `buckets` table. Validates visibility enum, clamps cache to 0–86400, enforces archive-tier restriction via `auth.CanEnablePublicRead()`. Uses flash messages for feedback.
+
+Template: `templates/customer/bucket_settings.html`. Routes: `GET/POST /dashboard/buckets/{name}/settings`.
+
 ## API Key Management (`apikeys.go`)
 
 Three handlers:

--- a/internal/dashboard/handlers/bucket_settings.go
+++ b/internal/dashboard/handlers/bucket_settings.go
@@ -1,0 +1,171 @@
+package handlers
+
+import (
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+const cdnBaseHost = "https://cdn.stored.ge/"
+
+func HandleBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		bucketName := chi.URLParam(r, "name")
+		if bucketName == "" {
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "buckets")
+		withCSRF(r.Context(), data)
+		withFlash(r.Context(), data)
+		data["BucketName"] = bucketName
+
+		vis := "private"
+		corsOrigins := "*"
+		cacheMaxAge := 3600
+		slug := ""
+
+		if db != nil {
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT visibility, cors_origins, cache_max_age_secs
+				 FROM buckets WHERE tenant_id = $1 AND name = $2`,
+				sd.TenantID, bucketName).Scan(&vis, &corsOrigins, &cacheMaxAge)
+
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT COALESCE(slug, '') FROM tenants WHERE id = $1`,
+				sd.TenantID).Scan(&slug)
+
+			var tier string
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT COALESCE(tier, '') FROM tenant_quotas WHERE tenant_id = $1`,
+				sd.TenantID).Scan(&tier)
+
+			allowed, reason := auth.CanEnablePublicRead(tier)
+			if !allowed {
+				data["ArchiveRestricted"] = true
+				data["ArchiveReason"] = reason
+			}
+		}
+
+		data["Visibility"] = vis
+		data["CORSOrigins"] = corsOrigins
+		data["CacheMaxAge"] = cacheMaxAge
+		data["Slug"] = slug
+
+		if vis == "public-read" && slug != "" {
+			data["CDNBaseURL"] = cdnBaseHost + slug + "/" + bucketName
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render bucket settings", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		bucketName := chi.URLParam(r, "name")
+		if bucketName == "" {
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			return
+		}
+
+		visibility := r.FormValue("visibility")
+		if visibility != "private" && visibility != "public-read" {
+			data := sessionData(sd, "buckets")
+			withCSRF(r.Context(), data)
+			data["BucketName"] = bucketName
+			data["Visibility"] = "private"
+			data["CORSOrigins"] = "*"
+			data["CacheMaxAge"] = 3600
+			data["FlashError"] = "Invalid visibility setting."
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_ = tmpl.ExecuteTemplate(w, "base", data)
+			return
+		}
+
+		corsOrigins := strings.TrimSpace(r.FormValue("cors_origins"))
+		if corsOrigins == "" {
+			corsOrigins = "*"
+		}
+
+		cacheMaxAge := 3600
+		if v := r.FormValue("cache_max_age"); v != "" {
+			if parsed, err := strconv.Atoi(v); err == nil {
+				cacheMaxAge = parsed
+			}
+		}
+		if cacheMaxAge < 0 {
+			cacheMaxAge = 0
+		}
+		if cacheMaxAge > 86400 {
+			cacheMaxAge = 86400
+		}
+
+		if db == nil {
+			middleware.SetFlash(w, "error", "Database not available.")
+			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+			return
+		}
+
+		if visibility == "public-read" {
+			var tier string
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT COALESCE(tier, '') FROM tenant_quotas WHERE tenant_id = $1`,
+				sd.TenantID).Scan(&tier)
+
+			allowed, reason := auth.CanEnablePublicRead(tier)
+			if !allowed {
+				middleware.SetFlash(w, "error", reason)
+				http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+				return
+			}
+		}
+
+		result, err := db.ExecContext(r.Context(),
+			`UPDATE buckets
+			 SET visibility = $1, cors_origins = $2, cache_max_age_secs = $3, updated_at = NOW()
+			 WHERE tenant_id = $4 AND name = $5`,
+			visibility, corsOrigins, cacheMaxAge, sd.TenantID, bucketName)
+		if err != nil {
+			logger.Error("update bucket settings", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to save settings.")
+			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+			return
+		}
+
+		rows, _ := result.RowsAffected()
+		if rows == 0 {
+			middleware.SetFlash(w, "error", "Bucket not found.")
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Bucket settings saved.")
+		http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+	}
+}

--- a/internal/dashboard/handlers/bucket_settings_test.go
+++ b/internal/dashboard/handlers/bucket_settings_test.go
@@ -1,0 +1,445 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+func testBucketSettingsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}{{block "nav" .}}{{end}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Settings{{end}}` +
+			`{{define "content"}}` +
+			`<h1>{{.BucketName}} Settings</h1>` +
+			`<span class="vis">{{.Visibility}}</span>` +
+			`{{if .CDNBaseURL}}<span class="cdn">{{.CDNBaseURL}}</span>{{end}}` +
+			`{{if .ArchiveRestricted}}<span class="archive">restricted</span>{{end}}` +
+			`{{if .ArchiveReason}}<span class="reason">{{.ArchiveReason}}</span>{{end}}` +
+			`<span class="cors">{{.CORSOrigins}}</span>` +
+			`<span class="cache">{{.CacheMaxAge}}</span>` +
+			`{{if .FlashSuccess}}<span class="flash-ok">{{.FlashSuccess}}</span>{{end}}` +
+			`{{if .FlashError}}<span class="flash-err">{{.FlashError}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func injectBucketRoute(req *http.Request, name string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", name)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// --- Unit tests (no DB) ---
+
+func TestHandleBucketSettings_NoSession(t *testing.T) {
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets/my-bucket/settings", nil)
+	req = injectBucketRoute(req, "my-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleBucketSettings_NoDB(t *testing.T) {
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, nil, zap.NewNop())
+
+	req := injectSession(httptest.NewRequest("GET", "/dashboard/buckets/my-bucket/settings", nil))
+	req = injectBucketRoute(req, "my-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "my-bucket Settings")
+	assert.Contains(t, body, `<span class="vis">private</span>`)
+}
+
+func TestHandleBucketSettings_EmptyName(t *testing.T) {
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, nil, zap.NewNop())
+
+	req := injectSession(httptest.NewRequest("GET", "/dashboard/buckets//settings", nil))
+	req = injectBucketRoute(req, "")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/buckets", w.Header().Get("Location"))
+}
+
+func TestHandleUpdateBucketSettings_NoSession(t *testing.T) {
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, nil, zap.NewNop())
+
+	form := url.Values{"visibility": {"public-read"}}
+	req := httptest.NewRequest("POST", "/dashboard/buckets/my-bucket/settings",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "my-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleUpdateBucketSettings_InvalidVisibility(t *testing.T) {
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, nil, zap.NewNop())
+
+	form := url.Values{"visibility": {"invalid"}}
+	req := injectSession(httptest.NewRequest("POST", "/dashboard/buckets/my-bucket/settings",
+		strings.NewReader(form.Encode())))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "my-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "flash-err")
+}
+
+// --- Integration tests (DB required) ---
+
+func TestHandleBucketSettings_ReadsFromDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s1', 'Settings Co', 'settings@test.com', 'VK-s1', 'SK-s1', 'settings-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility, cors_origins, cache_max_age_secs)
+		VALUES ('test-dash-s1', 'public-bucket', 'public-read', 'https://example.com', 7200)
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, db, zap.NewNop())
+
+	req := injectSessionWithTenant(
+		httptest.NewRequest("GET", "/dashboard/buckets/public-bucket/settings", nil),
+		"test-dash-s1")
+	req = injectBucketRoute(req, "public-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "public-bucket Settings")
+	assert.Contains(t, body, `<span class="vis">public-read</span>`)
+	assert.Contains(t, body, "cdn.stored.ge/settings-co/public-bucket")
+	assert.Contains(t, body, "https://example.com")
+	assert.Contains(t, body, "7200")
+}
+
+func TestHandleBucketSettings_CDNHiddenForPrivate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s2', 'Private Co', 'private@test.com', 'VK-s2', 'SK-s2', 'private-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s2', 'secret-bucket', 'private')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, db, zap.NewNop())
+
+	req := injectSessionWithTenant(
+		httptest.NewRequest("GET", "/dashboard/buckets/secret-bucket/settings", nil),
+		"test-dash-s2")
+	req = injectBucketRoute(req, "secret-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="vis">private</span>`)
+	assert.NotContains(t, body, "cdn.stored.ge")
+}
+
+func TestHandleUpdateBucketSettings_ToggleToPublic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s3', 'Toggle Co', 'toggle@test.com', 'VK-s3', 'SK-s3', 'toggle-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-s3', 1099511627776, 0, 'starter')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s3', 'toggle-bucket', 'private')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{
+		"visibility":    {"public-read"},
+		"cors_origins":  {"https://mysite.com"},
+		"cache_max_age": {"1800"},
+	}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/toggle-bucket/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-s3")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "toggle-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	var vis, cors string
+	var cache int
+	err = db.QueryRow(`SELECT visibility, cors_origins, cache_max_age_secs
+		FROM buckets WHERE tenant_id = 'test-dash-s3' AND name = 'toggle-bucket'`).
+		Scan(&vis, &cors, &cache)
+	require.NoError(t, err)
+	assert.Equal(t, "public-read", vis)
+	assert.Equal(t, "https://mysite.com", cors)
+	assert.Equal(t, 1800, cache)
+}
+
+func TestHandleUpdateBucketSettings_ArchiveTierBlocked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s4', 'Archive Co', 'archive@test.com', 'VK-s4', 'SK-s4', 'archive-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-s4', 1099511627776, 0, 'vault18')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s4', 'cold-bucket', 'private')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{"visibility": {"public-read"}}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/cold-bucket/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-s4")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "cold-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	// Visibility should NOT have changed.
+	var vis string
+	err = db.QueryRow(`SELECT visibility FROM buckets WHERE tenant_id = 'test-dash-s4' AND name = 'cold-bucket'`).Scan(&vis)
+	require.NoError(t, err)
+	assert.Equal(t, "private", vis)
+}
+
+func TestHandleUpdateBucketSettings_ToggleToPrivate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s5', 'Revoke Co', 'revoke@test.com', 'VK-s5', 'SK-s5', 'revoke-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-s5', 1099511627776, 0, 'starter')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s5', 'was-public', 'public-read')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{"visibility": {"private"}}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/was-public/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-s5")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "was-public")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	var vis string
+	err = db.QueryRow(`SELECT visibility FROM buckets WHERE tenant_id = 'test-dash-s5' AND name = 'was-public'`).Scan(&vis)
+	require.NoError(t, err)
+	assert.Equal(t, "private", vis)
+}
+
+func TestHandleBucketSettings_ArchiveTierShowsRestriction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s6', 'Geyser Co', 'geyser@test.com', 'VK-s6', 'SK-s6', 'geyser-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-s6', 1099511627776, 0, 'geyser')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s6', 'tape-bucket', 'private')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, db, zap.NewNop())
+
+	req := injectSessionWithTenant(
+		httptest.NewRequest("GET", "/dashboard/buckets/tape-bucket/settings", nil),
+		"test-dash-s6")
+	req = injectBucketRoute(req, "tape-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "restricted")
+	assert.Contains(t, body, "archive-tier")
+}
+
+func TestHandleUpdateBucketSettings_CacheMaxAgeClamped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s7', 'Clamp Co', 'clamp@test.com', 'VK-s7', 'SK-s7', 'clamp-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-s7', 1099511627776, 0, 'starter')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ('test-dash-s7', 'clamp-bucket', 'private')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{
+		"visibility":    {"private"},
+		"cache_max_age": {"999999"},
+	}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/clamp-bucket/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-s7")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "clamp-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	var cache int
+	err = db.QueryRow(`SELECT cache_max_age_secs FROM buckets WHERE tenant_id = 'test-dash-s7' AND name = 'clamp-bucket'`).Scan(&cache)
+	require.NoError(t, err)
+	assert.Equal(t, 86400, cache)
+}
+
+func TestHandleUpdateBucketSettings_BucketNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-s8', 'Ghost Co', 'ghost@test.com', 'VK-s8', 'SK-s8', 'ghost-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{"visibility": {"public-read"}}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/nonexistent/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-s8")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "nonexistent")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}

--- a/internal/dashboard/handlers/buckets.go
+++ b/internal/dashboard/handlers/buckets.go
@@ -19,6 +19,7 @@ import (
 // BucketRow is a single bucket for the bucket list template.
 type BucketRow struct {
 	Name            string
+	Visibility      string
 	ObjectCount     int
 	TotalSize       int64
 	LastModified    time.Time
@@ -205,6 +206,7 @@ func renderBucketList(w http.ResponseWriter, tmpl *template.Template, db *sql.DB
 func listBuckets(ctx context.Context, db *sql.DB, tenantID string) []BucketRow {
 	rows, err := db.QueryContext(ctx,
 		`SELECT b.name,
+		        b.visibility,
 		        COALESCE(o.object_count, 0),
 		        COALESCE(o.total_size, 0),
 		        COALESCE(o.last_modified, b.created_at)
@@ -229,7 +231,7 @@ func listBuckets(ctx context.Context, db *sql.DB, tenantID string) []BucketRow {
 	for rows.Next() {
 		var b BucketRow
 		var lastMod time.Time
-		if err := rows.Scan(&b.Name, &b.ObjectCount, &b.TotalSize, &lastMod); err != nil {
+		if err := rows.Scan(&b.Name, &b.Visibility, &b.ObjectCount, &b.TotalSize, &lastMod); err != nil {
 			continue
 		}
 		b.LastModified = lastMod

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -109,9 +109,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		template.Must(bucketObjsTmpl.ParseFS(Templates,
 			"templates/customer/bucket_objects.html",
 		))
+		bucketSettingsTmpl := template.Must(baseTmpl.Clone())
+		template.Must(bucketSettingsTmpl.ParseFS(Templates,
+			"templates/customer/bucket_settings.html",
+		))
 		dr.Get("/buckets", handlers.HandleBuckets(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
 		dr.Post("/buckets", handlers.HandleCreateBucket(bucketsTmpl, deps.DB, deps.DataPath, deps.Logger))
 		dr.Get("/buckets/{name}", handlers.HandleBucketObjects(bucketObjsTmpl, deps.DB, deps.Logger))
+		dr.Get("/buckets/{name}/settings", handlers.HandleBucketSettings(bucketSettingsTmpl, deps.DB, deps.Logger))
+		dr.Post("/buckets/{name}/settings", handlers.HandleUpdateBucketSettings(bucketSettingsTmpl, deps.DB, deps.Logger))
 
 		// API key management.
 		apikeysTmpl := template.Must(baseTmpl.Clone())

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -433,6 +433,58 @@ th {
     margin-bottom: 1rem;
 }
 
+/* Visibility toggle */
+.toggle-group { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+.toggle-label { cursor: pointer; }
+.toggle-label input[type="radio"] { display: none; }
+.toggle-option {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.15s;
+}
+.toggle-option:hover { border-color: var(--primary); }
+.toggle-label input[type="radio"]:checked + .toggle-option,
+.toggle-active { background: var(--primary); color: #fff; border-color: var(--primary); }
+.toggle-disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+
+/* CDN URL card */
+.cdn-card { border-color: var(--success); background: #f0fdf4; }
+.cdn-url-row { display: flex; align-items: center; gap: 0.75rem; margin-top: 0.5rem; }
+.cdn-url {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    background: #1e293b;
+    color: #e2e8f0;
+    border-radius: var(--radius);
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+/* Code tabs */
+.code-tabs { border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+.tab-bar { display: flex; background: var(--bg); border-bottom: 1px solid var(--border); }
+.tab-btn {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-family: var(--font);
+}
+.tab-btn:hover { color: var(--text); }
+.tab-active { color: var(--primary); border-bottom-color: var(--primary); }
+.tab-panel { display: none; }
+.tab-visible { display: block; }
+.tab-panel .code-block { margin: 0; border-radius: 0; }
+
 /* Responsive */
 @media (max-width: 768px) {
     .admin-layout { flex-direction: column; }

--- a/internal/dashboard/templates/customer/bucket_objects.html
+++ b/internal/dashboard/templates/customer/bucket_objects.html
@@ -5,6 +5,7 @@
         <h1>{{.BucketName}}</h1>
         <p class="text-muted">{{.ObjectCount}} object{{if ne .ObjectCount 1}}s{{end}} &middot; {{.TotalSizeFmt}}</p>
     </div>
+    <a href="/dashboard/buckets/{{.BucketName}}/settings" class="btn">Settings</a>
 </div>
 
 <nav class="breadcrumb">

--- a/internal/dashboard/templates/customer/bucket_settings.html
+++ b/internal/dashboard/templates/customer/bucket_settings.html
@@ -1,0 +1,134 @@
+{{define "title"}}{{.BucketName}} Settings — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>{{.BucketName}}</h1>
+        <p class="text-muted">Bucket Settings</p>
+    </div>
+</div>
+
+<nav class="breadcrumb">
+    <a href="/dashboard/">Dashboard</a> /
+    <a href="/dashboard/buckets">Buckets</a> /
+    <a href="/dashboard/buckets/{{.BucketName}}">{{.BucketName}}</a> /
+    <strong>Settings</strong>
+</nav>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+<form method="POST" action="/dashboard/buckets/{{.BucketName}}/settings">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+
+    <div class="card">
+        <div class="card-title">Visibility</div>
+        {{if .ArchiveRestricted}}
+        <div class="alert alert-error" style="margin-top: 0.5rem;">
+            {{.ArchiveReason}}
+        </div>
+        <div class="toggle-group">
+            <label class="toggle-label toggle-disabled">
+                <span class="toggle-switch toggle-off"></span>
+                <span>Private</span>
+            </label>
+        </div>
+        <input type="hidden" name="visibility" value="private">
+        {{else}}
+        <div class="toggle-group">
+            <label class="toggle-label">
+                <input type="radio" name="visibility" value="private" {{if eq .Visibility "private"}}checked{{end}}>
+                <span class="toggle-option{{if eq .Visibility "private"}} toggle-active{{end}}">Private</span>
+            </label>
+            <label class="toggle-label">
+                <input type="radio" name="visibility" value="public-read" {{if eq .Visibility "public-read"}}checked{{end}}>
+                <span class="toggle-option{{if eq .Visibility "public-read"}} toggle-active{{end}}">Public</span>
+            </label>
+        </div>
+        <p class="text-muted" style="margin-top: 0.5rem; font-size: 0.85rem;">
+            Public buckets serve objects without authentication via the CDN.
+        </p>
+        {{end}}
+    </div>
+
+    {{if and (eq .Visibility "public-read") .CDNBaseURL}}
+    <div class="card cdn-card">
+        <div class="card-title">CDN URL</div>
+        <div class="cdn-url-row">
+            <code class="cdn-url">{{.CDNBaseURL}}/</code>
+            <button type="button" class="btn btn-sm" onclick="navigator.clipboard.writeText('{{.CDNBaseURL}}/');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+        </div>
+
+        <div class="code-tabs" style="margin-top: 1rem;">
+            <div class="tab-bar">
+                <button type="button" class="tab-btn tab-active" onclick="showTab(this,'tab-curl')">curl</button>
+                <button type="button" class="tab-btn" onclick="showTab(this,'tab-aws')">AWS CLI</button>
+                <button type="button" class="tab-btn" onclick="showTab(this,'tab-js')">JavaScript</button>
+                <button type="button" class="tab-btn" onclick="showTab(this,'tab-python')">Python</button>
+                <button type="button" class="tab-btn" onclick="showTab(this,'tab-html')">HTML</button>
+            </div>
+            <div id="tab-curl" class="tab-panel tab-visible">
+                <pre class="code-block">curl {{.CDNBaseURL}}/path/to/file.jpg</pre>
+            </div>
+            <div id="tab-aws" class="tab-panel">
+                <pre class="code-block">aws s3 cp s3://{{.BucketName}}/path/to/file.jpg . \
+  --endpoint-url https://stored.ge</pre>
+            </div>
+            <div id="tab-js" class="tab-panel">
+                <pre class="code-block">const url = "{{.CDNBaseURL}}/path/to/file.jpg";
+const res = await fetch(url);
+const blob = await res.blob();</pre>
+            </div>
+            <div id="tab-python" class="tab-panel">
+                <pre class="code-block">import requests
+url = "{{.CDNBaseURL}}/path/to/file.jpg"
+r = requests.get(url)
+with open("file.jpg", "wb") as f:
+    f.write(r.content)</pre>
+            </div>
+            <div id="tab-html" class="tab-panel">
+                <pre class="code-block">&lt;img src="{{.CDNBaseURL}}/photo.jpg" alt="photo"&gt;
+&lt;video src="{{.CDNBaseURL}}/video.mp4" controls&gt;&lt;/video&gt;</pre>
+            </div>
+        </div>
+    </div>
+    {{end}}
+
+    <div class="card">
+        <div class="card-title">Cache Settings</div>
+        <div class="form-group">
+            <label>Cache Max Age (seconds)</label>
+            <input type="number" name="cache_max_age" value="{{.CacheMaxAge}}" min="0" max="86400"
+                   style="max-width: 200px;">
+            <p class="text-muted" style="font-size: 0.8rem; margin-top: 0.25rem;">
+                How long CDN edge servers cache objects (0–86400). Default: 3600 (1 hour).
+            </p>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-title">CORS Origins</div>
+        <div class="form-group">
+            <label>Allowed Origins</label>
+            <input type="text" name="cors_origins" value="{{.CORSOrigins}}"
+                   placeholder="* or https://example.com">
+            <p class="text-muted" style="font-size: 0.8rem; margin-top: 0.25rem;">
+                Use * to allow all origins, or specify domains separated by commas.
+            </p>
+        </div>
+    </div>
+
+    <div class="dashboard-actions">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
+        <a href="/dashboard/buckets/{{.BucketName}}" class="btn">Cancel</a>
+    </div>
+</form>
+
+<script>
+function showTab(btn, id) {
+    btn.closest('.code-tabs').querySelectorAll('.tab-panel').forEach(p => p.classList.remove('tab-visible'));
+    btn.closest('.tab-bar').querySelectorAll('.tab-btn').forEach(b => b.classList.remove('tab-active'));
+    document.getElementById(id).classList.add('tab-visible');
+    btn.classList.add('tab-active');
+}
+</script>
+{{end}}

--- a/internal/dashboard/templates/customer/buckets.html
+++ b/internal/dashboard/templates/customer/buckets.html
@@ -32,6 +32,7 @@
         <thead>
             <tr>
                 <th>Name</th>
+                <th>Visibility</th>
                 <th>Objects</th>
                 <th>Size</th>
                 <th>Last Modified</th>
@@ -42,10 +43,14 @@
             {{range .Buckets}}
             <tr>
                 <td><a href="/dashboard/buckets/{{.Name}}" class="bucket-link">{{.Name}}</a></td>
+                <td>{{if eq .Visibility "public-read"}}<span class="badge badge-success">Public</span>{{else}}<span class="badge badge-default">Private</span>{{end}}</td>
                 <td>{{.ObjectCount}}</td>
                 <td>{{.SizeFmt}}</td>
                 <td>{{.LastModifiedFmt}}</td>
-                <td><a href="/dashboard/buckets/{{.Name}}" class="btn btn-sm">Browse</a></td>
+                <td>
+                    <a href="/dashboard/buckets/{{.Name}}" class="btn btn-sm">Browse</a>
+                    <a href="/dashboard/buckets/{{.Name}}/settings" class="btn btn-sm">Settings</a>
+                </td>
             </tr>
             {{end}}
         </tbody>


### PR DESCRIPTION
## Summary
- **Bucket settings page**: new `/dashboard/buckets/{name}/settings` with GET/POST handlers
- **Visibility toggle**: private/public-read radio buttons, archive-tier restriction enforced via `CanEnablePublicRead(tier)`
- **CDN URL card**: shows `cdn.stored.ge/{slug}/{bucket}/` with copy button + tabbed code examples (curl, AWS CLI, JavaScript, Python, HTML embed) — only visible when bucket is public
- **Cache TTL + CORS**: configurable cache max age (0–86400s) and CORS origins per bucket
- **Bucket list updates**: visibility badge (Public/Private) + Settings link per bucket
- **Bucket objects updates**: Settings button in page header

## Test plan
- [x] Unit tests: no-session redirect, no-DB graceful degradation, empty name redirect, invalid visibility rejection (5 tests)
- [x] Integration tests: reads settings from DB, CDN URL hidden for private, toggle to public, archive-tier blocked, toggle to private, cache max age clamped, bucket not found (8 tests)
- [x] All existing handler tests pass (85 total)
- [x] Zero lint issues
- [ ] CI passes (build-and-test, integration-tests)