### PR TITLE
feat(s3): ListObjectsV2 pagination with continuation tokens [Phase 5.10.10]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -504,7 +504,7 @@ func (s *Server) handleDeleteObject(w http.ResponseWriter, r *http.Request, req 
 // handleListObjects handles bucket listing
 func (s *Server) handleListObjects(w http.ResponseWriter, r *http.Request, req *S3Request) {
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
-	adapter.HandleList(w, r, req.Bucket, "")
+	adapter.HandleListV2(w, r, req.Bucket)
 }
 
 // handleListBuckets handles listing all buckets

--- a/internal/api/s3_list.go
+++ b/internal/api/s3_list.go
@@ -1,0 +1,358 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const defaultMaxKeys = 1000
+
+// ListObjectsV2Params holds parsed S3 ListObjectsV2 query parameters.
+type ListObjectsV2Params struct {
+	Bucket            string
+	Prefix            string
+	Delimiter         string
+	MaxKeys           int
+	ContinuationToken string
+	StartAfter        string
+	EncodingType      string
+}
+
+// ListBucketV2Result is the XML response for ListObjectsV2.
+type ListBucketV2Result struct {
+	XMLName               xml.Name            `xml:"ListBucketResult"`
+	Xmlns                 string              `xml:"xmlns,attr"`
+	Name                  string              `xml:"Name"`
+	Prefix                string              `xml:"Prefix"`
+	Delimiter             string              `xml:"Delimiter,omitempty"`
+	MaxKeys               int                 `xml:"MaxKeys"`
+	KeyCount              int                 `xml:"KeyCount"`
+	IsTruncated           bool                `xml:"IsTruncated"`
+	Contents              []ListV2Entry       `xml:"Contents,omitempty"`
+	CommonPrefixes        []CommonPrefixEntry `xml:"CommonPrefixes,omitempty"`
+	ContinuationToken     string              `xml:"ContinuationToken,omitempty"`
+	NextContinuationToken string              `xml:"NextContinuationToken,omitempty"`
+	StartAfter            string              `xml:"StartAfter,omitempty"`
+	EncodingType          string              `xml:"EncodingType,omitempty"`
+}
+
+// ListV2Entry represents a single object in the list response.
+type ListV2Entry struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+// CommonPrefixEntry represents a grouped prefix when delimiter is used.
+type CommonPrefixEntry struct {
+	Prefix string `xml:"Prefix"`
+}
+
+func encodeContinuationToken(key string) string {
+	return base64.URLEncoding.EncodeToString([]byte(key))
+}
+
+func decodeContinuationToken(token string) (string, error) {
+	data, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return "", fmt.Errorf("decode continuation token: %w", err)
+	}
+	return string(data), nil
+}
+
+func parseListV2Params(r *http.Request, bucket string) ListObjectsV2Params {
+	q := r.URL.Query()
+	params := ListObjectsV2Params{
+		Bucket:            bucket,
+		Prefix:            q.Get("prefix"),
+		Delimiter:         q.Get("delimiter"),
+		MaxKeys:           defaultMaxKeys,
+		ContinuationToken: q.Get("continuation-token"),
+		StartAfter:        q.Get("start-after"),
+		EncodingType:      q.Get("encoding-type"),
+	}
+
+	if params.ContinuationToken == "" && params.StartAfter == "" {
+		if marker := q.Get("marker"); marker != "" {
+			params.StartAfter = marker
+		}
+	}
+
+	if mk := q.Get("max-keys"); mk != "" {
+		if v, err := strconv.Atoi(mk); err == nil && v >= 0 {
+			if v > 1000 {
+				v = 1000
+			}
+			params.MaxKeys = v
+		}
+	}
+
+	return params
+}
+
+// HandleListV2 processes S3 ListObjectsV2 requests with pagination,
+// prefix, delimiter, continuation-token, and start-after support.
+func (a *S3ToEngine) HandleListV2(w http.ResponseWriter, r *http.Request, bucket string) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil {
+		a.logger.Warn("no tenant in context", zap.Error(err))
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	params := parseListV2Params(r, bucket)
+
+	cursor := ""
+	if params.ContinuationToken != "" {
+		cursor, err = decodeContinuationToken(params.ContinuationToken)
+		if err != nil {
+			WriteS3Error(w, ErrInvalidRequest, r.URL.Path, generateRequestID())
+			return
+		}
+	} else if params.StartAfter != "" {
+		cursor = params.StartAfter
+	}
+
+	var rawEntries []ListV2Entry
+	if a.db != nil {
+		rawEntries, err = a.fetchListBatch(r.Context(), t.ID, bucket, params.Prefix, cursor, params.MaxKeys, params.Delimiter)
+	} else {
+		rawEntries, err = a.listFromDriver(r.Context(), t, bucket, params.Prefix, cursor)
+	}
+	if err != nil {
+		a.logger.Error("list objects failed", zap.String("bucket", bucket), zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	contents, commonPrefixes, isTruncated, lastKey := processListEntries(
+		rawEntries, params.Prefix, params.Delimiter, params.MaxKeys,
+	)
+
+	result := ListBucketV2Result{
+		Xmlns:          "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:           bucket,
+		Prefix:         params.Prefix,
+		MaxKeys:        params.MaxKeys,
+		KeyCount:       len(contents) + len(commonPrefixes),
+		IsTruncated:    isTruncated,
+		Contents:       contents,
+		CommonPrefixes: commonPrefixes,
+	}
+
+	if params.Delimiter != "" {
+		result.Delimiter = params.Delimiter
+	}
+	if params.ContinuationToken != "" {
+		result.ContinuationToken = params.ContinuationToken
+	}
+	if params.StartAfter != "" {
+		result.StartAfter = params.StartAfter
+	}
+	if params.EncodingType != "" {
+		result.EncodingType = params.EncodingType
+	}
+	if isTruncated && lastKey != "" {
+		result.NextContinuationToken = encodeContinuationToken(lastKey)
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	if _, writeErr := w.Write([]byte(xml.Header)); writeErr != nil {
+		a.logger.Error("failed to write XML header", zap.Error(writeErr))
+		return
+	}
+	if encErr := xml.NewEncoder(w).Encode(result); encErr != nil {
+		a.logger.Error("failed to encode list response", zap.Error(encErr))
+	}
+}
+
+// fetchListBatch queries object_head_cache for a page of objects.
+func (a *S3ToEngine) fetchListBatch(ctx context.Context, tenantID, bucket, prefix, cursor string, maxKeys int, delimiter string) ([]ListV2Entry, error) {
+	fetchLimit := maxKeys + 1
+	if delimiter != "" {
+		fetchLimit = maxKeys * 10
+		if fetchLimit < 1000 {
+			fetchLimit = 1000
+		}
+		if fetchLimit > 10000 {
+			fetchLimit = 10000
+		}
+	}
+
+	escapedPrefix := strings.ReplaceAll(prefix, `\`, `\\`)
+	escapedPrefix = strings.ReplaceAll(escapedPrefix, `%`, `\%`)
+	escapedPrefix = strings.ReplaceAll(escapedPrefix, `_`, `\_`)
+	likePattern := escapedPrefix + "%"
+
+	var rows *sql.Rows
+	var err error
+
+	switch {
+	case prefix == "" && cursor == "":
+		rows, err = a.db.QueryContext(ctx,
+			`SELECT object_key, size_bytes, etag, content_type, updated_at
+			 FROM object_head_cache
+			 WHERE tenant_id = $1 AND bucket = $2
+			 ORDER BY object_key ASC
+			 LIMIT $3`, tenantID, bucket, fetchLimit)
+	case prefix == "":
+		rows, err = a.db.QueryContext(ctx,
+			`SELECT object_key, size_bytes, etag, content_type, updated_at
+			 FROM object_head_cache
+			 WHERE tenant_id = $1 AND bucket = $2 AND object_key > $3
+			 ORDER BY object_key ASC
+			 LIMIT $4`, tenantID, bucket, cursor, fetchLimit)
+	case cursor == "":
+		rows, err = a.db.QueryContext(ctx,
+			`SELECT object_key, size_bytes, etag, content_type, updated_at
+			 FROM object_head_cache
+			 WHERE tenant_id = $1 AND bucket = $2
+			   AND object_key LIKE $3 ESCAPE '\'
+			 ORDER BY object_key ASC
+			 LIMIT $4`, tenantID, bucket, likePattern, fetchLimit)
+	default:
+		rows, err = a.db.QueryContext(ctx,
+			`SELECT object_key, size_bytes, etag, content_type, updated_at
+			 FROM object_head_cache
+			 WHERE tenant_id = $1 AND bucket = $2
+			   AND object_key LIKE $3 ESCAPE '\'
+			   AND object_key > $4
+			 ORDER BY object_key ASC
+			 LIMIT $5`, tenantID, bucket, likePattern, cursor, fetchLimit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query object_head_cache: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []ListV2Entry
+	for rows.Next() {
+		var key, etag, contentType string
+		var size int64
+		var updatedAt time.Time
+		if scanErr := rows.Scan(&key, &size, &etag, &contentType, &updatedAt); scanErr != nil {
+			return nil, fmt.Errorf("scan object_head_cache: %w", scanErr)
+		}
+		if etag != "" && !strings.HasPrefix(etag, `"`) {
+			etag = `"` + etag + `"`
+		}
+		entries = append(entries, ListV2Entry{
+			Key:          key,
+			Size:         size,
+			ETag:         etag,
+			LastModified: updatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+			StorageClass: "STANDARD",
+		})
+	}
+	if rowErr := rows.Err(); rowErr != nil {
+		return nil, fmt.Errorf("iterate object_head_cache: %w", rowErr)
+	}
+
+	return entries, nil
+}
+
+// listFromDriver falls back to the engine driver when DB is unavailable.
+func (a *S3ToEngine) listFromDriver(ctx context.Context, t *tenant.Tenant, bucket, prefix, cursor string) ([]ListV2Entry, error) {
+	container := t.NamespaceContainer(bucket)
+	artifacts, err := a.engine.List(ctx, container, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("engine list: %w", err)
+	}
+
+	sort.Slice(artifacts, func(i, j int) bool {
+		return artifacts[i].Key < artifacts[j].Key
+	})
+
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	var entries []ListV2Entry
+	for _, art := range artifacts {
+		if prefix != "" && !strings.HasPrefix(art.Key, prefix) {
+			continue
+		}
+		if cursor != "" && art.Key <= cursor {
+			continue
+		}
+		modified := now
+		if !art.Modified.IsZero() {
+			modified = art.Modified.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		etag := art.ETag
+		if etag != "" && !strings.HasPrefix(etag, `"`) {
+			etag = `"` + etag + `"`
+		}
+		entries = append(entries, ListV2Entry{
+			Key:          art.Key,
+			Size:         art.Size,
+			ETag:         etag,
+			LastModified: modified,
+			StorageClass: "STANDARD",
+		})
+	}
+
+	return entries, nil
+}
+
+// processListEntries applies delimiter grouping and max-keys truncation.
+// Returns contents, commonPrefixes, isTruncated, and the last key examined.
+func processListEntries(entries []ListV2Entry, prefix, delimiter string, maxKeys int) ([]ListV2Entry, []CommonPrefixEntry, bool, string) {
+	if delimiter == "" {
+		if len(entries) > maxKeys {
+			lastKey := ""
+			if maxKeys > 0 {
+				lastKey = entries[maxKeys-1].Key
+			}
+			return entries[:maxKeys], nil, true, lastKey
+		}
+		lastKey := ""
+		if len(entries) > 0 {
+			lastKey = entries[len(entries)-1].Key
+		}
+		return entries, nil, false, lastKey
+	}
+
+	var contents []ListV2Entry
+	var commonPrefixes []CommonPrefixEntry
+	seen := make(map[string]bool)
+	count := 0
+	var lastKey string
+
+	for _, entry := range entries {
+		lastKey = entry.Key
+
+		keyAfterPrefix := entry.Key[len(prefix):]
+		idx := strings.Index(keyAfterPrefix, delimiter)
+
+		if idx >= 0 {
+			cp := prefix + keyAfterPrefix[:idx+len(delimiter)]
+			if !seen[cp] {
+				if count >= maxKeys {
+					return contents, commonPrefixes, true, lastKey
+				}
+				seen[cp] = true
+				commonPrefixes = append(commonPrefixes, CommonPrefixEntry{Prefix: cp})
+				count++
+			}
+		} else {
+			if count >= maxKeys {
+				return contents, commonPrefixes, true, lastKey
+			}
+			contents = append(contents, entry)
+			count++
+		}
+	}
+
+	return contents, commonPrefixes, false, lastKey
+}

--- a/internal/api/s3_list_test.go
+++ b/internal/api/s3_list_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -16,23 +17,36 @@ import (
 	"go.uber.org/zap"
 )
 
-type ListBucketResult struct {
-	XMLName  xml.Name `xml:"ListBucketResult"`
-	Name     string   `xml:"Name"`
-	Contents []struct {
+type listV2Result struct {
+	XMLName               xml.Name `xml:"ListBucketResult"`
+	Name                  string   `xml:"Name"`
+	Prefix                string   `xml:"Prefix"`
+	Delimiter             string   `xml:"Delimiter"`
+	MaxKeys               int      `xml:"MaxKeys"`
+	KeyCount              int      `xml:"KeyCount"`
+	IsTruncated           bool     `xml:"IsTruncated"`
+	ContinuationToken     string   `xml:"ContinuationToken"`
+	NextContinuationToken string   `xml:"NextContinuationToken"`
+	StartAfter            string   `xml:"StartAfter"`
+	Contents              []struct {
 		Key          string `xml:"Key"`
 		Size         int64  `xml:"Size"`
+		ETag         string `xml:"ETag"`
+		LastModified string `xml:"LastModified"`
 		StorageClass string `xml:"StorageClass"`
 	} `xml:"Contents"`
+	CommonPrefixes []struct {
+		Prefix string `xml:"Prefix"`
+	} `xml:"CommonPrefixes"`
 }
 
-func TestS3_ListObjects(t *testing.T) {
+func setupListTestServer(t *testing.T) (*Server, *tenant.Tenant, func()) {
+	t.Helper()
 	logger := zap.NewNop()
 	eng := engine.NewEngine(nil, logger, nil)
 
-	tempDir, err := os.MkdirTemp("", "vaultaire-test-*")
+	tempDir, err := os.MkdirTemp("", "vaultaire-list-test-*")
 	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	driver := drivers.NewLocalDriver(tempDir, logger)
 	eng.AddDriver("local", driver)
@@ -51,30 +65,318 @@ func TestS3_ListObjects(t *testing.T) {
 		Namespace: "tenant/test-tenant/",
 	}
 
-	// Put multiple objects first
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+	return server, testTenant, cleanup
+}
+
+func putListTestObject(server *Server, t *tenant.Tenant, bucket, key, content string) {
+	req := httptest.NewRequest("PUT", "/"+bucket+"/"+key,
+		bytes.NewReader([]byte(content)))
+	ctx := tenant.WithTenant(req.Context(), t)
+	req = req.WithContext(ctx)
+	server.handleS3Request(httptest.NewRecorder(), req)
+}
+
+func listObjects(server *Server, t *tenant.Tenant, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", path, nil)
+	ctx := tenant.WithTenant(req.Context(), t)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	server.handleS3Request(w, req)
+	return w
+}
+
+func parseListResult(t *testing.T, w *httptest.ResponseRecorder) listV2Result {
+	t.Helper()
+	var result listV2Result
+	err := xml.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err, "XML parse failed: %s", w.Body.String())
+	return result
+}
+
+func TestS3_ListObjects(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
 	objects := []string{"file1.txt", "file2.txt", "dir/file3.txt"}
 	for _, key := range objects {
-		putReq := httptest.NewRequest("PUT", "/test-bucket/"+key,
-			bytes.NewReader([]byte("content of "+key)))
-		ctx := tenant.WithTenant(putReq.Context(), testTenant)
-		putReq = putReq.WithContext(ctx)
-		server.handleS3Request(httptest.NewRecorder(), putReq)
+		putListTestObject(server, testTenant, "test-bucket", key, "content of "+key)
 	}
 
-	// LIST the bucket
-	listReq := httptest.NewRequest("GET", "/test-bucket", nil)
-	ctx := tenant.WithTenant(listReq.Context(), testTenant)
-	listReq = listReq.WithContext(ctx)
-	listW := httptest.NewRecorder()
+	w := listObjects(server, testTenant, "/test-bucket")
+	assert.Equal(t, 200, w.Code)
 
-	server.handleS3Request(listW, listReq)
-	assert.Equal(t, 200, listW.Code, "LIST should return 200")
-
-	// Parse XML response
-	var result ListBucketResult
-	err = xml.Unmarshal(listW.Body.Bytes(), &result)
-	require.NoError(t, err)
-
+	result := parseListResult(t, w)
 	assert.Equal(t, "test-bucket", result.Name)
 	assert.Equal(t, 3, len(result.Contents))
+	assert.Equal(t, 3, result.KeyCount)
+	assert.False(t, result.IsTruncated)
+	assert.Equal(t, 1000, result.MaxKeys)
+}
+
+func TestListV2_MaxKeysAndPagination(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	for i := 0; i < 10; i++ {
+		putListTestObject(server, testTenant, "page-bucket", fmt.Sprintf("obj-%02d.txt", i),
+			fmt.Sprintf("content %d", i))
+	}
+
+	// Page 1: max-keys=3
+	w := listObjects(server, testTenant, "/page-bucket?max-keys=3")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, 3, r.KeyCount)
+	assert.True(t, r.IsTruncated)
+	assert.NotEmpty(t, r.NextContinuationToken)
+	assert.Equal(t, 3, r.MaxKeys)
+
+	keys := make([]string, len(r.Contents))
+	for i, c := range r.Contents {
+		keys[i] = c.Key
+	}
+	assert.Equal(t, []string{"obj-00.txt", "obj-01.txt", "obj-02.txt"}, keys)
+
+	// Page 2: use continuation token
+	w = listObjects(server, testTenant,
+		"/page-bucket?max-keys=3&continuation-token="+r.NextContinuationToken)
+	assert.Equal(t, 200, w.Code)
+	r2 := parseListResult(t, w)
+
+	assert.Equal(t, 3, r2.KeyCount)
+	assert.True(t, r2.IsTruncated)
+	assert.NotEmpty(t, r2.NextContinuationToken)
+	assert.Equal(t, r.NextContinuationToken, r2.ContinuationToken)
+
+	keys2 := make([]string, len(r2.Contents))
+	for i, c := range r2.Contents {
+		keys2[i] = c.Key
+	}
+	assert.Equal(t, []string{"obj-03.txt", "obj-04.txt", "obj-05.txt"}, keys2)
+
+	// Page 3
+	w = listObjects(server, testTenant,
+		"/page-bucket?max-keys=3&continuation-token="+r2.NextContinuationToken)
+	r3 := parseListResult(t, w)
+	assert.Equal(t, 3, r3.KeyCount)
+	assert.True(t, r3.IsTruncated)
+
+	// Page 4 (last page, 1 remaining)
+	w = listObjects(server, testTenant,
+		"/page-bucket?max-keys=3&continuation-token="+r3.NextContinuationToken)
+	r4 := parseListResult(t, w)
+	assert.Equal(t, 1, r4.KeyCount)
+	assert.False(t, r4.IsTruncated)
+	assert.Empty(t, r4.NextContinuationToken)
+	assert.Equal(t, "obj-09.txt", r4.Contents[0].Key)
+}
+
+func TestListV2_FullPaginationCollectsAllKeys(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	expected := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("key-%02d", i)
+		expected[i] = key
+		putListTestObject(server, testTenant, "full-bucket", key, "data")
+	}
+
+	var allKeys []string
+	token := ""
+	pages := 0
+
+	for {
+		path := "/full-bucket?max-keys=7"
+		if token != "" {
+			path += "&continuation-token=" + token
+		}
+		w := listObjects(server, testTenant, path)
+		assert.Equal(t, 200, w.Code)
+		r := parseListResult(t, w)
+
+		for _, c := range r.Contents {
+			allKeys = append(allKeys, c.Key)
+		}
+		pages++
+
+		if !r.IsTruncated {
+			break
+		}
+		token = r.NextContinuationToken
+		require.NotEmpty(t, token, "IsTruncated=true but no NextContinuationToken")
+	}
+
+	assert.Equal(t, expected, allKeys, "all keys should be returned exactly once across pages")
+	assert.Equal(t, 3, pages, "20 keys / 7 per page = 3 pages")
+}
+
+func TestListV2_StartAfter(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	for _, key := range []string{"alpha.txt", "bravo.txt", "charlie.txt", "delta.txt"} {
+		putListTestObject(server, testTenant, "sa-bucket", key, "data")
+	}
+
+	w := listObjects(server, testTenant, "/sa-bucket?start-after=bravo.txt")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, "bravo.txt", r.StartAfter)
+	assert.Equal(t, 2, r.KeyCount)
+	assert.Equal(t, "charlie.txt", r.Contents[0].Key)
+	assert.Equal(t, "delta.txt", r.Contents[1].Key)
+}
+
+func TestListV2_Prefix(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	for _, key := range []string{"logs/app.log", "logs/error.log", "data/file.csv", "readme.txt"} {
+		putListTestObject(server, testTenant, "prefix-bucket", key, "data")
+	}
+
+	w := listObjects(server, testTenant, "/prefix-bucket?prefix=logs/")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, "logs/", r.Prefix)
+	assert.Equal(t, 2, r.KeyCount)
+	keys := []string{r.Contents[0].Key, r.Contents[1].Key}
+	assert.Contains(t, keys, "logs/app.log")
+	assert.Contains(t, keys, "logs/error.log")
+}
+
+func TestListV2_Delimiter(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	for _, key := range []string{
+		"photos/2024/jan.jpg",
+		"photos/2024/feb.jpg",
+		"photos/2025/mar.jpg",
+		"photos/cover.jpg",
+		"readme.txt",
+	} {
+		putListTestObject(server, testTenant, "delim-bucket", key, "data")
+	}
+
+	// Root level with delimiter
+	w := listObjects(server, testTenant, "/delim-bucket?delimiter=/")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, "/", r.Delimiter)
+	assert.Equal(t, 1, len(r.Contents), "only readme.txt at root")
+	assert.Equal(t, "readme.txt", r.Contents[0].Key)
+	assert.Equal(t, 1, len(r.CommonPrefixes), "photos/ is the only common prefix")
+	assert.Equal(t, "photos/", r.CommonPrefixes[0].Prefix)
+
+	// Prefix + delimiter to browse one level deeper
+	w = listObjects(server, testTenant, "/delim-bucket?prefix=photos/&delimiter=/")
+	assert.Equal(t, 200, w.Code)
+	r = parseListResult(t, w)
+
+	assert.Equal(t, "photos/", r.Prefix)
+	assert.Equal(t, 1, len(r.Contents), "only photos/cover.jpg is a direct child")
+	assert.Equal(t, "photos/cover.jpg", r.Contents[0].Key)
+	assert.Equal(t, 2, len(r.CommonPrefixes), "photos/2024/ and photos/2025/")
+
+	cpPrefixes := []string{r.CommonPrefixes[0].Prefix, r.CommonPrefixes[1].Prefix}
+	assert.Contains(t, cpPrefixes, "photos/2024/")
+	assert.Contains(t, cpPrefixes, "photos/2025/")
+}
+
+func TestListV2_EmptyBucket(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	w := listObjects(server, testTenant, "/empty-bucket")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, "empty-bucket", r.Name)
+	assert.Equal(t, 0, r.KeyCount)
+	assert.False(t, r.IsTruncated)
+	assert.Empty(t, r.Contents)
+}
+
+func TestListV2_MaxKeysZero(t *testing.T) {
+	server, testTenant, cleanup := setupListTestServer(t)
+	defer cleanup()
+
+	putListTestObject(server, testTenant, "zero-bucket", "file.txt", "data")
+
+	w := listObjects(server, testTenant, "/zero-bucket?max-keys=0")
+	assert.Equal(t, 200, w.Code)
+	r := parseListResult(t, w)
+
+	assert.Equal(t, 0, r.MaxKeys)
+	assert.Equal(t, 0, r.KeyCount)
+	assert.True(t, r.IsTruncated)
+}
+
+func TestProcessListEntries_NoDelimiter(t *testing.T) {
+	entries := []ListV2Entry{
+		{Key: "a"}, {Key: "b"}, {Key: "c"}, {Key: "d"}, {Key: "e"},
+	}
+
+	contents, cps, trunc, lastKey := processListEntries(entries, "", "", 3)
+	assert.Equal(t, 3, len(contents))
+	assert.Nil(t, cps)
+	assert.True(t, trunc)
+	assert.Equal(t, "c", lastKey)
+	assert.Equal(t, "a", contents[0].Key)
+	assert.Equal(t, "c", contents[2].Key)
+
+	contents2, _, trunc2, lastKey2 := processListEntries(entries, "", "", 10)
+	assert.Equal(t, 5, len(contents2))
+	assert.False(t, trunc2)
+	assert.Equal(t, "e", lastKey2)
+}
+
+func TestProcessListEntries_WithDelimiter(t *testing.T) {
+	entries := []ListV2Entry{
+		{Key: "dir1/a.txt"},
+		{Key: "dir1/b.txt"},
+		{Key: "dir2/c.txt"},
+		{Key: "file.txt"},
+	}
+
+	contents, cps, trunc, _ := processListEntries(entries, "", "/", 10)
+	assert.Equal(t, 1, len(contents))
+	assert.Equal(t, "file.txt", contents[0].Key)
+	assert.Equal(t, 2, len(cps))
+	assert.Equal(t, "dir1/", cps[0].Prefix)
+	assert.Equal(t, "dir2/", cps[1].Prefix)
+	assert.False(t, trunc)
+}
+
+func TestProcessListEntries_DelimiterWithMaxKeys(t *testing.T) {
+	entries := []ListV2Entry{
+		{Key: "a/1"}, {Key: "a/2"}, {Key: "a/3"},
+		{Key: "b/1"}, {Key: "b/2"},
+		{Key: "c/1"},
+		{Key: "top.txt"},
+	}
+
+	contents, cps, trunc, _ := processListEntries(entries, "", "/", 2)
+	assert.Equal(t, 0, len(contents))
+	assert.Equal(t, 2, len(cps))
+	assert.Equal(t, "a/", cps[0].Prefix)
+	assert.Equal(t, "b/", cps[1].Prefix)
+	assert.True(t, trunc)
+}
+
+func TestContinuationToken_RoundTrip(t *testing.T) {
+	keys := []string{"simple-key", "path/with/slashes", "special chars!@#", "日本語キー"}
+	for _, key := range keys {
+		token := encodeContinuationToken(key)
+		decoded, err := decodeContinuationToken(token)
+		require.NoError(t, err)
+		assert.Equal(t, key, decoded)
+	}
 }


