### PR TITLE
feat(s3): bucket notifications with webhook delivery [Phase 5.10.12]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -116,6 +116,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 		case "GET":
 			if _, ok := req.Query["versioning"]; ok {
 				req.Operation = "GetBucketVersioning"
+			} else if _, ok := req.Query["notification"]; ok {
+				req.Operation = "GetBucketNotification"
 			} else if _, ok := req.Query["uploads"]; ok {
 				req.Operation = "ListMultipartUploads"
 			} else {
@@ -124,6 +126,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 		case "PUT":
 			if _, ok := req.Query["versioning"]; ok {
 				req.Operation = "PutBucketVersioning"
+			} else if _, ok := req.Query["notification"]; ok {
+				req.Operation = "PutBucketNotification"
 			} else {
 				req.Operation = "CreateBucket"
 			}
@@ -406,6 +410,10 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleGetBucketVersioning(cw, r, s3Req)
 	case "PutBucketVersioning":
 		s.handlePutBucketVersioning(cw, r, s3Req)
+	case "GetBucketNotification":
+		s.handleGetBucketNotification(cw, r, s3Req)
+	case "PutBucketNotification":
+		s.handlePutBucketNotification(cw, r, s3Req)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))

--- a/internal/api/s3_copy.go
+++ b/internal/api/s3_copy.go
@@ -193,6 +193,9 @@ func (s *Server) handleCopyObject(w http.ResponseWriter, r *http.Request, req *S
 		zap.String("directive", directive),
 		zap.Int64("size", counter.n),
 		zap.String("etag", etag))
+
+	notifySvc := NewNotificationDispatcher(s.db, s.logger)
+	notifySvc.Fire(t.ID, destBucket, "s3:ObjectCreated:Copy", destKey, counter.n, etag)
 }
 
 // parseCopySource parses the x-amz-copy-source header value.

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -19,17 +19,19 @@ import (
 
 // S3ToEngine adapts S3 requests to engine operations.
 type S3ToEngine struct {
-	engine engine.Engine
-	db     *sql.DB
-	logger *zap.Logger
+	engine    engine.Engine
+	db        *sql.DB
+	logger    *zap.Logger
+	notifySvc *NotificationDispatcher
 }
 
 // NewS3ToEngine creates a new adapter
 func NewS3ToEngine(e engine.Engine, db *sql.DB, logger *zap.Logger) *S3ToEngine {
 	return &S3ToEngine{
-		engine: e,
-		db:     db,
-		logger: logger,
+		engine:    e,
+		db:        db,
+		logger:    logger,
+		notifySvc: NewNotificationDispatcher(db, logger),
 	}
 }
 
@@ -465,6 +467,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.String("version_id", versionID),
 		zap.Bool("aws_chunked", chunked),
 		zap.Int64("size", size))
+
+	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:Put", object, size, etag)
 }
 
 // HandleDelete processes S3 DELETE requests
@@ -514,6 +518,7 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 
 		w.Header().Set("x-amz-version-id", reqVersionID)
 		w.WriteHeader(http.StatusNoContent)
+		a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
 		return
 	}
 
@@ -539,6 +544,7 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 		w.Header().Set("x-amz-version-id", markerID)
 		w.Header().Set("x-amz-delete-marker", "true")
 		w.WriteHeader(http.StatusNoContent)
+		a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
 		return
 	}
 
@@ -564,6 +570,7 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
 }
 
 // HandleList processes S3 LIST requests

--- a/internal/api/s3_multipart.go
+++ b/internal/api/s3_multipart.go
@@ -448,6 +448,9 @@ func (s *Server) handleCompleteMultipartUpload(w http.ResponseWriter, r *http.Re
 	}); err != nil {
 		s.logger.Error("failed to encode complete response", zap.Error(err))
 	}
