### PR TITLE
fix(security): S3 bucket name validation + TLS verification [pre-beta]

### DIFF
--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,6 +13,12 @@ import (
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
 )
+
+var s3BucketNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$`)
+
+func validateBucketName(name string) bool {
+	return s3BucketNameRe.MatchString(name) && !strings.Contains(name, "..")
+}
 
 // ListBucketsResponse for S3 API
 type ListBucketsResponse struct {
@@ -94,6 +101,11 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/")
 	bucket := strings.SplitN(path, "/", 2)[0]
 
+	if !validateBucketName(bucket) {
+		WriteS3Error(w, ErrInvalidBucketName, r.URL.Path, generateRequestID())
+		return
+	}
+
 	// Get tenant from context
 	t, err := tenant.FromContext(ctx)
 	tenantID := "default"
@@ -107,7 +119,7 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 
 	// Create container directory
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
-	if err := os.MkdirAll(dirPath, 0755); err != nil { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		s.logger.Error("Failed to create container", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
@@ -138,6 +150,11 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/")
 	bucket := strings.SplitN(path, "/", 2)[0]
 
+	if !validateBucketName(bucket) {
+		WriteS3Error(w, ErrInvalidBucketName, r.URL.Path, generateRequestID())
+		return
+	}
+
 	// Get tenant from context
 	t, err := tenant.FromContext(ctx)
 	tenantID := "default"
@@ -152,7 +169,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
 
 	// Check if bucket exists
-	if _, err := os.Stat(dirPath); os.IsNotExist(err) { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 		WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
 		return
 	}
@@ -180,7 +197,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Delete the bucket
-	if err := os.RemoveAll(dirPath); err != nil { // #nosec G703 — TODO: add path sanitization to reject ../ in bucket names
+	if err := os.RemoveAll(dirPath); err != nil {
 		s.logger.Error("Failed to delete bucket", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return

--- a/internal/api/s3_buckets_test.go
+++ b/internal/api/s3_buckets_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/tenant"
@@ -148,6 +149,75 @@ func TestListBuckets_ReadsFromDB(t *testing.T) {
 	assert.Len(t, resp.Buckets.Bucket, 2)
 	assert.Equal(t, "alpha-bucket", resp.Buckets.Bucket[0].Name)
 	assert.Equal(t, "beta-bucket", resp.Buckets.Bucket[1].Name)
+}
+
+func TestCreateBucket_InvalidName_Rejected(t *testing.T) {
+	s := &Server{logger: zap.NewNop(), db: nil}
+
+	invalidNames := []string{
+		"../etc",
+		"..",
+		"../../tmp/pwned",
+		"UPPERCASE",
+		"a",
+		"has%20spaces",
+		strings.Repeat("a", 64),
+		"-leading-dash",
+		"trailing-dash-",
+	}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest("PUT", "/"+name, nil)
+			w := httptest.NewRecorder()
+			s.CreateBucket(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "bucket name %q should be rejected", name)
+			assert.Contains(t, w.Body.String(), "InvalidBucketName")
+		})
+	}
+}
+
+func TestDeleteBucket_InvalidName_Rejected(t *testing.T) {
+	s := &Server{logger: zap.NewNop(), db: nil}
+
+	invalidNames := []string{
+		"../etc",
+		"..",
+		"../../tmp/pwned",
+		"UPPERCASE",
+	}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest("DELETE", "/"+name, nil)
+			w := httptest.NewRecorder()
+			s.DeleteBucket(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "bucket name %q should be rejected", name)
+			assert.Contains(t, w.Body.String(), "InvalidBucketName")
+		})
+	}
+}
+
+func TestCreateBucket_ValidNames(t *testing.T) {
+	s := &Server{logger: zap.NewNop(), db: nil}
+
+	validNames := []string{
+		"my-bucket",
+		"data.2026",
+		"abc",
+		"a-b",
+		"my.long.bucket.name.with.dots",
+	}
+
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			defer func() { _ = os.RemoveAll("/tmp/vaultaire/default/" + name) }()
+			req := httptest.NewRequest("PUT", "/"+name, nil)
+			w := httptest.NewRecorder()
+			s.CreateBucket(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, "bucket name %q should be accepted", name)
+		})
+	}
 }
 
 func TestListBuckets_NoDB_FallsBackToFilesystem(t *testing.T) {

--- a/internal/drivers/s3compat.go
+++ b/internal/drivers/s3compat.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path"
+	"strings"
 
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,11 +27,16 @@ type S3CompatDriver struct {
 
 // NewS3CompatDriver creates a new S3-compatible storage driver
 func NewS3CompatDriver(accessKey, secretKey string, logger *zap.Logger) (*S3CompatDriver, error) {
-	// Create HTTP client that allows self-signed certs
+	insecure := strings.EqualFold(os.Getenv("S3COMPAT_INSECURE_TLS"), "true") ||
+		os.Getenv("S3COMPAT_INSECURE_TLS") == "1"
+	if insecure {
+		logger.Warn("S3-compatible TLS verification disabled via S3COMPAT_INSECURE_TLS")
+	}
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402 — TODO: make InsecureSkipVerify configurable per backend instead of hardcoded true
+				InsecureSkipVerify: insecure, // #nosec G402 — operator opt-in for self-signed certs
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- **Path traversal fix**: `CreateBucket` and `DeleteBucket` now validate bucket names via `^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$` + `..` rejection before any filesystem operations. Invalid names return `InvalidBucketName` (400). Removes 3 `#nosec G703 — TODO` annotations.
- **TLS fix**: `S3CompatDriver` no longer hardcodes `InsecureSkipVerify: true`. Now defaults to secure (verify certs); opt-in via `S3COMPAT_INSECURE_TLS=true` env var with warning log. Removes `#nosec G402 — TODO` annotation.

## Test plan
- [x] 18 sub-tests: invalid names rejected (traversal, uppercase, too-short/long, leading/trailing dash), valid names accepted
- [x] All existing S3 bucket tests pass
- [x] Zero lint issues
- [ ] CI passes