### PR TITLE
feat(cdn): content-type fix + HTTP range requests [Phase 5.10.7]

### DIFF
--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -91,6 +91,25 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = reader.Close() }()
 
+	rangeHeader := r.Header.Get("Range")
+	if rangeHeader != "" && sizeBytes > 0 {
+		rng, parseErr := parseRangeHeader(rangeHeader, sizeBytes)
+		if parseErr != nil {
+			writeRangeNotSatisfiable(w, sizeBytes)
+			return
+		}
+		if err := serveRange(w, reader, rng, sizeBytes, contentType); err != nil {
+			s.logger.Error("cdn range serve failed",
+				zap.String("key", key),
+				zap.Error(err))
+			return
+		}
+		if s.bandwidthTracker != nil {
+			s.bandwidthTracker.Record(ctx, tenantID, 0, rng.length)
+		}
+		return
+	}
+
 	written, err := io.Copy(w, reader)
 	if err != nil {
 		s.logger.Error("cdn stream failed",

--- a/internal/api/cdn_test.go
+++ b/internal/api/cdn_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -376,6 +377,81 @@ func TestCDNHostRouter_StripsPort(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	assert.True(t, cdnCalled)
+}
+
+func TestCDN_RangeRequest_PartialContent(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Range", "bytes=0-4")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	assert.Equal(t, f.content[:5], body)
+
+	assert.Equal(t, fmt.Sprintf("bytes 0-4/%d", len(f.content)), w.Header().Get("Content-Range"))
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+}
+
+func TestCDN_RangeRequest_MiddleRange(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Range", "bytes=6-8")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	assert.Equal(t, f.content[6:9], body)
+}
+
+func TestCDN_RangeRequest_SuffixRange(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Range", "bytes=-3")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	assert.Equal(t, f.content[len(f.content)-3:], body)
+}
+
+func TestCDN_RangeRequest_Unsatisfiable(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Range", "bytes=9999-10000")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Range"), fmt.Sprintf("bytes */%d", len(f.content)))
+}
+
+func TestCDN_RangeRequest_NoRangeHeaderStillReturns200(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	assert.Equal(t, f.content, body)
 }
 
 func TestCDN_MissingDBReturns404(t *testing.T) {

--- a/internal/api/range.go
+++ b/internal/api/range.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type httpRange struct {
+	start  int64
+	end    int64
+	length int64
+}
+
+func parseRangeHeader(header string, totalSize int64) (*httpRange, error) {
+	if header == "" || !strings.HasPrefix(header, "bytes=") {
+		return nil, fmt.Errorf("invalid range header")
+	}
+
+	spec := strings.TrimPrefix(header, "bytes=")
+
+	if strings.Contains(spec, ",") {
+		return nil, fmt.Errorf("multi-range not supported")
+	}
+
+	parts := strings.SplitN(spec, "-", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid range spec %q", spec)
+	}
+
+	var start, end int64
+
+	if parts[0] == "" {
+		// Suffix range: bytes=-N (last N bytes)
+		suffix, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || suffix <= 0 {
+			return nil, fmt.Errorf("invalid suffix range %q", spec)
+		}
+		start = totalSize - suffix
+		if start < 0 {
+			start = 0
+		}
+		end = totalSize - 1
+	} else {
+		var err error
+		start, err = strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid range start %q", parts[0])
+		}
+
+		if parts[1] == "" {
+			// Open-ended: bytes=N-
+			end = totalSize - 1
+		} else {
+			end, err = strconv.ParseInt(parts[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid range end %q", parts[1])
+			}
+		}
+	}
+
+	if end >= totalSize {
+		end = totalSize - 1
+	}
+
+	if start > end || start >= totalSize {
+		return nil, fmt.Errorf("unsatisfiable range %d-%d/%d", start, end, totalSize)
+	}
+
+	return &httpRange{
+		start:  start,
+		end:    end,
+		length: end - start + 1,
+	}, nil
+}
+
+func serveRange(w http.ResponseWriter, reader io.Reader, rng *httpRange, totalSize int64, contentType string) error {
+	if seeker, ok := reader.(io.ReadSeeker); ok {
+		if _, err := seeker.Seek(rng.start, io.SeekStart); err != nil {
+			return fmt.Errorf("seek to %d: %w", rng.start, err)
+		}
+	} else if rng.start > 0 {
+		if _, err := io.CopyN(io.Discard, reader, rng.start); err != nil {
+			return fmt.Errorf("discard %d prefix bytes: %w", rng.start, err)
+		}
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, totalSize))
+	w.Header().Set("Content-Length", strconv.FormatInt(rng.length, 10))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.WriteHeader(http.StatusPartialContent)
+
+	_, err := io.CopyN(w, reader, rng.length)
+	return err
+}
+
+func writeRangeNotSatisfiable(w http.ResponseWriter, totalSize int64) {
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", totalSize))
+	w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+}

