### PR TITLE
feat(cdn): public CDN handler for bucket objects [Phase 5.10.6]

### DIFF
--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
+	slug := chi.URLParam(r, "slug")
+	bucket := chi.URLParam(r, "bucket")
+	key := strings.TrimPrefix(chi.URLParam(r, "*"), "/")
+
+	if slug == "" || bucket == "" || key == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	if s.db == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	ctx := r.Context()
+
+	var tenantID string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT id FROM tenants WHERE slug = $1", slug).Scan(&tenantID)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var visibility, corsOrigins string
+	var cacheMaxAgeSecs int
+	err = s.db.QueryRowContext(ctx, `
+		SELECT visibility, cors_origins, cache_max_age_secs
+		FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, bucket).Scan(&visibility, &corsOrigins, &cacheMaxAgeSecs)
+	if err != nil || visibility != "public-read" {
+		http.NotFound(w, r)
+		return
+	}
+
+	if s.cdnRateLimiter != nil && !s.cdnRateLimiter.Allow("cdn:"+slug+":"+bucket) {
+		http.NotFound(w, r)
+		return
+	}
+
+	var sizeBytes int64
+	var etag, contentType string
+	err = s.db.QueryRowContext(ctx, `
+		SELECT size_bytes, etag, content_type
+		FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		tenantID, bucket, key).Scan(&sizeBytes, &etag, &contentType)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", sizeBytes))
+	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, stale-while-revalidate=600", cacheMaxAgeSecs))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Robots-Tag", "noindex, nofollow")
+
+	if corsOrigins != "" {
+		w.Header().Set("Access-Control-Allow-Origin", corsOrigins)
+	}
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	container := fmt.Sprintf("%s_%s", tenantID, bucket)
+	reader, err := s.engine.Get(ctx, container, key)
+	if err != nil {
+		s.logger.Error("cdn engine.Get failed",
+			zap.String("container", container),
+			zap.String("key", key),
+			zap.Error(err))
+		http.NotFound(w, r)
+		return
+	}
+	defer func() { _ = reader.Close() }()
+
+	written, err := io.Copy(w, reader)
+	if err != nil {
+		s.logger.Error("cdn stream failed",
+			zap.String("key", key),
+			zap.Error(err))
+		return
+	}
+
+	if s.bandwidthTracker != nil {
+		s.bandwidthTracker.Record(ctx, tenantID, 0, written)
+	}
+
+	s.logger.Debug("cdn served",
+		zap.String("slug", slug),
+		zap.String("bucket", bucket),
+		zap.String("key", key),
+		zap.Int64("bytes", written))
+}

--- a/internal/api/cdn_middleware.go
+++ b/internal/api/cdn_middleware.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net"
+	"net/http"
+)
+
+// CDNHostRouter routes requests with Host cdn.stored.ge or cdn.stored.cloud
+// to cdnHandler. All other hosts go to the fallback handler (normal router).
+func CDNHostRouter(cdnHandler, fallback http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		switch host {
+		case "cdn.stored.ge", "cdn.stored.cloud":
+			cdnHandler.ServeHTTP(w, r)
+		default:
+			fallback.ServeHTTP(w, r)
+		}
+	})
+}

