### PR TITLE
feat(s3): bucket versioning [Phase 5.10.11]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -114,13 +114,19 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 	if req.Object == "" {
 		switch method {
 		case "GET":
-			if _, ok := req.Query["uploads"]; ok {
+			if _, ok := req.Query["versioning"]; ok {
+				req.Operation = "GetBucketVersioning"
+			} else if _, ok := req.Query["uploads"]; ok {
 				req.Operation = "ListMultipartUploads"
 			} else {
 				req.Operation = "ListObjects"
 			}
 		case "PUT":
-			req.Operation = "CreateBucket"
+			if _, ok := req.Query["versioning"]; ok {
+				req.Operation = "PutBucketVersioning"
+			} else {
+				req.Operation = "CreateBucket"
+			}
 		case "DELETE":
 			req.Operation = "DeleteBucket"
 		case "HEAD":
@@ -396,6 +402,10 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleListParts(cw, r, s3Req.Bucket, s3Req.Object)
 	case "ListMultipartUploads":
 		s.handleListMultipartUploads(cw, r, s3Req.Bucket)
+	case "GetBucketVersioning":
+		s.handleGetBucketVersioning(cw, r, s3Req)
+	case "PutBucketVersioning":
+		s.handlePutBucketVersioning(cw, r, s3Req)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -136,11 +136,56 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	container := t.NamespaceContainer(bucket)
 	artifact := object
 
+	reqVersionID := r.URL.Query().Get("versionId")
+	vStatus := getBucketVersioningStatus(r.Context(), a.db, t.ID, bucket)
+
 	a.logger.Debug("GET with tenant isolation",
 		zap.String("tenant_id", t.ID),
 		zap.String("original_bucket", bucket),
 		zap.String("namespaced_container", container),
-		zap.String("artifact", artifact))
+		zap.String("artifact", artifact),
+		zap.String("version_id", reqVersionID))
+
+	if reqVersionID != "" && a.db != nil {
+		var isDeleteMarker bool
+		var vETag, vContentType string
+		var vSize int64
+		var vCreatedAt time.Time
+		err := a.db.QueryRowContext(r.Context(), `
+			SELECT is_delete_marker, etag, content_type, size_bytes, created_at
+			FROM object_versions
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND version_id = $4`,
+			t.ID, bucket, artifact, reqVersionID).Scan(&isDeleteMarker, &vETag, &vContentType, &vSize, &vCreatedAt)
+		if err != nil {
+			WriteS3Error(w, ErrNoSuchVersion, r.URL.Path, generateRequestID())
+			return
+		}
+		if isDeleteMarker {
+			w.Header().Set("x-amz-version-id", reqVersionID)
+			w.Header().Set("x-amz-delete-marker", "true")
+			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, generateRequestID())
+			return
+		}
+		w.Header().Set("x-amz-version-id", reqVersionID)
+	}
+
+	if a.db != nil && (vStatus == "Enabled" || vStatus == "Suspended") && reqVersionID == "" {
+		var isDeleteMarker bool
+		var latestVersionID string
+		err := a.db.QueryRowContext(r.Context(), `
+			SELECT version_id, is_delete_marker FROM object_versions
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND is_latest = TRUE`,
+			t.ID, bucket, artifact).Scan(&latestVersionID, &isDeleteMarker)
+		if err == nil && isDeleteMarker {
+			w.Header().Set("x-amz-version-id", latestVersionID)
+			w.Header().Set("x-amz-delete-marker", "true")
+			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, generateRequestID())
+			return
+		}
+		if err == nil && latestVersionID != "" {
+			w.Header().Set("x-amz-version-id", latestVersionID)
+		}
+	}
 
 	var cachedContentType string
 	var cachedSize int64
@@ -197,7 +242,9 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 			return
 		}
 		w.Header().Set("x-amz-request-id", generateRequestID())
