### PR TITLE
feat(s3): conditional requests + cache headers [Phase 5.10.8]

### DIFF
--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
@@ -53,23 +54,37 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 
 	var sizeBytes int64
 	var etag, contentType string
+	var updatedAt time.Time
 	err = s.db.QueryRowContext(ctx, `
-		SELECT size_bytes, etag, content_type
+		SELECT size_bytes, etag, content_type, updated_at
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-		tenantID, bucket, key).Scan(&sizeBytes, &etag, &contentType)
+		tenantID, bucket, key).Scan(&sizeBytes, &etag, &contentType, &updatedAt)
 	if err != nil {
 		http.NotFound(w, r)
+		return
+	}
+
+	cacheControl := fmt.Sprintf("public, max-age=%d, stale-while-revalidate=600", cacheMaxAgeSecs)
+
+	if code := evaluateConditionalGET(r, etag, updatedAt); code == http.StatusNotModified {
+		writeNotModified(w, etag, updatedAt, cacheControl)
+		return
+	} else if code == http.StatusPreconditionFailed {
+		w.WriteHeader(http.StatusPreconditionFailed)
 		return
 	}
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", sizeBytes))
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
-	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, stale-while-revalidate=600", cacheMaxAgeSecs))
+	w.Header().Set("Cache-Control", cacheControl)
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Robots-Tag", "noindex, nofollow")
+	if !updatedAt.IsZero() {
+		w.Header().Set("Last-Modified", updatedAt.UTC().Format(http.TimeFormat))
+	}
 
 	if corsOrigins != "" {
 		w.Header().Set("Access-Control-Allow-Origin", corsOrigins)

--- a/internal/api/conditional.go
+++ b/internal/api/conditional.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func normalizeETag(etag string) string {
+	etag = strings.TrimPrefix(etag, "W/")
+	etag = strings.Trim(etag, `"`)
+	return etag
+}
+
+func etagsMatch(a, b string) bool {
+	na, nb := normalizeETag(a), normalizeETag(b)
+	return na != "" && na == nb
+}
+
+func checkIfNoneMatch(r *http.Request, currentETag string) bool {
+	inm := r.Header.Get("If-None-Match")
+	if inm == "" {
+		return false
+	}
+	if inm == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(inm, ",") {
+		if etagsMatch(strings.TrimSpace(candidate), currentETag) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkIfModifiedSince(r *http.Request, lastModified time.Time) bool {
+	ims := r.Header.Get("If-Modified-Since")
+	if ims == "" {
+		return false
+	}
+	t, err := http.ParseTime(ims)
+	if err != nil {
+		return false
+	}
+	return !lastModified.Truncate(time.Second).After(t.Truncate(time.Second))
+}
+
+func checkIfUnmodifiedSince(r *http.Request, lastModified time.Time) bool {
+	ius := r.Header.Get("If-Unmodified-Since")
+	if ius == "" {
+		return false
+	}
+	t, err := http.ParseTime(ius)
+	if err != nil {
+		return false
+	}
+	return lastModified.Truncate(time.Second).After(t.Truncate(time.Second))
+}
+
+func checkIfMatch(r *http.Request, currentETag string) bool {
+	im := r.Header.Get("If-Match")
+	if im == "" {
+		return false
+	}
+	if im == "*" {
+		return false
+	}
+	for _, candidate := range strings.Split(im, ",") {
+		if etagsMatch(strings.TrimSpace(candidate), currentETag) {
+			return false
+		}
+	}
+	return true
+}
+
+// evaluateConditionalGET checks conditional headers per RFC 9110 §13.2.2.
+// Returns 304, 412, or 0 (proceed normally).
+func evaluateConditionalGET(r *http.Request, etag string, lastModified time.Time) int {
+	if checkIfUnmodifiedSince(r, lastModified) {
+		return http.StatusPreconditionFailed
+	}
+	if checkIfNoneMatch(r, etag) {
+		return http.StatusNotModified
+	}
+	if r.Header.Get("If-None-Match") == "" && checkIfModifiedSince(r, lastModified) {
+		return http.StatusNotModified
+	}
+	return 0
+}
+
+func writeNotModified(w http.ResponseWriter, etag string, lastModified time.Time, cacheControl string) {
+	if etag != "" {
+		w.Header().Set("ETag", fmt.Sprintf(`"%s"`, normalizeETag(etag)))
+	}
+	if !lastModified.IsZero() {
+		w.Header().Set("Last-Modified", lastModified.UTC().Format(http.TimeFormat))
+	}
+	if cacheControl != "" {
+		w.Header().Set("Cache-Control", cacheControl)
+	}
+	w.WriteHeader(http.StatusNotModified)
+}

--- a/internal/api/conditional_test.go
+++ b/internal/api/conditional_test.go
@@ -1,0 +1,579 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+)
+
+// --- Unit tests for conditional helpers ---
+
+func TestNormalizeETag(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"abc123"`, "abc123"},
+		{`abc123`, "abc123"},
+		{`W/"abc123"`, "abc123"},
+		{`W/"abc"`, "abc"},
+		{`""`, ""},
+		{``, ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, normalizeETag(tt.input), "normalizeETag(%q)", tt.input)
+	}
+}
+
+func TestEtagsMatch(t *testing.T) {
+	tests := []struct {
+		a, b  string
+		match bool
+	}{
+		{`"abc"`, `"abc"`, true},
+		{`"abc"`, `abc`, true},
+		{`W/"abc"`, `"abc"`, true},
+		{`W/"abc"`, `abc`, true},
+		{`"abc"`, `"def"`, false},
+		{`""`, `""`, false},
+		{``, ``, false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.match, etagsMatch(tt.a, tt.b), "etagsMatch(%q, %q)", tt.a, tt.b)
+	}
+}
+
+func TestCheckIfNoneMatch(t *testing.T) {
+	t.Run("matching etag returns true", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"abc123"`)
+		assert.True(t, checkIfNoneMatch(req, "abc123"))
+	})
+
+	t.Run("non-matching etag returns false", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"abc123"`)
+		assert.False(t, checkIfNoneMatch(req, "def456"))
+	})
+
+	t.Run("wildcard returns true", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", "*")
+		assert.True(t, checkIfNoneMatch(req, "anything"))
+	})
+
+	t.Run("multiple etags with match", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"aaa", "bbb", "ccc"`)
+		assert.True(t, checkIfNoneMatch(req, "bbb"))
+	})
+
+	t.Run("multiple etags without match", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"aaa", "bbb"`)
+		assert.False(t, checkIfNoneMatch(req, "ccc"))
+	})
+
+	t.Run("weak etag matches", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `W/"abc123"`)
+		assert.True(t, checkIfNoneMatch(req, "abc123"))
+	})
+
+	t.Run("no header returns false", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		assert.False(t, checkIfNoneMatch(req, "abc123"))
+	})
+}
+
+func TestCheckIfModifiedSince(t *testing.T) {
+	ref := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("not modified when same time", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Modified-Since", ref.Format(http.TimeFormat))
+		assert.True(t, checkIfModifiedSince(req, ref))
+	})
+
+	t.Run("not modified when older", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Modified-Since", ref.Format(http.TimeFormat))
+		assert.True(t, checkIfModifiedSince(req, ref.Add(-time.Hour)))
+	})
+
+	t.Run("modified when newer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Modified-Since", ref.Format(http.TimeFormat))
+		assert.False(t, checkIfModifiedSince(req, ref.Add(time.Hour)))
+	})
+
+	t.Run("invalid date returns false", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Modified-Since", "garbage")
+		assert.False(t, checkIfModifiedSince(req, ref))
+	})
+
+	t.Run("no header returns false", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		assert.False(t, checkIfModifiedSince(req, ref))
+	})
+}
+
+func TestCheckIfUnmodifiedSince(t *testing.T) {
+	ref := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("unmodified when same time", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Unmodified-Since", ref.Format(http.TimeFormat))
+		assert.False(t, checkIfUnmodifiedSince(req, ref))
+	})
+
+	t.Run("unmodified when older", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Unmodified-Since", ref.Format(http.TimeFormat))
+		assert.False(t, checkIfUnmodifiedSince(req, ref.Add(-time.Hour)))
+	})
+
+	t.Run("modified returns true (412)", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Unmodified-Since", ref.Format(http.TimeFormat))
+		assert.True(t, checkIfUnmodifiedSince(req, ref.Add(time.Hour)))
+	})
+}
+
+func TestCheckIfMatch(t *testing.T) {
+	t.Run("matching etag — precondition passes", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("If-Match", `"abc123"`)
+		assert.False(t, checkIfMatch(req, "abc123"))
+	})
+
+	t.Run("non-matching etag — precondition fails", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("If-Match", `"abc123"`)
+		assert.True(t, checkIfMatch(req, "def456"))
+	})
+
+	t.Run("wildcard — precondition passes", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("If-Match", "*")
+		assert.False(t, checkIfMatch(req, "anything"))
+	})
+
+	t.Run("no header — precondition passes", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		assert.False(t, checkIfMatch(req, "abc"))
+	})
+
+	t.Run("multiple etags with match", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("If-Match", `"aaa", "bbb"`)
+		assert.False(t, checkIfMatch(req, "bbb"))
+	})
+
+	t.Run("multiple etags without match", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("If-Match", `"aaa", "bbb"`)
+		assert.True(t, checkIfMatch(req, "ccc"))
+	})
+}
+
+func TestEvaluateConditionalGET(t *testing.T) {
+	ref := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("304 on If-None-Match match", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"abc123"`)
+		assert.Equal(t, http.StatusNotModified, evaluateConditionalGET(req, "abc123", ref))
+	})
+
+	t.Run("304 on If-Modified-Since not modified", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Modified-Since", ref.Format(http.TimeFormat))
+		assert.Equal(t, http.StatusNotModified, evaluateConditionalGET(req, "abc", ref.Add(-time.Hour)))
+	})
+
+	t.Run("If-Modified-Since ignored when If-None-Match present", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"no-match"`)
+		req.Header.Set("If-Modified-Since", ref.Format(http.TimeFormat))
+		assert.Equal(t, 0, evaluateConditionalGET(req, "abc", ref.Add(-time.Hour)))
+	})
+
+	t.Run("412 on If-Unmodified-Since when modified", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Unmodified-Since", ref.Format(http.TimeFormat))
+		assert.Equal(t, http.StatusPreconditionFailed, evaluateConditionalGET(req, "abc", ref.Add(time.Hour)))
+	})
+
+	t.Run("412 takes priority over 304", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-Unmodified-Since", ref.Format(http.TimeFormat))
+		req.Header.Set("If-None-Match", `"abc"`)
+		assert.Equal(t, http.StatusPreconditionFailed, evaluateConditionalGET(req, "abc", ref.Add(time.Hour)))
+	})
+
+	t.Run("0 when no conditional headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		assert.Equal(t, 0, evaluateConditionalGET(req, "abc", ref))
+	})
+
+	t.Run("0 when conditions pass", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("If-None-Match", `"old-etag"`)
+		assert.Equal(t, 0, evaluateConditionalGET(req, "new-etag", ref))
+	})
+}
+
+func TestWriteNotModified(t *testing.T) {
+	ref := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	w := httptest.NewRecorder()
+
+	writeNotModified(w, "abc123", ref, "public, max-age=3600")
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, `"abc123"`, w.Header().Get("ETag"))
+	assert.Equal(t, ref.UTC().Format(http.TimeFormat), w.Header().Get("Last-Modified"))
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body, "304 must not include a body")
+}
+
+// --- Integration tests for S3 GET conditional requests ---
+
+func TestHandleGet_IfNoneMatch_304(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("conditional content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "cond.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "cond.txt", len(content), "cond999", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/cond.txt", nil)
+	req.Header.Set("If-None-Match", `"cond999"`)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "cond.txt")
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, `"cond999"`, w.Header().Get("ETag"))
+	assert.NotEmpty(t, w.Header().Get("Last-Modified"))
+	assert.Equal(t, "private, no-cache", w.Header().Get("Cache-Control"))
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body)
+}
+
+func TestHandleGet_IfNoneMatch_NoMatch_Returns200(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("fresh content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "fresh.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "fresh.txt", len(content), "fresh999", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/fresh.txt", nil)
+	req.Header.Set("If-None-Match", `"old-etag"`)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "fresh.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, content, body)
+}
+
+func TestHandleGet_ETagAndLastModifiedOnResponse(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("header test content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "headers.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "headers.txt", len(content), "hdr123", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/headers.txt", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "headers.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, `"hdr123"`, w.Header().Get("ETag"))
+	assert.NotEmpty(t, w.Header().Get("Last-Modified"))
+	assert.Equal(t, "private, no-cache", w.Header().Get("Cache-Control"))
+}
+
+func TestHandlePut_IfMatch_412(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("original content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "locked.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "locked.txt", len(content), "orig111", "text/plain")
+	require.NoError(t, err)
+
+	newContent := []byte("updated content")
+	req := httptest.NewRequest("PUT", "/test-bucket/locked.txt", bytes.NewReader(newContent))
+	req.Header.Set("If-Match", `"wrong-etag"`)
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "locked.txt")
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestHandlePut_IfMatch_MatchingETag_Succeeds(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("original content")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "update.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "update.txt", len(content), "match111", "text/plain")
+	require.NoError(t, err)
+
+	newContent := []byte("updated content")
+	req := httptest.NewRequest("PUT", "/test-bucket/update.txt", bytes.NewReader(newContent))
+	req.Header.Set("If-Match", `"match111"`)
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "update.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotEmpty(t, w.Header().Get("ETag"))
+}
+
+// --- Integration tests for CDN conditional requests ---
+
+func TestCDN_IfNoneMatch_304(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("If-None-Match", `"abc123"`)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, `"abc123"`, w.Header().Get("ETag"))
+	assert.NotEmpty(t, w.Header().Get("Last-Modified"))
+	assert.Contains(t, w.Header().Get("Cache-Control"), "public")
+
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body, "304 must not include a body")
+}
+
+func TestCDN_IfNoneMatch_NoMatch_Returns200(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("If-None-Match", `"stale-etag"`)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, f.content, body)
+}
+
+func TestCDN_IfModifiedSince_304(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	var updatedAt time.Time
+	err := f.db.QueryRow(`
+		SELECT updated_at FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
+	`, f.tenantID, f.bucket, f.key).Scan(&updatedAt)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("If-Modified-Since", updatedAt.Add(time.Hour).UTC().Format(http.TimeFormat))
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body)
+}
+
+func TestCDN_IfModifiedSince_Modified_Returns200(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("If-Modified-Since", "Mon, 01 Jan 2020 00:00:00 GMT")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, f.content, body)
+}
+
+func TestCDN_LastModifiedHeader(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	lm := w.Header().Get("Last-Modified")
+	assert.NotEmpty(t, lm, "CDN response should include Last-Modified")
+
+	parsed, err := http.ParseTime(lm)
+	require.NoError(t, err)
+	assert.False(t, parsed.IsZero())
+}
+
+// --- HeadObject tests ---
+
+func TestHeadObject_LastModifiedFromCache(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	f := setupAdapterFixture(t)
+
+	_, err := f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6, updated_at = $7
+	`, f.tenantID, "test-bucket", "dated.txt", 100, "date111", "text/plain",
+		time.Date(2026, 4, 15, 10, 30, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("HEAD", "/test-bucket/dated.txt", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s := &Server{
+		db:     f.db,
+		logger: f.adapter.logger,
+	}
+
+	w := httptest.NewRecorder()
+	s3req := &S3Request{Bucket: "test-bucket", Object: "dated.txt"}
+	s.handleHeadObject(w, req, s3req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	lm := w.Header().Get("Last-Modified")
+	require.NotEmpty(t, lm)
+	parsed, err := http.ParseTime(lm)
+	require.NoError(t, err)
+	assert.Equal(t, 2026, parsed.Year())
+	assert.Equal(t, time.April, parsed.Month())
+	assert.Equal(t, 15, parsed.Day())
+}
+
+func TestHandleGet_S3CacheControlHeader(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	content := []byte("cache control test")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "cc.txt", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, "test-bucket", "cc.txt", len(content), "cc123", "text/plain")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/test-bucket/cc.txt", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, "test-bucket", "cc.txt")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "private, no-cache", w.Header().Get("Cache-Control"))
+}
+
+func TestCDN_HeadObject_ConditionalRequest(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("HEAD", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("If-None-Match", `"abc123"`)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Empty(t, body)
+}
+
+func TestCDN_IfUnmodifiedSince_412(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/cdn/%s/%s/%s", f.slug, f.bucket, f.key), nil)
+	req.Header.Set("If-Unmodified-Since", "Mon, 01 Jan 2020 00:00:00 GMT")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -439,12 +439,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 
 	var sizeBytes int64
 	var etag, contentType string
+	var updatedAt time.Time
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type
+		SELECT size_bytes, etag, content_type, updated_at
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -469,7 +470,11 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	}
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
-	w.Header().Set("Last-Modified", time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT"))
+	if !updatedAt.IsZero() {
+		w.Header().Set("Last-Modified", updatedAt.UTC().Format(http.TimeFormat))
+	} else {
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	}
 	w.Header().Set("x-amz-storage-class", "STANDARD")
 	w.Header().Set("x-amz-request-id", generateRequestID())
 	// HEAD must not write a body.

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -144,15 +144,27 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 
 	var cachedContentType string
 	var cachedSize int64
+	var cachedETag string
+	var cachedUpdatedAt time.Time
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes
+			SELECT content_type, size_bytes, etag, updated_at
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt)
 		if err == nil {
 			cacheHit = true
+		}
+	}
+
+	if cacheHit {
+		if code := evaluateConditionalGET(r, cachedETag, cachedUpdatedAt); code == http.StatusNotModified {
+			writeNotModified(w, cachedETag, cachedUpdatedAt, "private, no-cache")
+			return
+		} else if code == http.StatusPreconditionFailed {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
 		}
 	}
 
@@ -199,8 +211,17 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	w.Header().Set("x-amz-request-id", generateRequestID())
 	w.Header().Set("x-amz-version-id", "null")
 	w.Header().Set("Accept-Ranges", "bytes")
-	if cacheHit && cachedSize > 0 {
-		w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
+	w.Header().Set("Cache-Control", "private, no-cache")
+	if cacheHit {
+		if cachedSize > 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
+		}
+		if cachedETag != "" {
+			w.Header().Set("ETag", fmt.Sprintf(`"%s"`, cachedETag))
+		}
+		if !cachedUpdatedAt.IsZero() {
+			w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
+		}
 	}
 
 	written, err := io.Copy(w, reader)
@@ -283,6 +304,18 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 	if size < 0 {
 		size = 0
+	}
+
+	if r.Header.Get("If-Match") != "" && a.db != nil {
+		var currentETag string
+		err := a.db.QueryRowContext(r.Context(), `
+			SELECT etag FROM object_head_cache
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, bucket, artifact).Scan(&currentETag)
+		if err == nil && checkIfMatch(r, currentETag) {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
 	}
 
 	chunked := isAWSChunked(r)


### PR DESCRIPTION
## Summary
- **Conditional requests** (`internal/api/conditional.go`): RFC 9110-compliant If-None-Match (304), If-Modified-Since (304), If-Unmodified-Since (412), If-Match on PUT (412 optimistic concurrency). Handles quoted/weak/wildcard ETags, multiple comma-separated values.
- **S3 GET headers fixed**: ETag, Last-Modified, and `Cache-Control: private, no-cache` now set on all GET 200 responses (previously only on HEAD).
- **HEAD Last-Modified bug fix**: `handleHeadObject` now uses `updated_at` from `object_head_cache` instead of `time.Now()`.
- **CDN conditional requests**: Returns 304 with headers (ETag, Last-Modified, Cache-Control) but no body. Adds `Last-Modified` to normal 200 responses.
- **Performance**: All conditional checks run BEFORE `engine.Get()` — avoids backend data fetch when returning 304/412.
- **JuiceFS compatibility**: If-None-Match support enables JuiceFS metadata consistency checks.

## Test plan
- [x] 27 unit tests: ETag normalization, If-None-Match, If-Modified-Since, If-Unmodified-Since, If-Match, evaluateConditionalGET, writeNotModified
- [x] 14 integration tests: S3 GET 304/200, PUT If-Match 412/200, CDN 304/200/If-Modified-Since/Last-Modified/HEAD/If-Unmodified-Since, HEAD Last-Modified from cache, S3 Cache-Control
- [x] All existing tests pass
- [x] Zero lint issues
- [x] Pre-commit hooks pass (fmt, test, golangci-lint)