--- a/internal/api/cdn_test.go
+++ b/internal/api/cdn_test.go
@@ -1,0 +1,397 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+func cdnTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	err = db.Ping()
+	require.NoError(t, err)
+	return db
+}
+
+type cdnTestFixture struct {
+	server   *Server
+	router   chi.Router
+	db       *sql.DB
+	tenantID string
+	slug     string
+	bucket   string
+	key      string
+	content  []byte
+}
+
+func setupCDNFixture(t *testing.T) *cdnTestFixture {
+	t.Helper()
+
+	db := cdnTestDB(t)
+	logger := zap.NewNop()
+
+	// Create temp dir for local storage.
+	tempDir, err := os.MkdirTemp("", "vaultaire-cdn-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := "cdn-test-tenant-" + t.Name()
+	slug := "cdn-test-slug-" + t.Name()
+	bucket := "public-bucket"
+	key := "hello.txt"
+	content := []byte("hello from CDN")
+
+	// Seed tenant with slug.
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key, slug, slug_locked)
+		VALUES ($1, $2, $3, $4, $5, $6, true)
+		ON CONFLICT (id) DO UPDATE SET slug = $6
+	`, tenantID, "CDN Test", "cdn@test.local", "AK-"+tenantID, "SK-"+tenantID, slug)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	// Seed public bucket.
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, cors_origins, cache_max_age_secs)
+		VALUES ($1, $2, 'public-read', 'https://example.com', 7200)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET visibility = 'public-read', cors_origins = 'https://example.com', cache_max_age_secs = 7200
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	// Seed private bucket.
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, $2, 'private')
+		ON CONFLICT (tenant_id, name) DO UPDATE SET visibility = 'private'
+	`, tenantID, "private-bucket")
+	require.NoError(t, err)
+
+	// Seed object in head cache.
+	_, err = db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, tenantID, bucket, key, len(content), "abc123", "text/plain")
+	require.NoError(t, err)
+
+	// Write object to local storage (namespaced: tenantID_bucket/key).
+	container := tenantID + "_" + bucket
+	containerDir := filepath.Join(tempDir, container)
+	require.NoError(t, os.MkdirAll(containerDir, 0755))
+
+	ctx := context.Background()
+	_, err = eng.Put(ctx, container, key, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	rl := NewRateLimiter()
+	bt := NewBandwidthTracker(nil)
+	bt.SetLogger(logger)
+
+	s := &Server{
+		logger:           logger,
+		router:           chi.NewRouter(),
+		db:               db,
+		engine:           eng,
+		bandwidthTracker: bt,
+		cdnRateLimiter:   rl,
+	}
+
+	s.router.Get("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+	s.router.Head("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+
+	return &cdnTestFixture{
+		server:   s,
+		router:   s.router,
+		db:       db,
+		tenantID: tenantID,
+		slug:     slug,
+		bucket:   bucket,
+		key:      key,
+		content:  content,
+	}
+}
+
+func TestCDN_GetPublicObject(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	assert.Equal(t, f.content, body)
+
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	assert.Equal(t, `"abc123"`, w.Header().Get("ETag"))
+	assert.Contains(t, w.Header().Get("Cache-Control"), "public")
+	assert.Contains(t, w.Header().Get("Cache-Control"), "max-age=7200")
+	assert.Contains(t, w.Header().Get("Cache-Control"), "stale-while-revalidate=600")
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "noindex, nofollow", w.Header().Get("X-Robots-Tag"))
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCDN_HeadPublicObject(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("HEAD", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	assert.Equal(t, `"abc123"`, w.Header().Get("ETag"))
+	assert.NotEmpty(t, w.Header().Get("Content-Length"))
+	assert.Contains(t, w.Header().Get("Cache-Control"), "public")
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body, "HEAD must not return a body")
+}
+
+func TestCDN_PrivateBucket_Returns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/private-bucket/secret.txt", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCDN_UnknownSlug_Returns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/nonexistent-slug/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCDN_UnknownBucket_Returns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/no-such-bucket/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCDN_UnknownKey_Returns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/does-not-exist.bin", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCDN_404sAreIndistinguishable(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"unknown slug", "/cdn/no-slug/" + f.bucket + "/" + f.key},
+		{"private bucket", "/cdn/" + f.slug + "/private-bucket/file.txt"},
+		{"unknown bucket", "/cdn/" + f.slug + "/nope/file.txt"},
+		{"unknown key", "/cdn/" + f.slug + "/" + f.bucket + "/missing.bin"},
+	}
+
+	var bodies []string
+	for _, tc := range cases {
+		req := httptest.NewRequest("GET", tc.path, nil)
+		w := httptest.NewRecorder()
+		f.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, tc.name)
+		b, _ := io.ReadAll(w.Body)
+		bodies = append(bodies, string(b))
+	}
+
+	for i := 1; i < len(bodies); i++ {
+		assert.Equal(t, bodies[0], bodies[i],
+			"404 body for %q differs from %q", cases[i].name, cases[0].name)
+	}
+}
+
+func TestCDN_PostReturns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+		req := httptest.NewRequest(method, "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+		w := httptest.NewRecorder()
+		f.router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code, "method %s should be 405", method)
+	}
+}
+
+func TestCDN_BandwidthRecorded(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	bt := NewBandwidthTracker(nil)
+	bt.SetLogger(zap.NewNop())
+	f.server.bandwidthTracker = bt
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	require.NotEmpty(t, bt.buffer, "bandwidth event should be buffered")
+	assert.Equal(t, f.tenantID, bt.buffer[0].tenantID)
+	assert.Equal(t, int64(0), bt.buffer[0].ingress)
+	assert.Equal(t, int64(len(f.content)), bt.buffer[0].egress)
+}
+
+func TestCDN_NestedKeyPath(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	nestedKey := "images/photos/sunset.jpg"
+	content := []byte("fake jpeg data")
+
+	container := f.tenantID + "_" + f.bucket
+	ctx := context.Background()
+	_, err := f.server.engine.Put(ctx, container, nestedKey, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, f.bucket, nestedKey, len(content), "nested123", "image/jpeg")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+nestedKey, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, content, body)
+	assert.Equal(t, "image/jpeg", w.Header().Get("Content-Type"))
+}
+
+// --- CDNHostRouter tests (no DB needed) ---
+
+func TestCDNHostRouter_RoutesToCDN(t *testing.T) {
+	cdnCalled := false
+	cdnHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cdnCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("fallback should not be called for CDN host")
+	})
+
+	handler := CDNHostRouter(cdnHandler, fallback)
+
+	for _, host := range []string{"cdn.stored.ge", "cdn.stored.cloud"} {
+		cdnCalled = false
+		req := httptest.NewRequest("GET", "/test-slug/test-bucket/file.txt", nil)
+		req.Host = host
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.True(t, cdnCalled, "CDN handler should be called for host %s", host)
+	}
+}
+
+func TestCDNHostRouter_FallsBackForOtherHosts(t *testing.T) {
+	cdnHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("CDN handler should not be called for non-CDN host")
+	})
+	fallbackCalled := false
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CDNHostRouter(cdnHandler, fallback)
+
+	for _, host := range []string{"stored.ge", "api.stored.ge", "localhost:8000", ""} {
+		fallbackCalled = false
+		req := httptest.NewRequest("GET", "/some/path", nil)
+		req.Host = host
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.True(t, fallbackCalled, "fallback should be called for host %q", host)
+	}
+}
+
+func TestCDNHostRouter_StripsPort(t *testing.T) {
+	cdnCalled := false
+	cdnHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cdnCalled = true
+	})
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("fallback should not be called")
+	})
+
+	handler := CDNHostRouter(cdnHandler, fallback)
+
+	req := httptest.NewRequest("GET", "/slug/bucket/key", nil)
+	req.Host = "cdn.stored.ge:443"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.True(t, cdnCalled)
+}
+
+func TestCDN_MissingDBReturns404(t *testing.T) {
+	logger := zap.NewNop()
+
+	s := &Server{
+		logger:         logger,
+		router:         chi.NewRouter(),
+		db:             nil,
+		cdnRateLimiter: NewRateLimiter(),
+	}
+	s.router.Get("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+
+	req := httptest.NewRequest("GET", "/cdn/slug/bucket/key.txt", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,7 @@ type Server struct {
 	githubOAuth      *oauth2.Config
 	mfaService       *auth.MFAService
 	mfaPendingStore  *dashboard.MFAPendingStore
+	cdnRateLimiter   *RateLimiter
 	startTime        time.Time
 }
 
@@ -140,6 +141,8 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		}
 	}
 
+	s.cdnRateLimiter = NewRateLimiter()
+
 	// MFA service for TOTP generation and validation.
 	s.mfaService = auth.NewMFAService("stored.ge")
 	s.mfaPendingStore = dashboard.NewMFAPendingStore()
@@ -207,9 +210,14 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 
 	s.setupRoutes()
 
+	// CDN host-based router: cdn.stored.ge → CDN handler, everything else → normal router.
+	cdnRouter := chi.NewRouter()
+	cdnRouter.Get("/{slug}/{bucket}/*", s.handleCDNRequest)
+	cdnRouter.Head("/{slug}/{bucket}/*", s.handleCDNRequest)
+
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
-		Handler:      s.router,
+		Handler:      CDNHostRouter(cdnRouter, s.router),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
@@ -384,6 +392,11 @@ func (s *Server) setupRoutes() {
 
 	// Public status page — no auth, renders HTML.
 	s.router.Get("/status", s.handleStatusPage)
+
+	// CDN path-based routes — before dashboard and S3 catch-all.
+	s.logger.Info("Registering CDN routes")
+	s.router.Get("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+	s.router.Head("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
 
 	// Dashboard routes must be registered BEFORE the S3 catch-all so that
 	// /login, /dashboard/*, /admin/*, and /static/* are matched first.


### PR DESCRIPTION
## Summary
- **CDN handler** (`cdn.go`): unauthenticated GET/HEAD serving of public bucket objects at `/{slug}/{bucket}/{key}`. Slug→tenant lookup, bucket visibility=public-read check, Content-Type from `object_head_cache`, streaming via `engine.Get()`, bandwidth tracking, rate limiting per bucket. All error cases return 404 — no information leakage between bad slug, private bucket, missing bucket, or missing key.
- **Host router** (`cdn_middleware.go`): `CDNHostRouter` routes `cdn.stored.ge` / `cdn.stored.cloud` requests to the CDN handler; everything else falls through to normal router.
- **Route wiring** (`server.go`): path-based `/cdn/{slug}/{bucket}/*` routes + host-based routing via `CDNHostRouter` wrapping the HTTP server handler. CDN routes mounted before dashboard and S3 catch-all.
- **CDN headers**: Content-Type, Content-Length, ETag, Cache-Control (public, max-age from bucket config, stale-while-revalidate=600), Accept-Ranges, X-Content-Type-Options: nosniff, X-Robots-Tag: noindex, CORS from bucket config.

## Test plan
- [x] Unit tests: CDNHostRouter routing (3 tests), missing DB returns 404
- [x] Integration tests: GET/HEAD public object with full header validation, private bucket 404, unknown slug 404, unknown bucket 404, unknown key 404, indistinguishable 404 responses, non-GET methods 405, bandwidth recording, nested key paths
- [x] Zero lint issues
- [ ] CI passes