+
+	notifySvc := NewNotificationDispatcher(s.db, s.logger)
+	notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:CompleteMultipartUpload", object, totalSize, etagValue)
 }
 
 func (s *Server) handleAbortMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {

--- a/internal/api/s3_notifications.go
+++ b/internal/api/s3_notifications.go
@@ -1,0 +1,382 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const maxNotificationBodyBytes = 65536
+
+// S3 notification XML types
+
+type NotificationConfiguration struct {
+	XMLName xml.Name             `xml:"NotificationConfiguration"`
+	Xmlns   string               `xml:"xmlns,attr,omitempty"`
+	Topics  []TopicConfiguration `xml:"TopicConfiguration,omitempty"`
+}
+
+type TopicConfiguration struct {
+	ID     string   `xml:"Id,omitempty"`
+	Topic  string   `xml:"Topic"`
+	Events []string `xml:"Event"`
+}
+
+func (s *Server) handleGetBucketNotification(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(xml.Header))
+		_, _ = w.Write([]byte(`<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>`))
+		return
+	}
+
+	rows, err := s.db.QueryContext(r.Context(), `
+		SELECT id, event_filter, target_url
+		FROM bucket_notifications
+		WHERE tenant_id = $1 AND bucket = $2
+		ORDER BY created_at ASC
+	`, t.ID, req.Bucket)
+	if err != nil {
+		s.logger.Error("query bucket notifications", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	topicMap := make(map[string]*TopicConfiguration)
+	var topicOrder []string
+
+	for rows.Next() {
+		var id, eventFilter, targetURL string
+		if err := rows.Scan(&id, &eventFilter, &targetURL); err != nil {
+			s.logger.Error("scan notification row", zap.Error(err))
+			continue
+		}
+		key := targetURL
+		tc, ok := topicMap[key]
+		if !ok {
+			tc = &TopicConfiguration{
+				ID:    id,
+				Topic: targetURL,
+			}
+			topicMap[key] = tc
+			topicOrder = append(topicOrder, key)
+		}
+		tc.Events = append(tc.Events, eventFilter)
+	}
+	if err := rows.Err(); err != nil {
+		s.logger.Error("notification rows iteration", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	resp := NotificationConfiguration{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+	}
+	for _, key := range topicOrder {
+		resp.Topics = append(resp.Topics, *topicMap[key])
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutBucketNotification(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxNotificationBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config NotificationConfiguration
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		s.logger.Error("begin tx for notification config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(r.Context(),
+		`DELETE FROM bucket_notifications WHERE tenant_id = $1 AND bucket = $2`,
+		t.ID, req.Bucket)
+	if err != nil {
+		s.logger.Error("clear notification config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	for _, tc := range config.Topics {
+		if tc.Topic == "" || len(tc.Events) == 0 {
+			continue
+		}
+		for _, event := range tc.Events {
+			if !isValidS3EventFilter(event) {
+				WriteS3Error(w, ErrInvalidRequest, r.URL.Path, generateRequestID())
+				return
+			}
+			_, err = tx.ExecContext(r.Context(), `
+				INSERT INTO bucket_notifications (tenant_id, bucket, event_filter, target_type, target_url)
+				VALUES ($1, $2, $3, 'webhook', $4)
+			`, t.ID, req.Bucket, event, tc.Topic)
+			if err != nil {
+				s.logger.Error("insert notification config", zap.Error(err))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logger.Error("commit notification config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("bucket notification config updated",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.Int("topics", len(config.Topics)))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func isValidS3EventFilter(event string) bool {
+	valid := []string{
+		"s3:ObjectCreated:*",
+		"s3:ObjectCreated:Put",
+		"s3:ObjectCreated:Post",
+		"s3:ObjectCreated:Copy",
+		"s3:ObjectCreated:CompleteMultipartUpload",
+		"s3:ObjectRemoved:*",
+		"s3:ObjectRemoved:Delete",
+		"s3:ObjectRemoved:DeleteMarkerCreated",
+		"s3:*",
+	}
+	for _, v := range valid {
+		if event == v {
+			return true
+		}
+	}
+	return false
+}
+
+// NotificationDispatcher fires S3 event notifications asynchronously.
+type NotificationDispatcher struct {
+	db     *sql.DB
+	logger *zap.Logger
+	client *http.Client
+}
+
+func NewNotificationDispatcher(db *sql.DB, logger *zap.Logger) *NotificationDispatcher {
+	if db == nil {
+		return nil
+	}
+	return &NotificationDispatcher{
+		db:     db,
+		logger: logger,
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// S3Event is the S3-compatible notification payload.
+type S3Event struct {
+	Records []S3EventRecord `json:"Records"`
+}
+
+type S3EventRecord struct {
+	EventVersion string          `json:"eventVersion"`
+	EventSource  string          `json:"eventSource"`
+	EventName    string          `json:"eventName"`
+	EventTime    string          `json:"eventTime"`
+	S3           S3EventS3       `json:"s3"`
+	UserIdentity S3EventIdentity `json:"userIdentity"`
+}
+
+type S3EventS3 struct {
+	Bucket S3EventBucket `json:"bucket"`
+	Object S3EventObject `json:"object"`
+}
+
+type S3EventBucket struct {
+	Name string `json:"name"`
+}
+
+type S3EventObject struct {
+	Key  string `json:"key"`
+	Size int64  `json:"size,omitempty"`
+	ETag string `json:"eTag,omitempty"`
+}
+
+type S3EventIdentity struct {
+	PrincipalID string `json:"principalId"`
+}
+
+// Fire dispatches a notification event asynchronously.
+func (d *NotificationDispatcher) Fire(tenantID, bucket, eventName, objectKey string, size int64, etag string) {
+	if d == nil {
+		return
+	}
+
+	go d.dispatch(tenantID, bucket, eventName, objectKey, size, etag)
+}
+
+func (d *NotificationDispatcher) dispatch(tenantID, bucket, eventName, objectKey string, size int64, etag string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT target_url, event_filter
+		FROM bucket_notifications
+		WHERE tenant_id = $1 AND bucket = $2 AND enabled = TRUE
+	`, tenantID, bucket)
+	if err != nil {
+		d.logger.Error("query notifications for dispatch",
+			zap.Error(err),
+			zap.String("tenant_id", tenantID),
+			zap.String("bucket", bucket))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type target struct {
+		url    string
+		filter string
+	}
+	var targets []target
+	for rows.Next() {
+		var t target
+		if err := rows.Scan(&t.url, &t.filter); err != nil {
+			d.logger.Error("scan notification target", zap.Error(err))
+			continue
+		}
+		targets = append(targets, t)
+	}
+
+	payload := S3Event{
+		Records: []S3EventRecord{{
+			EventVersion: "2.1",
+			EventSource:  "stored.ge",
+			EventName:    eventName,
+			EventTime:    time.Now().UTC().Format(time.RFC3339),
+			S3: S3EventS3{
+				Bucket: S3EventBucket{Name: bucket},
+				Object: S3EventObject{Key: objectKey, Size: size, ETag: etag},
+			},
+			UserIdentity: S3EventIdentity{PrincipalID: tenantID},
+		}},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		d.logger.Error("marshal notification payload", zap.Error(err))
+		return
+	}
+
+	for _, t := range targets {
+		if !matchesEventFilter(t.filter, eventName) {
+			continue
+		}
+		d.deliver(ctx, t.url, body, eventName)
+	}
+}
+
+func matchesEventFilter(filter, eventName string) bool {
+	if filter == "s3:*" {
+		return true
+	}
+	if filter == eventName {
+		return true
+	}
+	if strings.HasSuffix(filter, ":*") {
+		prefix := strings.TrimSuffix(filter, ":*")
+		if strings.HasPrefix(eventName, prefix+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *NotificationDispatcher) deliver(ctx context.Context, url string, body []byte, eventName string) {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		d.logger.Error("create notification request",
+			zap.Error(err),
+			zap.String("url", url))
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-S3-Event", eventName)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		d.logger.Warn("notification delivery failed",
+			zap.Error(err),
+			zap.String("url", url),
+			zap.String("event", eventName))
+		return
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		d.logger.Debug("notification delivered",
+			zap.String("url", url),
+			zap.String("event", eventName),
+			zap.Int("status", resp.StatusCode))
+	} else {
+		d.logger.Warn("notification delivery non-2xx",
+			zap.String("url", url),
+			zap.String("event", eventName),
+			zap.Int("status", resp.StatusCode))
+	}
+}
+
+// FireSync dispatches a notification event synchronously (for testing).
+func (d *NotificationDispatcher) FireSync(tenantID, bucket, eventName, objectKey string, size int64, etag string) {
+	if d == nil {
+		return
+	}
+	d.dispatch(tenantID, bucket, eventName, objectKey, size, etag)
+}
+
+// SetHTTPClient replaces the HTTP client (for testing).
+func (d *NotificationDispatcher) SetHTTPClient(c *http.Client) {
+	if d == nil {
+		return
+	}
+	d.client = c
+}

--- a/internal/api/s3_notifications_test.go
+++ b/internal/api/s3_notifications_test.go
@@ -1,0 +1,474 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type notificationFixture struct {
+	server   *Server
+	adapter  *S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	tenantID string
+	tenant   *tenant.Tenant
+	tempDir  string
+	bucket   string
+}
+
+func setupNotificationFixture(t *testing.T) *notificationFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-notif-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("notif-%d", os.Getpid())
+	bucket := "notif-bucket"
+	email := fmt.Sprintf("notif-%d@test.local", os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Notification Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, $2, 'private')
+		ON CONFLICT (tenant_id, name) DO NOTHING
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM bucket_notifications WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tn.NamespaceContainer(bucket)
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+
+	return &notificationFixture{
+		server:   srv,
+		adapter:  NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		tenantID: tenantID,
+		tenant:   tn,
+		tempDir:  tempDir,
+		bucket:   bucket,
+	}
+}
+
+func TestNotification_PutGetConfig(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	// PUT notification config
+	configXML := `<?xml version="1.0" encoding="UTF-8"?>
+<NotificationConfiguration>
+  <TopicConfiguration>
+    <Id>config1</Id>
+    <Topic>https://example.com/webhook</Topic>
+    <Event>s3:ObjectCreated:*</Event>
+    <Event>s3:ObjectRemoved:*</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code, "PUT notification should succeed")
+
+	// GET notification config
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?notification", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w = httptest.NewRecorder()
+	f.server.handleGetBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code, "GET notification should succeed")
+
+	var got NotificationConfiguration
+	body, _ := io.ReadAll(w.Body)
+	err := xml.Unmarshal(body, &got)
+	require.NoError(t, err)
+
+	require.Len(t, got.Topics, 1)
+	assert.Equal(t, "https://example.com/webhook", got.Topics[0].Topic)
+	assert.Contains(t, got.Topics[0].Events, "s3:ObjectCreated:*")
+	assert.Contains(t, got.Topics[0].Events, "s3:ObjectRemoved:*")
+}
+
+func TestNotification_ClearConfig(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	// PUT a config first
+	configXML := `<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>https://example.com/hook</Topic>
+    <Event>s3:ObjectCreated:Put</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Now clear it with empty config
+	emptyXML := `<NotificationConfiguration/>`
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(emptyXML)))
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// GET should return empty config
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?notification", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got NotificationConfiguration
+	body, _ := io.ReadAll(w.Body)
+	err := xml.Unmarshal(body, &got)
+	require.NoError(t, err)
+	assert.Empty(t, got.Topics)
+}
+
+func TestNotification_EventFired(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	// Set up a test webhook server to receive events
+	var mu sync.Mutex
+	var received []S3Event
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event S3Event
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &event); err == nil {
+			mu.Lock()
+			received = append(received, event)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	// Configure notification to point at our test server
+	configXML := fmt.Sprintf(`<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>%s</Topic>
+    <Event>s3:ObjectCreated:*</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`, webhookSrv.URL)
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// PUT an object — should trigger notification
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"/test-file.txt", bytes.NewReader([]byte("hello world")))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+
+	// Use FireSync for deterministic testing
+	dispatcher := NewNotificationDispatcher(f.db, zap.NewNop())
+	f.adapter.notifySvc = dispatcher
+	f.adapter.HandlePut(w, req, f.bucket, "test-file.txt")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// The Fire call is async — use FireSync to verify
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectCreated:Put", "test-file.txt", 11, "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(received), 1, "webhook should receive at least one event")
+
+	event := received[len(received)-1]
+	require.Len(t, event.Records, 1)
+	assert.Equal(t, "s3:ObjectCreated:Put", event.Records[0].EventName)
+	assert.Equal(t, f.bucket, event.Records[0].S3.Bucket.Name)
+	assert.Equal(t, "test-file.txt", event.Records[0].S3.Object.Key)
+	assert.Equal(t, f.tenantID, event.Records[0].UserIdentity.PrincipalID)
+	assert.Equal(t, "stored.ge", event.Records[0].EventSource)
+}
+
+func TestNotification_WildcardMatch(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	var mu sync.Mutex
+	var eventNames []string
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event S3Event
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &event); err == nil && len(event.Records) > 0 {
+			mu.Lock()
+			eventNames = append(eventNames, event.Records[0].EventName)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	// Configure with wildcard filter
+	configXML := fmt.Sprintf(`<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>%s</Topic>
+    <Event>s3:ObjectCreated:*</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`, webhookSrv.URL)
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	dispatcher := NewNotificationDispatcher(f.db, zap.NewNop())
+
+	// Fire Put event — should match wildcard
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectCreated:Put", "file1.txt", 100, "abc")
+
+	// Fire Copy event — should also match wildcard
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectCreated:Copy", "file2.txt", 200, "def")
+
+	// Fire Delete event — should NOT match s3:ObjectCreated:*
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectRemoved:Delete", "file3.txt", 0, "")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Len(t, eventNames, 2, "wildcard should match Put and Copy but not Delete")
+	assert.Contains(t, eventNames, "s3:ObjectCreated:Put")
+	assert.Contains(t, eventNames, "s3:ObjectCreated:Copy")
+}
+
+func TestNotification_DeleteEventFired(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	var mu sync.Mutex
+	var received []S3Event
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event S3Event
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &event); err == nil {
+			mu.Lock()
+			received = append(received, event)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	// Configure notification for delete events
+	configXML := fmt.Sprintf(`<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>%s</Topic>
+    <Event>s3:ObjectRemoved:*</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`, webhookSrv.URL)
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// PUT an object first
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"/delete-me.txt", bytes.NewReader([]byte("data")))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, f.bucket, "delete-me.txt")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// DELETE the object — use sync dispatcher
+	dispatcher := NewNotificationDispatcher(f.db, zap.NewNop())
+	f.adapter.notifySvc = dispatcher
+
+	req = httptest.NewRequest("DELETE", "/"+f.bucket+"/delete-me.txt", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.adapter.HandleDelete(w, req, f.bucket, "delete-me.txt")
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	// Fire is async; call sync to verify
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectRemoved:Delete", "delete-me.txt", 0, "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(received), 1, "webhook should receive delete event")
+
+	event := received[len(received)-1]
+	require.Len(t, event.Records, 1)
+	assert.Equal(t, "s3:ObjectRemoved:Delete", event.Records[0].EventName)
+	assert.Equal(t, f.bucket, event.Records[0].S3.Bucket.Name)
+	assert.Equal(t, "delete-me.txt", event.Records[0].S3.Object.Key)
+}
+
+func TestNotification_DisabledNotDelivered(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	var mu sync.Mutex
+	var received []S3Event
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event S3Event
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &event); err == nil {
+			mu.Lock()
+			received = append(received, event)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	// Configure notification
+	configXML := fmt.Sprintf(`<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>%s</Topic>
+    <Event>s3:ObjectCreated:Put</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`, webhookSrv.URL)
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Disable all notifications for this bucket
+	_, err := f.db.Exec(`UPDATE bucket_notifications SET enabled = FALSE WHERE tenant_id = $1 AND bucket = $2`,
+		f.tenantID, f.bucket)
+	require.NoError(t, err)
+
+	// Fire event — should NOT be delivered
+	dispatcher := NewNotificationDispatcher(f.db, zap.NewNop())
+	dispatcher.FireSync(f.tenantID, f.bucket, "s3:ObjectCreated:Put", "file.txt", 100, "abc")
+
+	// Small sleep to ensure nothing arrives
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, received, "disabled notifications should not be delivered")
+}
+
+func TestNotification_EventFilterMatch(t *testing.T) {
+	tests := []struct {
+		filter    string
+		eventName string
+		want      bool
+	}{
+		{"s3:ObjectCreated:*", "s3:ObjectCreated:Put", true},
+		{"s3:ObjectCreated:*", "s3:ObjectCreated:Copy", true},
+		{"s3:ObjectCreated:*", "s3:ObjectCreated:CompleteMultipartUpload", true},
+		{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete", false},
+		{"s3:ObjectRemoved:*", "s3:ObjectRemoved:Delete", true},
+		{"s3:ObjectRemoved:*", "s3:ObjectCreated:Put", false},
+		{"s3:ObjectCreated:Put", "s3:ObjectCreated:Put", true},
+		{"s3:ObjectCreated:Put", "s3:ObjectCreated:Copy", false},
+		{"s3:*", "s3:ObjectCreated:Put", true},
+		{"s3:*", "s3:ObjectRemoved:Delete", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s_%s", tc.filter, tc.eventName), func(t *testing.T) {
+			got := matchesEventFilter(tc.filter, tc.eventName)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNotification_InvalidEventFilter(t *testing.T) {
+	f := setupNotificationFixture(t)
+
+	configXML := `<NotificationConfiguration>
+  <TopicConfiguration>
+    <Topic>https://example.com/webhook</Topic>
+    <Event>invalid:Event:Type</Event>
+  </TopicConfiguration>
+</NotificationConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?notification", bytes.NewReader([]byte(configXML)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketNotification(w, req, &S3Request{Bucket: f.bucket, TenantID: f.tenantID})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "invalid event filter should be rejected")
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -18,6 +18,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 024 | Multipart uploads |
 | 025 | Bucket registry: `buckets` table, tenant `slug`+`slug_locked` columns, `backend_name` on `object_head_cache` |
 | 026 | S3 versioning: `versioning_status` on `buckets`, `object_versions` table |
+| 027 | Bucket notifications: `bucket_notifications` table for S3 event webhook config |
 
 ## Key Tables
 
@@ -33,6 +34,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`
+- **bucket_notifications** — `id (PK)`, `tenant_id`, `bucket`, `event_filter`, `target_type`, `target_url`, `enabled`, `created_at` — S3 event notification webhook config
 
 ## Connection
 

--- a/internal/database/migrations/027_bucket_notifications.sql
+++ b/internal/database/migrations/027_bucket_notifications.sql
@@ -1,0 +1,18 @@
+-- 027_bucket_notifications.sql
+-- Phase 5.10.12: S3 bucket notification configuration
+-- Idempotent — safe to re-run on every deploy
+
+CREATE TABLE IF NOT EXISTS bucket_notifications (
+    id              TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+    tenant_id       TEXT NOT NULL,
+    bucket          TEXT NOT NULL,
+    event_filter    TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_url      TEXT NOT NULL,
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bucket_notif_lookup
+    ON bucket_notifications(tenant_id, bucket) WHERE enabled = TRUE;


### PR DESCRIPTION
## Summary
- S3-compatible bucket notification configuration via `PUT/GET /{bucket}?notification` using `<NotificationConfiguration>` XML
- Async webhook delivery for object events: `s3:ObjectCreated:Put`, `s3:ObjectCreated:Copy`, `s3:ObjectCreated:CompleteMultipartUpload`, `s3:ObjectRemoved:Delete`
- Wildcard event matching (`s3:ObjectCreated:*`, `s3:*`) with 5-second timeout, fire-and-forget goroutine — never blocks S3 responses
- Migration 027 adds `bucket_notifications` table with tenant+bucket index on enabled rows

## Test plan
- [ ] `TestNotification_PutGetConfig` — PUT notification config, GET returns it as XML
- [ ] `TestNotification_ClearConfig` — PUT empty `<NotificationConfiguration/>` clears all notifications
- [ ] `TestNotification_EventFired` — PUT object with notification configured, verify webhook receives S3-format event
- [ ] `TestNotification_WildcardMatch` — `s3:ObjectCreated:*` matches Put and Copy but not Delete
- [ ] `TestNotification_DeleteEventFired` — DELETE fires `s3:ObjectRemoved:Delete` event
- [ ] `TestNotification_DisabledNotDelivered` — disabled notification rows are not delivered
- [ ] `TestNotification_EventFilterMatch` — unit tests for all filter/event combinations
- [ ] `TestNotification_InvalidEventFilter` — invalid event filter rejected with 400