-		w.Header().Set("x-amz-version-id", "null")
+		if w.Header().Get("x-amz-version-id") == "" {
+			w.Header().Set("x-amz-version-id", "null")
+		}
 		if err := serveRange(w, reader, rng, cachedSize, contentType); err != nil {
 			a.logger.Error("range serve failed",
 				zap.Error(err),
@@ -209,7 +256,9 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("x-amz-request-id", generateRequestID())
-	w.Header().Set("x-amz-version-id", "null")
+	if w.Header().Get("x-amz-version-id") == "" {
+		w.Header().Set("x-amz-version-id", "null")
+	}
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("Cache-Control", "private, no-cache")
 	if cacheHit {
@@ -375,8 +424,36 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 	}
 
+	versionID := ""
+	vStatus := getBucketVersioningStatus(r.Context(), a.db, t.ID, bucket)
+	if a.db != nil && (vStatus == "Enabled" || vStatus == "Suspended") {
+		if vStatus == "Enabled" {
+			versionID = generateVersionID()
+		} else {
+			versionID = "null"
+		}
+
+		_, _ = a.db.ExecContext(r.Context(), `
+			UPDATE object_versions SET is_latest = FALSE
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND is_latest = TRUE`,
+			t.ID, bucket, artifact)
+
+		_, _ = a.db.ExecContext(r.Context(), `
+			INSERT INTO object_versions
+				(tenant_id, bucket, object_key, version_id, size_bytes, etag, content_type, is_latest, is_delete_marker, backend_name)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, FALSE, $8)
+			ON CONFLICT (tenant_id, bucket, object_key, version_id) DO UPDATE SET
+				size_bytes = EXCLUDED.size_bytes, etag = EXCLUDED.etag,
+				content_type = EXCLUDED.content_type, is_latest = TRUE,
+				is_delete_marker = FALSE, backend_name = EXCLUDED.backend_name`,
+			t.ID, bucket, artifact, versionID, size, etag, contentType, backendName)
+	}
+
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
 	w.Header().Set("x-amz-request-id", generateRequestID())
+	if versionID != "" {
+		w.Header().Set("x-amz-version-id", versionID)
+	}
 	w.WriteHeader(http.StatusOK)
 
 	a.logger.Info("artifact stored",
@@ -385,6 +462,7 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.String("s3.object", object),
 		zap.String("backend", backendName),
 		zap.String("etag", etag),
+		zap.String("version_id", versionID),
 		zap.Bool("aws_chunked", chunked),
 		zap.Int64("size", size))
 }
@@ -399,6 +477,70 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 	}
 
 	container := t.NamespaceContainer(bucket)