### PR DESCRIPTION
## Summary
- Full ListObjectsV2 implementation with `continuation-token`, `start-after`, `max-keys`, `prefix`, and `delimiter` support
- DB-backed listing queries `object_head_cache` for full object metadata (size, ETag, LastModified, content-type) with cursor-based pagination
- Driver fallback path for DB-less environments (sorted in-memory pagination)
- Delimiter processing produces `CommonPrefixes` for directory-style browsing (e.g., S3 console, rclone)
- V1 backward compat: `marker` param mapped to `start-after`
- 12 tests covering pagination round-trips, prefix/delimiter, start-after, edge cases (empty bucket, max-keys=0)

## Test plan
- [x] `TestS3_ListObjects` — basic 3-object listing (existing test, updated for V2)
- [x] `TestListV2_MaxKeysAndPagination` — 4-page walk through 10 objects with max-keys=3
- [x] `TestListV2_FullPaginationCollectsAllKeys` — 20 objects, 7/page, verifies all keys returned exactly once
- [x] `TestListV2_StartAfter` — skips keys before the marker
- [x] `TestListV2_Prefix` — filters by key prefix
- [x] `TestListV2_Delimiter` — root-level and nested directory grouping
- [x] `TestListV2_EmptyBucket` — zero results
- [x] `TestListV2_MaxKeysZero` — edge case: max-keys=0 returns IsTruncated=true
- [x] Unit tests for `processListEntries` and `encodeContinuationToken` round-trip
- [x] Race detector clean, golangci-lint clean