--- a/internal/api/range_test.go
+++ b/internal/api/range_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRangeHeader_Valid(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		totalSize  int64
+		wantStart  int64
+		wantEnd    int64
+		wantLength int64
+	}{
+		{
+			name:       "full range",
+			header:     "bytes=0-99",
+			totalSize:  1000,
+			wantStart:  0,
+			wantEnd:    99,
+			wantLength: 100,
+		},
+		{
+			name:       "middle range",
+			header:     "bytes=100-199",
+			totalSize:  1000,
+			wantStart:  100,
+			wantEnd:    199,
+			wantLength: 100,
+		},
+		{
+			name:       "suffix range",
+			header:     "bytes=-100",
+			totalSize:  1000,
+			wantStart:  900,
+			wantEnd:    999,
+			wantLength: 100,
+		},
+		{
+			name:       "open-ended range",
+			header:     "bytes=500-",
+			totalSize:  1000,
+			wantStart:  500,
+			wantEnd:    999,
+			wantLength: 500,
+		},
+		{
+			name:       "single byte",
+			header:     "bytes=0-0",
+			totalSize:  100,
+			wantStart:  0,
+			wantEnd:    0,
+			wantLength: 1,
+		},
+		{
+			name:       "last byte",
+			header:     "bytes=-1",
+			totalSize:  100,
+			wantStart:  99,
+			wantEnd:    99,
+			wantLength: 1,
+		},
+		{
+			name:       "end clamped to total",
+			header:     "bytes=0-9999",
+			totalSize:  100,
+			wantStart:  0,
+			wantEnd:    99,
+			wantLength: 100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rng, err := parseRangeHeader(tc.header, tc.totalSize)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStart, rng.start)
+			assert.Equal(t, tc.wantEnd, rng.end)
+			assert.Equal(t, tc.wantLength, rng.length)
+		})
+	}
+}
+
+func TestParseRangeHeader_Invalid(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		totalSize int64
+	}{
+		{"empty", "", 100},
+		{"no bytes prefix", "0-99", 100},
+		{"multi-range", "bytes=0-50, 100-150", 1000},
+		{"start after end", "bytes=100-50", 1000},
+		{"start past total", "bytes=1000-2000", 100},
+		{"negative not a suffix", "bytes=-0", 100},
+		{"garbage", "bytes=abc-def", 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRangeHeader(tc.header, tc.totalSize)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestServeRange_WithSeeker(t *testing.T) {
+	content := []byte("Hello, World! This is range test content.")
+	reader := bytes.NewReader(content)
+
+	rng := &httpRange{start: 7, end: 11, length: 5}
+
+	w := httptest.NewRecorder()
+	err := serveRange(w, reader, rng, int64(len(content)), "text/plain")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 7-11/41", w.Header().Get("Content-Range"))
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "World", string(body))
+}
+
+func TestServeRange_WithNonSeeker(t *testing.T) {
+	content := []byte("Hello, World! This is range test content.")
+	reader := io.NopCloser(strings.NewReader(string(content)))
+
+	rng := &httpRange{start: 7, end: 11, length: 5}
+
+	w := httptest.NewRecorder()
+	err := serveRange(w, reader, rng, int64(len(content)), "application/octet-stream")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 7-11/41", w.Header().Get("Content-Range"))
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "World", string(body))
+}
+
+func TestServeRange_EntireFile(t *testing.T) {
+	content := []byte("ABCDE")
+	reader := bytes.NewReader(content)
+
+	rng := &httpRange{start: 0, end: 4, length: 5}
+
+	w := httptest.NewRecorder()
+	err := serveRange(w, reader, rng, 5, "text/plain")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 0-4/5", w.Header().Get("Content-Range"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "ABCDE", string(body))
+}
+
+func TestWriteRangeNotSatisfiable(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeRangeNotSatisfiable(w, 500)
+
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+	assert.Equal(t, "bytes */500", w.Header().Get("Content-Range"))
+}

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -126,12 +126,6 @@ func isAWSChunked(r *http.Request) bool {
 
 // HandleGet processes S3 GET requests using the engine
 func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, object string) {
-	rangeHeader := r.Header.Get("Range")
-	if rangeHeader != "" {
-		a.logger.Debug("Range request ignored (not yet implemented)",
-			zap.String("range", rangeHeader))
-	}
-
 	t, err := tenant.FromContext(r.Context())
 	if err != nil {
 		a.logger.Warn("no tenant in context", zap.Error(err))
@@ -147,6 +141,25 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.String("original_bucket", bucket),
 		zap.String("namespaced_container", container),
 		zap.String("artifact", artifact))
+
+	var cachedContentType string
+	var cachedSize int64
+	var cacheHit bool
+	if a.db != nil {
+		err := a.db.QueryRowContext(r.Context(), `
+			SELECT content_type, size_bytes
+			FROM object_head_cache
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize)
+		if err == nil {
+			cacheHit = true
+		}
+	}
+
+	contentType := cachedContentType
+	if contentType == "" {
+		contentType = a.detectContentType(artifact)
+	}
 
 	reader, err := a.engine.Get(r.Context(), container, artifact)
 	if err != nil {
@@ -164,11 +177,31 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 	defer func() { _ = reader.Close() }()
 
-	contentType := a.detectContentType(artifact)
+	rangeHeader := r.Header.Get("Range")
+	if rangeHeader != "" && cacheHit && cachedSize > 0 {
+		rng, parseErr := parseRangeHeader(rangeHeader, cachedSize)
+		if parseErr != nil {
+			writeRangeNotSatisfiable(w, cachedSize)
+			return
+		}
+		w.Header().Set("x-amz-request-id", generateRequestID())
+		w.Header().Set("x-amz-version-id", "null")
+		if err := serveRange(w, reader, rng, cachedSize, contentType); err != nil {
+			a.logger.Error("range serve failed",
+				zap.Error(err),
+				zap.String("container", container),
+				zap.String("artifact", artifact))
+		}
+		return
+	}
+
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("x-amz-request-id", generateRequestID())
 	w.Header().Set("x-amz-version-id", "null")
 	w.Header().Set("Accept-Ranges", "bytes")
+	if cacheHit && cachedSize > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
+	}
 
 	written, err := io.Copy(w, reader)
 	if err != nil {

--- a/internal/api/s3_engine_adapter_test.go
+++ b/internal/api/s3_engine_adapter_test.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type adapterTestFixture struct {
+	adapter  *S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	tenantID string
+	tenant   *tenant.Tenant
+	tempDir  string
+}
+
+func setupAdapterFixture(t *testing.T) *adapterTestFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-adapter-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := "adapter-test-" + t.Name()
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Adapter Test", "adapter@test.local", "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tn.NamespaceContainer("test-bucket")
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	return &adapterTestFixture{
+		adapter:  NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		tenantID: tenantID,
+		tenant:   tn,
+		tempDir:  tempDir,
+	}
+}
+
+func TestHandleGet_ContentTypeFromCache(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("fake video content for testing")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "video.mp4", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "video.mp4", len(content), "abc123", "video/mp4")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/video.mp4", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "video.mp4")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "video/mp4", w.Header().Get("Content-Type"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, content, body)
+}
+
+func TestHandleGet_ContentTypeFallsBackToExtension(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("some json data")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "data.json", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/data.json", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "data.json")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+func TestHandleGet_RangeRequest(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "alphabet.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "alphabet.txt", len(content), "alpha123", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/alphabet.txt", nil)
+	req.Header.Set("Range", "bytes=0-4")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "alphabet.txt")
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 0-4/26", w.Header().Get("Content-Range"))
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "ABCDE", string(body))
+}
+
+func TestHandleGet_RangeRequest_Unsatisfiable(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("short")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "small.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "small.txt", len(content), "small123", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/small.txt", nil)
+	req.Header.Set("Range", "bytes=100-200")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "small.txt")
+
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+}
+
+func TestHandleGet_RangeIgnoredWithoutCache(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("no cache content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "nocache.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/nocache.txt", nil)
+	req.Header.Set("Range", "bytes=0-4")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "nocache.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code, "without cache, range is ignored and full content returned")
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, content, body)
+}
+
+func TestHandleGet_ContentLengthSetFromCache(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("content with known size")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "sized.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "sized.txt", len(content), "sized123", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/sized.txt", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "sized.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "23", w.Header().Get("Content-Length"))
+}


### PR DESCRIPTION
## Summary
- **Content-Type bug fix**: `HandleGet` now queries `object_head_cache` for the stored `content_type` from the original PUT instead of using extension-based `detectContentType()` (~12 MIME types). Falls back to extension detection when no cache hit or no DB.
- **Range requests** (`internal/api/range.go`): Parse `Range: bytes=start-end` header, return 206 Partial Content with proper `Content-Range` header. Single range only. Uses `io.ReadSeeker.Seek()` when available, read-and-discard prefix bytes otherwise.
- **S3 GetObject**: Serves 206 for valid ranges, 416 Range Not Satisfiable for invalid, gracefully ignores Range when no cache. Also now sets `Content-Length` from cache on normal 200 responses.
- **CDN handler**: Range support wired in — critical for browser video seeking (`.mp4`/`.webm` files won't play without range request support).

## Files changed (3 modified, 3 new)
- `internal/api/s3_engine_adapter.go` — Content-Type from cache, range request handling in HandleGet
- `internal/api/cdn.go` — Range request handling in CDN handler
- `internal/api/range.go` (new) — `parseRangeHeader()`, `serveRange()`, `writeRangeNotSatisfiable()` shared helpers
- `internal/api/range_test.go` (new) — 15 unit tests for range parsing + serving
- `internal/api/s3_engine_adapter_test.go` (new) — 6 integration tests for content-type fix + range requests
- `internal/api/cdn_test.go` — 5 new CDN range integration tests

## Test plan
- [x] 15 unit tests: valid range parse (7 cases), invalid range parse (7 cases), serve with seeker, serve without seeker, serve entire file, 416 response
- [x] 6 S3 integration tests: content-type from cache, extension fallback, range 206, range 416, range without cache (graceful), Content-Length from cache
- [x] 5 CDN integration tests: partial content, middle range, suffix range, unsatisfiable range, no-range-header still 200
- [x] All existing tests pass (`go test ./internal/api/... -short`)
- [x] Zero lint issues (`golangci-lint run ./...`)
- [x] All pre-commit hooks pass (go fmt, go test, golangci-lint)