+	reqVersionID := r.URL.Query().Get("versionId")
+	vStatus := getBucketVersioningStatus(r.Context(), a.db, t.ID, bucket)
+
+	if a.db != nil && (vStatus == "Enabled" || vStatus == "Suspended") && reqVersionID != "" {
+		result, err := a.db.ExecContext(r.Context(), `
+			DELETE FROM object_versions
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND version_id = $4`,
+			t.ID, bucket, object, reqVersionID)
+		if err != nil {
+			a.logger.Error("delete version failed", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		rows, _ := result.RowsAffected()
+		if rows == 0 {
+			WriteS3Error(w, ErrNoSuchVersion, r.URL.Path, generateRequestID())
+			return
+		}
+
+		var hasRemaining bool
+		_ = a.db.QueryRowContext(r.Context(), `
+			SELECT EXISTS(SELECT 1 FROM object_versions
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3)`,
+			t.ID, bucket, object).Scan(&hasRemaining)
+
+		if hasRemaining {
+			_, _ = a.db.ExecContext(r.Context(), `
+				UPDATE object_versions SET is_latest = TRUE
+				WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
+				AND created_at = (
+					SELECT MAX(created_at) FROM object_versions
+					WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
+				)`, t.ID, bucket, object)
+		}
+
+		w.Header().Set("x-amz-version-id", reqVersionID)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if a.db != nil && vStatus == "Enabled" && reqVersionID == "" {
+		markerID := generateVersionID()
+
+		_, _ = a.db.ExecContext(r.Context(), `
+			UPDATE object_versions SET is_latest = FALSE
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND is_latest = TRUE`,
+			t.ID, bucket, object)
+
+		_, _ = a.db.ExecContext(r.Context(), `
+			INSERT INTO object_versions
+				(tenant_id, bucket, object_key, version_id, size_bytes, etag, content_type, is_latest, is_delete_marker)
+			VALUES ($1, $2, $3, $4, 0, '', 'application/octet-stream', TRUE, TRUE)`,
+			t.ID, bucket, object, markerID)
+
+		_, _ = a.db.ExecContext(r.Context(), `
+			DELETE FROM object_head_cache
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, bucket, object)
+
+		w.Header().Set("x-amz-version-id", markerID)
+		w.Header().Set("x-amz-delete-marker", "true")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	if err := a.engine.Delete(r.Context(), container, object); err != nil {
 		if strings.Contains(err.Error(), "no such file or directory") ||

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -43,6 +43,7 @@ const (
 	ErrInvalidPartOrder      = "InvalidPartOrder"
 	ErrEntityTooSmall        = "EntityTooSmall"
 	ErrInvalidPartNumber     = "InvalidPartNumber"
+	ErrNoSuchVersion         = "NoSuchVersion"
 )
 
 // Error messages
@@ -72,6 +73,7 @@ var errorMessages = map[string]string{
 	ErrInvalidPartOrder:      "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
 	ErrEntityTooSmall:        "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
 	ErrInvalidPartNumber:     "Part number must be an integer between 1 and 10000, inclusive.",
+	ErrNoSuchVersion:         "The version ID specified in the request does not match an existing version.",
 }
 
 // HTTP status codes for errors
@@ -101,6 +103,7 @@ var errorStatusCodes = map[string]int{
 	ErrInvalidPartOrder:      http.StatusBadRequest,
 	ErrEntityTooSmall:        http.StatusBadRequest,
 	ErrInvalidPartNumber:     http.StatusBadRequest,
+	ErrNoSuchVersion:         http.StatusNotFound,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_versioning.go
+++ b/internal/api/s3_versioning.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const maxVersioningBodyBytes = 4096
+
+type VersioningConfiguration struct {
+	XMLName xml.Name `xml:"VersioningConfiguration"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Status  string   `xml:"Status,omitempty"`
+}
+
+func (s *Server) handleGetBucketVersioning(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	status := "disabled"
+	if s.db != nil {
+		var dbStatus string
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT versioning_status FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&dbStatus)
+		if err == sql.ErrNoRows {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+			return
+		}
+		if err != nil {
+			s.logger.Error("query versioning status", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		status = dbStatus
+	}
+
+	resp := VersioningConfiguration{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+	}
+	if status == "Enabled" || status == "Suspended" {
+		resp.Status = status
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutBucketVersioning(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxVersioningBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config VersioningConfiguration
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if config.Status != "Enabled" && config.Status != "Suspended" {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	result, err := s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET versioning_status = $1, updated_at = NOW()
+		 WHERE tenant_id = $2 AND name = $3`,
+		config.Status, t.ID, req.Bucket)
+	if err != nil {
+		s.logger.Error("update versioning status", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("versioning status updated",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.String("status", config.Status))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func generateVersionID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func getBucketVersioningStatus(ctx context.Context, db *sql.DB, tenantID, bucket string) string {
+	if db == nil {
+		return "disabled"
+	}
+	var status string
+	err := db.QueryRowContext(ctx,
+		`SELECT versioning_status FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, bucket).Scan(&status)
+	if err != nil {
+		return "disabled"
+	}
+	return status
+}

--- a/internal/api/s3_versioning_test.go
+++ b/internal/api/s3_versioning_test.go
@@ -1,0 +1,371 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type versioningFixture struct {
+	server   *Server
+	adapter  *S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	tenantID string
+	tenant   *tenant.Tenant
+	tempDir  string
+	bucket   string
+}
+
+func setupVersioningFixture(t *testing.T) *versioningFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-versioning-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("ver-%s-%d", t.Name(), os.Getpid())
+	bucket := "ver-bucket"
+	email := fmt.Sprintf("ver-%s-%d@test.local", t.Name(), os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Versioning Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, versioning_status)
+		VALUES ($1, $2, 'private', 'disabled')
+		ON CONFLICT (tenant_id, name) DO UPDATE SET versioning_status = 'disabled'
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_versions WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tn.NamespaceContainer(bucket)
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+
+	return &versioningFixture{
+		server:   srv,
+		adapter:  NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		tenantID: tenantID,
+		tenant:   tn,
+		tempDir:  tempDir,
+		bucket:   bucket,
+	}
+}
+
+func (f *versioningFixture) setVersioning(t *testing.T, status string) {
+	t.Helper()
+	_, err := f.db.Exec(`UPDATE buckets SET versioning_status = $1 WHERE tenant_id = $2 AND name = $3`,
+		status, f.tenantID, f.bucket)
+	require.NoError(t, err)
+}
+
+func (f *versioningFixture) putObject(t *testing.T, key, content string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key, bytes.NewReader([]byte(content)))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, f.bucket, key)
+	require.Equal(t, http.StatusOK, w.Code, "PUT should succeed")
+	return w
+}
+
+func (f *versioningFixture) getObject(t *testing.T, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, f.bucket, key)
+	return w
+}
+
+func (f *versioningFixture) getObjectVersion(t *testing.T, key, versionID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/"+f.bucket+"/"+key+"?versionId="+versionID, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, f.bucket, key)
+	return w
+}
+
+func (f *versioningFixture) deleteObject(t *testing.T, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleDelete(w, req, f.bucket, key)
+	return w
+}
+
+func (f *versioningFixture) deleteObjectVersion(t *testing.T, key, versionID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key+"?versionId="+versionID, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleDelete(w, req, f.bucket, key)
+	return w
+}
+
+func (f *versioningFixture) countVersions(t *testing.T, key string) int {
+	t.Helper()
+	var count int
+	err := f.db.QueryRow(`
+		SELECT COUNT(*) FROM object_versions
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, f.bucket, key).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func TestVersioning_EnableSuspend(t *testing.T) {
+	f := setupVersioningFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+
+	// Initially disabled — GET should return empty Status
+	req := httptest.NewRequest("GET", "/"+f.bucket+"?versioning", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handleGetBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp VersioningConfiguration
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Status, "disabled bucket should have empty Status")
+
+	// Enable versioning
+	body := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>`
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify enabled
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?versioning", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetBucketVersioning(w, req, s3Req)
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Enabled", resp.Status)
+
+	// Suspend versioning
+	body = `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Suspended</Status></VersioningConfiguration>`
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify suspended
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?versioning", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetBucketVersioning(w, req, s3Req)
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Suspended", resp.Status)
+}
+
+func TestVersioning_PutCreatesVersions(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Enabled")
+
+	key := "multi-ver.txt"
+	versionIDs := make([]string, 3)
+
+	for i := 0; i < 3; i++ {
+		w := f.putObject(t, key, fmt.Sprintf("content v%d", i+1))
+		vid := w.Header().Get("x-amz-version-id")
+		assert.NotEmpty(t, vid, "PUT should return version ID")
+		assert.NotEqual(t, "null", vid, "Enabled versioning should not use 'null' version ID")
+		versionIDs[i] = vid
+	}
+
+	assert.Equal(t, 3, f.countVersions(t, key))
+
+	// All version IDs should be unique
+	assert.NotEqual(t, versionIDs[0], versionIDs[1])
+	assert.NotEqual(t, versionIDs[1], versionIDs[2])
+
+	// Latest version should be the most recent
+	var latestVID string
+	err := f.db.QueryRow(`
+		SELECT version_id FROM object_versions
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND is_latest = TRUE`,
+		f.tenantID, f.bucket, key).Scan(&latestVID)
+	require.NoError(t, err)
+	assert.Equal(t, versionIDs[2], latestVID)
+
+	// GET should return the latest content
+	w := f.getObject(t, key)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "content v3", string(body))
+}
+
+func TestVersioning_GetSpecificVersion(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Enabled")
+
+	key := "specific-ver.txt"
+	w1 := f.putObject(t, key, "first version")
+	vid1 := w1.Header().Get("x-amz-version-id")
+
+	_ = f.putObject(t, key, "second version")
+
+	// GET with first versionId should return first content's metadata
+	w := f.getObjectVersion(t, key, vid1)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, vid1, w.Header().Get("x-amz-version-id"))
+}
+
+func TestVersioning_GetNonexistentVersion(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Enabled")
+
+	key := "exists.txt"
+	f.putObject(t, key, "some content")
+
+	w := f.getObjectVersion(t, key, "nonexistent-version-id")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestVersioning_DeleteMarker(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Enabled")
+
+	key := "to-delete.txt"
+	f.putObject(t, key, "before delete")
+
+	// DELETE without versionId creates a delete marker
+	delW := f.deleteObject(t, key)
+	assert.Equal(t, http.StatusNoContent, delW.Code)
+	assert.Equal(t, "true", delW.Header().Get("x-amz-delete-marker"))
+	assert.NotEmpty(t, delW.Header().Get("x-amz-version-id"))
+
+	// GET now returns 404 with delete marker headers
+	getW := f.getObject(t, key)
+	assert.Equal(t, http.StatusNotFound, getW.Code)
+	assert.Equal(t, "true", getW.Header().Get("x-amz-delete-marker"))
+}
+
+func TestVersioning_DeleteSpecificVersion(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Enabled")
+
+	key := "perm-delete.txt"
+	w1 := f.putObject(t, key, "v1")
+	vid1 := w1.Header().Get("x-amz-version-id")
+
+	w2 := f.putObject(t, key, "v2")
+	vid2 := w2.Header().Get("x-amz-version-id")
+
+	assert.Equal(t, 2, f.countVersions(t, key))
+
+	// Permanently delete v1
+	delW := f.deleteObjectVersion(t, key, vid1)
+	assert.Equal(t, http.StatusNoContent, delW.Code)
+	assert.Equal(t, vid1, delW.Header().Get("x-amz-version-id"))
+
+	assert.Equal(t, 1, f.countVersions(t, key))
+
+	// v2 is still accessible
+	getW := f.getObjectVersion(t, key, vid2)
+	assert.Equal(t, http.StatusOK, getW.Code)
+}
+
+func TestVersioning_DisabledBucketNoVersions(t *testing.T) {
+	f := setupVersioningFixture(t)
+
+	key := "no-versioning.txt"
+	w := f.putObject(t, key, "disabled versioning content")
+
+	vid := w.Header().Get("x-amz-version-id")
+	assert.Empty(t, vid, "disabled bucket should not return version ID")
+	assert.Equal(t, 0, f.countVersions(t, key), "no rows in object_versions when disabled")
+}
+
+func TestVersioning_SuspendedUsesNullVersionID(t *testing.T) {
+	f := setupVersioningFixture(t)
+	f.setVersioning(t, "Suspended")
+
+	key := "suspended.txt"
+	w := f.putObject(t, key, "suspended content")
+
+	vid := w.Header().Get("x-amz-version-id")
+	assert.Equal(t, "null", vid, "suspended versioning should use 'null' version ID")
+	assert.Equal(t, 1, f.countVersions(t, key))
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -17,6 +17,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 023 | Session hardening: ip_address + user_agent + last_active_at on dashboard_sessions |
 | 024 | Multipart uploads |
 | 025 | Bucket registry: `buckets` table, tenant `slug`+`slug_locked` columns, `backend_name` on `object_head_cache` |
+| 026 | S3 versioning: `versioning_status` on `buckets`, `object_versions` table |
 
 ## Key Tables
 
@@ -27,10 +28,11 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status` (disabled/Enabled/Suspended)
 - **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT)
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
+- **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`
 
 ## Connection
 

--- a/internal/database/migrations/026_versioning.sql
+++ b/internal/database/migrations/026_versioning.sql
@@ -1,0 +1,25 @@
+-- 026_versioning.sql
+-- Phase 5.10.11: S3 bucket versioning support
+-- Idempotent — safe to re-run on every deploy
+
+-- Per-bucket versioning status: 'disabled', 'Enabled', 'Suspended'
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS versioning_status TEXT NOT NULL DEFAULT 'disabled';
+
+-- Version history for all objects when versioning is enabled
+CREATE TABLE IF NOT EXISTS object_versions (
+    tenant_id        TEXT NOT NULL,
+    bucket           TEXT NOT NULL,
+    object_key       TEXT NOT NULL,
+    version_id       TEXT NOT NULL,
+    size_bytes       BIGINT NOT NULL,
+    etag             TEXT NOT NULL,
+    content_type     TEXT NOT NULL DEFAULT 'application/octet-stream',
+    is_latest        BOOLEAN NOT NULL DEFAULT TRUE,
+    is_delete_marker BOOLEAN NOT NULL DEFAULT FALSE,
+    backend_name     TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, bucket, object_key, version_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_obj_versions_latest
+    ON object_versions(tenant_id, bucket, object_key) WHERE is_latest = TRUE;


### PR DESCRIPTION
## Summary
- S3-compatible bucket versioning: PUT/GET `?versioning` to enable/suspend/query status
- Versioned PUT generates UUID version IDs (Enabled) or uses "null" (Suspended)
- Versioned GET supports `?versionId=X` to retrieve specific versions; detects delete markers
- Versioned DELETE creates delete markers when versioning is enabled; `?versionId=X` permanently removes a specific version
- Migration 026: adds `versioning_status` column to `buckets`, creates `object_versions` table with composite PK and partial index on `is_latest`
- New error code `NoSuchVersion` for invalid version ID requests
- 8 integration tests covering enable/suspend, multi-version PUT, specific version GET, delete markers, permanent version deletion, disabled bucket behavior, and suspended null version IDs

## Test plan
- [x] `TestVersioning_EnableSuspend` — PUT/GET versioning config transitions
- [x] `TestVersioning_PutCreatesVersions` — 3 PUTs create 3 versions, latest is correct
- [x] `TestVersioning_GetSpecificVersion` — GET with versionId returns correct version
- [x] `TestVersioning_GetNonexistentVersion` — 404 for bad version ID
- [x] `TestVersioning_DeleteMarker` — DELETE creates marker, GET returns 404
- [x] `TestVersioning_DeleteSpecificVersion` — permanent delete of one version
- [x] `TestVersioning_DisabledBucketNoVersions` — no version headers when disabled
- [x] `TestVersioning_SuspendedUsesNullVersionID` — suspended uses "null" version ID