### PR TITLE
feat(cdn): CORS configuration for public bucket content [Phase 5.10.9]

### DIFF
--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -47,6 +47,11 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Method == http.MethodOptions {
+		handleCDNPreflight(w, r, corsOrigins)
+		return
+	}
+
 	if s.cdnRateLimiter != nil && !s.cdnRateLimiter.Allow("cdn:"+slug+":"+bucket) {
 		http.NotFound(w, r)
 		return
@@ -86,9 +91,7 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Last-Modified", updatedAt.UTC().Format(http.TimeFormat))
 	}
 
-	if corsOrigins != "" {
-		w.Header().Set("Access-Control-Allow-Origin", corsOrigins)
-	}
+	setCORSHeaders(w, r, corsOrigins)
 
 	if r.Method == http.MethodHead {
 		return

--- a/internal/api/cdn_test.go
+++ b/internal/api/cdn_test.go
@@ -131,6 +131,7 @@ func setupCDNFixture(t *testing.T) *cdnTestFixture {
 
 	s.router.Get("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
 	s.router.Head("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+	s.router.Options("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
 
 	return &cdnTestFixture{
 		server:   s,
@@ -165,7 +166,8 @@ func TestCDN_GetPublicObject(t *testing.T) {
 	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
 	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, "noindex, nofollow", w.Header().Get("X-Robots-Tag"))
-	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"),
+		"CORS headers should not be set without an Origin request header")
 }
 
 func TestCDN_HeadPublicObject(t *testing.T) {
@@ -452,6 +454,92 @@ func TestCDN_RangeRequest_NoRangeHeaderStillReturns200(t *testing.T) {
 	body, err := io.ReadAll(w.Body)
 	require.NoError(t, err)
 	assert.Equal(t, f.content, body)
+}
+
+func TestCDN_CORS_PreflightReturnsHeaders(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("OPTIONS", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, HEAD, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Contains(t, w.Header().Get("Access-Control-Expose-Headers"), "ETag")
+	assert.Contains(t, w.Header().Get("Access-Control-Expose-Headers"), "Content-Range")
+	assert.Equal(t, "86400", w.Header().Get("Access-Control-Max-Age"))
+	assert.Equal(t, "0", w.Header().Get("Content-Length"))
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+func TestCDN_CORS_GetIncludesHeaders(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, HEAD, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Contains(t, w.Header().Get("Access-Control-Expose-Headers"), "Content-Length")
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+func TestCDN_CORS_NoOriginHeaderNoCORS(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCDN_CORS_DisallowedOriginNoCORS(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Origin", "https://evil.com")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCDN_CORS_PrivateBucketPreflightReturns404(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	req := httptest.NewRequest("OPTIONS", "/cdn/"+f.slug+"/private-bucket/file.txt", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCDN_CORS_WildcardOrigins(t *testing.T) {
+	f := setupCDNFixture(t)
+
+	_, err := f.db.Exec(`
+		UPDATE buckets SET cors_origins = '*'
+		WHERE tenant_id = $1 AND name = $2`, f.tenantID, f.bucket)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+f.key, nil)
+	req.Header.Set("Origin", "https://any-site.com")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, w.Header().Get("Vary"), "wildcard should not set Vary: Origin")
 }
 
 func TestCDN_MissingDBReturns404(t *testing.T) {

--- a/internal/api/cors.go
+++ b/internal/api/cors.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	cdnAllowMethods  = "GET, HEAD, OPTIONS"
+	cdnExposeHeaders = "ETag, Content-Length, Content-Range, Content-Type, Last-Modified, Accept-Ranges"
+	cdnMaxAge        = "86400"
+)
+
+func setCORSHeaders(w http.ResponseWriter, r *http.Request, allowedOrigins string) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return
+	}
+
+	matched := matchOrigin(origin, allowedOrigins)
+	if matched == "" {
+		return
+	}
+
+	w.Header().Set("Access-Control-Allow-Origin", matched)
+	w.Header().Set("Access-Control-Allow-Methods", cdnAllowMethods)
+	w.Header().Set("Access-Control-Expose-Headers", cdnExposeHeaders)
+	w.Header().Set("Access-Control-Max-Age", cdnMaxAge)
+	if matched != "*" {
+		w.Header().Add("Vary", "Origin")
+	}
+}
+
+func handleCDNPreflight(w http.ResponseWriter, r *http.Request, allowedOrigins string) {
+	setCORSHeaders(w, r, allowedOrigins)
+	w.Header().Set("Content-Length", "0")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func matchOrigin(origin, allowedOrigins string) string {
+	if allowedOrigins == "" || origin == "" {
+		return ""
+	}
+	if allowedOrigins == "*" {
+		return "*"
+	}
+	for _, allowed := range strings.Split(allowedOrigins, ",") {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "*" {
+			return "*"
+		}
+		if strings.EqualFold(origin, allowed) {
+			return origin
+		}
+	}
+	return ""
+}

--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchOrigin_Wildcard(t *testing.T) {
+	assert.Equal(t, "*", matchOrigin("https://example.com", "*"))
+}
+
+func TestMatchOrigin_ExactMatch(t *testing.T) {
+	assert.Equal(t, "https://example.com", matchOrigin("https://example.com", "https://example.com"))
+}
+
+func TestMatchOrigin_CaseInsensitive(t *testing.T) {
+	assert.Equal(t, "https://Example.COM", matchOrigin("https://Example.COM", "https://example.com"))
+}
+
+func TestMatchOrigin_CommaSeparated(t *testing.T) {
+	origins := "https://foo.com, https://bar.com, https://baz.com"
+	assert.Equal(t, "https://bar.com", matchOrigin("https://bar.com", origins))
+	assert.Equal(t, "https://baz.com", matchOrigin("https://baz.com", origins))
+}
+
+func TestMatchOrigin_NoMatch(t *testing.T) {
+	assert.Equal(t, "", matchOrigin("https://evil.com", "https://example.com"))
+}
+
+func TestMatchOrigin_EmptyOrigin(t *testing.T) {
+	assert.Equal(t, "", matchOrigin("", "https://example.com"))
+}
+
+func TestMatchOrigin_EmptyAllowed(t *testing.T) {
+	assert.Equal(t, "", matchOrigin("https://example.com", ""))
+}
+
+func TestMatchOrigin_WildcardInList(t *testing.T) {
+	assert.Equal(t, "*", matchOrigin("https://anything.com", "https://specific.com, *"))
+}
+
+func TestSetCORSHeaders_WithOrigin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	setCORSHeaders(w, req, "https://example.com")
+
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, cdnAllowMethods, w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, cdnExposeHeaders, w.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, cdnMaxAge, w.Header().Get("Access-Control-Max-Age"))
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+func TestSetCORSHeaders_Wildcard(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	setCORSHeaders(w, req, "*")
+
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, w.Header().Get("Vary"), "wildcard should not set Vary: Origin")
+}
+
+func TestSetCORSHeaders_NoOriginHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	setCORSHeaders(w, req, "https://example.com")
+
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestSetCORSHeaders_OriginNotAllowed(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	w := httptest.NewRecorder()
+
+	setCORSHeaders(w, req, "https://example.com")
+
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestHandleCDNPreflight(t *testing.T) {
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	handleCDNPreflight(w, req, "https://example.com")
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "0", w.Header().Get("Content-Length"))
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, cdnAllowMethods, w.Header().Get("Access-Control-Allow-Methods"))
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,7 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	cdnRouter := chi.NewRouter()
 	cdnRouter.Get("/{slug}/{bucket}/*", s.handleCDNRequest)
 	cdnRouter.Head("/{slug}/{bucket}/*", s.handleCDNRequest)
+	cdnRouter.Options("/{slug}/{bucket}/*", s.handleCDNRequest)
 
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
@@ -397,6 +398,7 @@ func (s *Server) setupRoutes() {
 	s.logger.Info("Registering CDN routes")
 	s.router.Get("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
 	s.router.Head("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
+	s.router.Options("/cdn/{slug}/{bucket}/*", s.handleCDNRequest)
 
 	// Dashboard routes must be registered BEFORE the S3 catch-all so that
 	// /login, /dashboard/*, /admin/*, and /static/* are matched first.

--- a/internal/devops/domain.go
+++ b/internal/devops/domain.go
@@ -95,6 +95,7 @@ var DefaultDomainConfigs = map[string]*DomainConfig{
 			"https://www.stored.ge",
 			"https://api.stored.ge",
 			"https://dashboard.stored.ge",
+			"https://cdn.stored.ge",
 		},
 		RedirectWWW: true,
 		ForceHTTPS:  true,


### PR DESCRIPTION
## Summary
- Add shared CORS helper (`internal/api/cors.go`) with origin matching against per-bucket `cors_origins` config from the `buckets` table
- CDN handler returns proper `Access-Control-Allow-Origin`, `Allow-Methods`, `Expose-Headers`, `Max-Age` on GET/HEAD responses when `Origin` header is present
- Handle OPTIONS preflight requests on CDN paths — validates slug + public bucket visibility before responding (private/unknown → 404, no info leakage)
- Add `https://cdn.stored.ge` to production `AllowedOrigins` in `domain.go`
- `Vary: Origin` set for non-wildcard origins (correct caching behavior)

## Files changed
| File | Change |
|------|--------|
| `internal/api/cors.go` | **New** — `setCORSHeaders`, `handleCDNPreflight`, `matchOrigin` |
| `internal/api/cors_test.go` | **New** — 13 unit tests for origin matching + header setting |
| `internal/api/cdn.go` | Replace inline CORS with helper, add OPTIONS handling |
| `internal/api/cdn_test.go` | 7 new integration tests (preflight, GET CORS, disallowed origin, wildcard, private bucket OPTIONS) |
| `internal/api/server.go` | Register OPTIONS route for CDN paths (both path-based and host-based) |
| `internal/devops/domain.go` | Add `cdn.stored.ge` to production AllowedOrigins |

## Test plan
- [x] `matchOrigin` handles wildcard, exact match, comma-separated, case-insensitive, no-match, empty inputs
- [x] `setCORSHeaders` sets all headers with Origin, skips without Origin, skips for disallowed origin
- [x] `handleCDNPreflight` returns 204 with correct CORS headers
- [x] CDN OPTIONS preflight on public bucket returns 204 + full CORS headers
- [x] CDN GET with Origin includes CORS headers in response
- [x] CDN GET without Origin header omits CORS headers
- [x] Disallowed origin gets no CORS headers (content still served — CORS is browser-enforced)
- [x] Private bucket OPTIONS returns 404 with no CORS headers
- [x] Wildcard `cors_origins = '*'` returns `Access-Control-Allow-Origin: *` without `Vary: Origin`
- [x] All existing CDN tests pass (range, conditional, bandwidth, etc.)