### PR TITLE
feat(s3): object lock with GOVERNANCE/COMPLIANCE retention and legal hold [Phase 5.10.13]

### DIFF
--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -118,6 +118,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 				req.Operation = "GetBucketVersioning"
 			} else if _, ok := req.Query["notification"]; ok {
 				req.Operation = "GetBucketNotification"
+			} else if _, ok := req.Query["object-lock"]; ok {
+				req.Operation = "GetObjectLockConfiguration"
 			} else if _, ok := req.Query["uploads"]; ok {
 				req.Operation = "ListMultipartUploads"
 			} else {
@@ -128,6 +130,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 				req.Operation = "PutBucketVersioning"
 			} else if _, ok := req.Query["notification"]; ok {
 				req.Operation = "PutBucketNotification"
+			} else if _, ok := req.Query["object-lock"]; ok {
+				req.Operation = "PutObjectLockConfiguration"
 			} else {
 				req.Operation = "CreateBucket"
 			}
@@ -149,13 +153,21 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 
 	switch method {
 	case "GET":
-		if _, ok := req.Query["uploadId"]; ok {
+		if _, ok := req.Query["retention"]; ok {
+			req.Operation = "GetObjectRetention"
+		} else if _, ok := req.Query["legal-hold"]; ok {
+			req.Operation = "GetObjectLegalHold"
+		} else if _, ok := req.Query["uploadId"]; ok {
 			req.Operation = "ListParts"
 		} else {
 			req.Operation = "GetObject"
 		}
 	case "PUT":
-		if _, ok := req.Query["partNumber"]; ok {
+		if _, ok := req.Query["retention"]; ok {
+			req.Operation = "PutObjectRetention"
+		} else if _, ok := req.Query["legal-hold"]; ok {
+			req.Operation = "PutObjectLegalHold"
+		} else if _, ok := req.Query["partNumber"]; ok {
 			req.Operation = "UploadPart"
 		} else {
 			req.Operation = "PutObject"
@@ -414,6 +426,18 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleGetBucketNotification(cw, r, s3Req)
 	case "PutBucketNotification":
 		s.handlePutBucketNotification(cw, r, s3Req)
+	case "GetObjectLockConfiguration":
+		s.handleGetObjectLockConfiguration(cw, r, s3Req)
+	case "PutObjectLockConfiguration":
+		s.handlePutObjectLockConfiguration(cw, r, s3Req)
+	case "GetObjectRetention":
+		s.handleGetObjectRetention(cw, r, s3Req)
+	case "PutObjectRetention":
+		s.handlePutObjectRetention(cw, r, s3Req)
+	case "GetObjectLegalHold":
+		s.handleGetObjectLegalHold(cw, r, s3Req)
+	case "PutObjectLegalHold":
+		s.handlePutObjectLegalHold(cw, r, s3Req)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))

--- a/internal/api/s3_batch.go
+++ b/internal/api/s3_batch.go
@@ -112,6 +112,15 @@ func (s *Server) handleDeleteObjects(w http.ResponseWriter, r *http.Request, req
 			continue
 		}
 
+		if lockErr := checkObjectLock(r.Context(), s.db, t.ID, bucket, key, isObjectLockBypass(r)); lockErr != nil {
+			result.Errors = append(result.Errors, DeleteError{
+				Key:     key,
+				Code:    ErrObjectLocked,
+				Message: errorMessages[ErrObjectLocked],
+			})
+			continue
+		}
+
 		delErr := s.engine.Delete(r.Context(), container, key)
 		isMissing := delErr != nil && (strings.Contains(delErr.Error(), "no such file or directory") ||
 			strings.Contains(delErr.Error(), "not found"))

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -357,15 +357,21 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		size = 0
 	}
 
-	if r.Header.Get("If-Match") != "" && a.db != nil {
-		var currentETag string
-		err := a.db.QueryRowContext(r.Context(), `
+	if a.db != nil {
+		var existingETag string
+		existsErr := a.db.QueryRowContext(r.Context(), `
 			SELECT etag FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&currentETag)
-		if err == nil && checkIfMatch(r, currentETag) {
-			w.WriteHeader(http.StatusPreconditionFailed)
-			return
+			t.ID, bucket, artifact).Scan(&existingETag)
+		if existsErr == nil {
+			if lockErr := checkObjectLock(r.Context(), a.db, t.ID, bucket, artifact, isObjectLockBypass(r)); lockErr != nil {
+				WriteS3Error(w, ErrObjectLocked, r.URL.Path, generateRequestID())
+				return
+			}
+			if r.Header.Get("If-Match") != "" && checkIfMatch(r, existingETag) {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
 		}
 	}
 
@@ -450,6 +456,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 				is_delete_marker = FALSE, backend_name = EXCLUDED.backend_name`,
 			t.ID, bucket, artifact, versionID, size, etag, contentType, backendName)
 	}
+
+	applyObjectLockOnPut(r.Context(), a.db, t.ID, bucket, artifact, r)
 
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
 	w.Header().Set("x-amz-request-id", generateRequestID())
@@ -545,6 +553,11 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 		w.Header().Set("x-amz-delete-marker", "true")
 		w.WriteHeader(http.StatusNoContent)
 		a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
+		return
+	}
+
+	if lockErr := checkObjectLock(r.Context(), a.db, t.ID, bucket, object, isObjectLockBypass(r)); lockErr != nil {
+		WriteS3Error(w, ErrObjectLocked, r.URL.Path, generateRequestID())
 		return
 	}
 

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -18,92 +18,98 @@ type S3Error struct {
 
 // S3 Error codes
 const (
-	ErrNoSuchBucket          = "NoSuchBucket"
-	ErrNoSuchKey             = "NoSuchKey"
-	ErrBucketAlreadyExists   = "BucketAlreadyExists"
-	ErrBucketNotEmpty        = "BucketNotEmpty"
-	ErrInvalidBucketName     = "InvalidBucketName"
-	ErrInvalidObjectName     = "InvalidObjectName"
-	ErrAccessDenied          = "AccessDenied"
-	ErrInvalidRequest        = "InvalidRequest"
-	ErrIncompleteBody        = "IncompleteBody"
-	ErrInternalError         = "InternalError"
-	ErrNotImplemented        = "NotImplemented"
-	ErrMissingContentLength  = "MissingContentLength"
-	ErrRequestTimeout        = "RequestTimeout"
-	ErrBadDigest             = "BadDigest"
-	ErrEntityTooLarge        = "EntityTooLarge"
-	ErrMalformedXML          = "MalformedXML"
-	ErrMethodNotAllowed      = "MethodNotAllowed"
-	ErrSignatureDoesNotMatch = "SignatureDoesNotMatch"
-	ErrAccountSuspended      = "AccountSuspended"
-	ErrSlowDown              = "SlowDown"
-	ErrNoSuchUpload          = "NoSuchUpload"
-	ErrInvalidPart           = "InvalidPart"
-	ErrInvalidPartOrder      = "InvalidPartOrder"
-	ErrEntityTooSmall        = "EntityTooSmall"
-	ErrInvalidPartNumber     = "InvalidPartNumber"
-	ErrNoSuchVersion         = "NoSuchVersion"
+	ErrNoSuchBucket           = "NoSuchBucket"
+	ErrNoSuchKey              = "NoSuchKey"
+	ErrBucketAlreadyExists    = "BucketAlreadyExists"
+	ErrBucketNotEmpty         = "BucketNotEmpty"
+	ErrInvalidBucketName      = "InvalidBucketName"
+	ErrInvalidObjectName      = "InvalidObjectName"
+	ErrAccessDenied           = "AccessDenied"
+	ErrInvalidRequest         = "InvalidRequest"
+	ErrIncompleteBody         = "IncompleteBody"
+	ErrInternalError          = "InternalError"
+	ErrNotImplemented         = "NotImplemented"
+	ErrMissingContentLength   = "MissingContentLength"
+	ErrRequestTimeout         = "RequestTimeout"
+	ErrBadDigest              = "BadDigest"
+	ErrEntityTooLarge         = "EntityTooLarge"
+	ErrMalformedXML           = "MalformedXML"
+	ErrMethodNotAllowed       = "MethodNotAllowed"
+	ErrSignatureDoesNotMatch  = "SignatureDoesNotMatch"
+	ErrAccountSuspended       = "AccountSuspended"
+	ErrSlowDown               = "SlowDown"
+	ErrNoSuchUpload           = "NoSuchUpload"
+	ErrInvalidPart            = "InvalidPart"
+	ErrInvalidPartOrder       = "InvalidPartOrder"
+	ErrEntityTooSmall         = "EntityTooSmall"
+	ErrInvalidPartNumber      = "InvalidPartNumber"
+	ErrNoSuchVersion          = "NoSuchVersion"
+	ErrObjectLocked           = "ObjectLocked"
+	ErrInvalidRetentionPeriod = "InvalidRetentionPeriod"
 )
 
 // Error messages
 var errorMessages = map[string]string{
-	ErrNoSuchBucket:          "The specified bucket does not exist",
-	ErrNoSuchKey:             "The specified key does not exist",
-	ErrBucketAlreadyExists:   "The requested bucket name is not available",
-	ErrBucketNotEmpty:        "The bucket you tried to delete is not empty",
-	ErrInvalidBucketName:     "The specified bucket is not valid",
-	ErrInvalidObjectName:     "The specified object name is not valid",
-	ErrAccessDenied:          "Access denied",
-	ErrInvalidRequest:        "Invalid request",
-	ErrIncompleteBody:        "You did not provide the number of bytes specified by the Content-Length HTTP header",
-	ErrInternalError:         "We encountered an internal error. Please try again",
-	ErrNotImplemented:        "A feature you requested is not yet implemented",
-	ErrMissingContentLength:  "You must provide the Content-Length HTTP header",
-	ErrRequestTimeout:        "Your socket connection to the server was not read from or written to within the timeout period",
-	ErrBadDigest:             "The Content-MD5 you specified did not match what we received",
-	ErrEntityTooLarge:        "Your proposed upload exceeds the maximum allowed size",
-	ErrMalformedXML:          "The XML you provided was not well-formed or did not validate against our published schema",
-	ErrMethodNotAllowed:      "The specified method is not allowed against this resource",
-	ErrSignatureDoesNotMatch: "The request signature we calculated does not match the signature you provided",
-	ErrAccountSuspended:      "Your account has been suspended. Contact support for assistance.",
-	ErrSlowDown:              "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
-	ErrNoSuchUpload:          "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
-	ErrInvalidPart:           "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-	ErrInvalidPartOrder:      "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
-	ErrEntityTooSmall:        "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
-	ErrInvalidPartNumber:     "Part number must be an integer between 1 and 10000, inclusive.",
-	ErrNoSuchVersion:         "The version ID specified in the request does not match an existing version.",
+	ErrNoSuchBucket:           "The specified bucket does not exist",
+	ErrNoSuchKey:              "The specified key does not exist",
+	ErrBucketAlreadyExists:    "The requested bucket name is not available",
+	ErrBucketNotEmpty:         "The bucket you tried to delete is not empty",
+	ErrInvalidBucketName:      "The specified bucket is not valid",
+	ErrInvalidObjectName:      "The specified object name is not valid",
+	ErrAccessDenied:           "Access denied",
+	ErrInvalidRequest:         "Invalid request",
+	ErrIncompleteBody:         "You did not provide the number of bytes specified by the Content-Length HTTP header",
+	ErrInternalError:          "We encountered an internal error. Please try again",
+	ErrNotImplemented:         "A feature you requested is not yet implemented",
+	ErrMissingContentLength:   "You must provide the Content-Length HTTP header",
+	ErrRequestTimeout:         "Your socket connection to the server was not read from or written to within the timeout period",
+	ErrBadDigest:              "The Content-MD5 you specified did not match what we received",
+	ErrEntityTooLarge:         "Your proposed upload exceeds the maximum allowed size",
+	ErrMalformedXML:           "The XML you provided was not well-formed or did not validate against our published schema",
+	ErrMethodNotAllowed:       "The specified method is not allowed against this resource",
+	ErrSignatureDoesNotMatch:  "The request signature we calculated does not match the signature you provided",
+	ErrAccountSuspended:       "Your account has been suspended. Contact support for assistance.",
+	ErrSlowDown:               "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
+	ErrNoSuchUpload:           "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+	ErrInvalidPart:            "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+	ErrInvalidPartOrder:       "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+	ErrEntityTooSmall:         "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
+	ErrInvalidPartNumber:      "Part number must be an integer between 1 and 10000, inclusive.",
+	ErrNoSuchVersion:          "The version ID specified in the request does not match an existing version.",
+	ErrObjectLocked:           "Object is protected by Object Lock",
+	ErrInvalidRetentionPeriod: "The retention period specified is not valid",
 }
 
 // HTTP status codes for errors
 var errorStatusCodes = map[string]int{
-	ErrNoSuchBucket:          http.StatusNotFound,
-	ErrNoSuchKey:             http.StatusNotFound,
-	ErrBucketAlreadyExists:   http.StatusConflict,
-	ErrBucketNotEmpty:        http.StatusConflict,
-	ErrInvalidBucketName:     http.StatusBadRequest,
-	ErrInvalidObjectName:     http.StatusBadRequest,
-	ErrAccessDenied:          http.StatusForbidden,
-	ErrInvalidRequest:        http.StatusBadRequest,
-	ErrIncompleteBody:        http.StatusBadRequest,
-	ErrInternalError:         http.StatusInternalServerError,
-	ErrNotImplemented:        http.StatusNotImplemented,
-	ErrMissingContentLength:  http.StatusLengthRequired,
-	ErrRequestTimeout:        http.StatusRequestTimeout,
-	ErrBadDigest:             http.StatusBadRequest,
-	ErrEntityTooLarge:        http.StatusRequestEntityTooLarge,
-	ErrMalformedXML:          http.StatusBadRequest,
-	ErrMethodNotAllowed:      http.StatusMethodNotAllowed,
-	ErrSignatureDoesNotMatch: http.StatusForbidden,
-	ErrAccountSuspended:      http.StatusForbidden,
-	ErrSlowDown:              http.StatusTooManyRequests,
-	ErrNoSuchUpload:          http.StatusNotFound,
-	ErrInvalidPart:           http.StatusBadRequest,
-	ErrInvalidPartOrder:      http.StatusBadRequest,
-	ErrEntityTooSmall:        http.StatusBadRequest,
-	ErrInvalidPartNumber:     http.StatusBadRequest,
-	ErrNoSuchVersion:         http.StatusNotFound,
+	ErrNoSuchBucket:           http.StatusNotFound,
+	ErrNoSuchKey:              http.StatusNotFound,
+	ErrBucketAlreadyExists:    http.StatusConflict,
+	ErrBucketNotEmpty:         http.StatusConflict,
+	ErrInvalidBucketName:      http.StatusBadRequest,
+	ErrInvalidObjectName:      http.StatusBadRequest,
+	ErrAccessDenied:           http.StatusForbidden,
+	ErrInvalidRequest:         http.StatusBadRequest,
+	ErrIncompleteBody:         http.StatusBadRequest,
+	ErrInternalError:          http.StatusInternalServerError,
+	ErrNotImplemented:         http.StatusNotImplemented,
+	ErrMissingContentLength:   http.StatusLengthRequired,
+	ErrRequestTimeout:         http.StatusRequestTimeout,
+	ErrBadDigest:              http.StatusBadRequest,
+	ErrEntityTooLarge:         http.StatusRequestEntityTooLarge,
+	ErrMalformedXML:           http.StatusBadRequest,
+	ErrMethodNotAllowed:       http.StatusMethodNotAllowed,
+	ErrSignatureDoesNotMatch:  http.StatusForbidden,
+	ErrAccountSuspended:       http.StatusForbidden,
+	ErrSlowDown:               http.StatusTooManyRequests,
+	ErrNoSuchUpload:           http.StatusNotFound,
+	ErrInvalidPart:            http.StatusBadRequest,
+	ErrInvalidPartOrder:       http.StatusBadRequest,
+	ErrEntityTooSmall:         http.StatusBadRequest,
+	ErrInvalidPartNumber:      http.StatusBadRequest,
+	ErrNoSuchVersion:          http.StatusNotFound,
+	ErrObjectLocked:           http.StatusForbidden,
+	ErrInvalidRetentionPeriod: http.StatusBadRequest,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_lock.go
+++ b/internal/api/s3_lock.go
@@ -1,0 +1,480 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const maxLockBodyBytes = 8192
+
+// XML types for Object Lock configuration
+
+type ObjectLockConfiguration struct {
+	XMLName           xml.Name        `xml:"ObjectLockConfiguration"`
+	Xmlns             string          `xml:"xmlns,attr,omitempty"`
+	ObjectLockEnabled string          `xml:"ObjectLockEnabled,omitempty"`
+	Rule              *ObjectLockRule `xml:"Rule,omitempty"`
+}
+
+type ObjectLockRule struct {
+	DefaultRetention *DefaultRetention `xml:"DefaultRetention"`
+}
+
+type DefaultRetention struct {
+	Mode string `xml:"Mode"`
+	Days int    `xml:"Days,omitempty"`
+}
+
+// XML types for per-object retention
+
+type RetentionConfig struct {
+	XMLName         xml.Name `xml:"Retention"`
+	Xmlns           string   `xml:"xmlns,attr,omitempty"`
+	Mode            string   `xml:"Mode,omitempty"`
+	RetainUntilDate string   `xml:"RetainUntilDate,omitempty"`
+}
+
+// XML types for per-object legal hold
+
+type LegalHoldConfig struct {
+	XMLName xml.Name `xml:"LegalHold"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Status  string   `xml:"Status"`
+}
+
+// --- Bucket-level Object Lock ---
+
+func (s *Server) handleGetObjectLockConfiguration(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	resp := ObjectLockConfiguration{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+	}
+
+	if s.db != nil {
+		var enabled bool
+		var mode string
+		var days int
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT object_lock_enabled, default_retention_mode, default_retention_days
+			 FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&enabled, &mode, &days)
+		if err == sql.ErrNoRows {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+			return
+		}
+		if err != nil {
+			s.logger.Error("query object lock config", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+
+		if enabled {
+			resp.ObjectLockEnabled = "Enabled"
+		}
+		if mode != "" && days > 0 {
+			resp.Rule = &ObjectLockRule{
+				DefaultRetention: &DefaultRetention{
+					Mode: mode,
+					Days: days,
+				},
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutObjectLockConfiguration(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLockBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config ObjectLockConfiguration
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	enabled := config.ObjectLockEnabled == "Enabled"
+	mode := ""
+	days := 0
+
+	if config.Rule != nil && config.Rule.DefaultRetention != nil {
+		dr := config.Rule.DefaultRetention
+		if dr.Mode != "GOVERNANCE" && dr.Mode != "COMPLIANCE" {
+			WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+			return
+		}
+		if dr.Days <= 0 {
+			WriteS3Error(w, ErrInvalidRetentionPeriod, r.URL.Path, generateRequestID())
+			return
+		}
+		mode = dr.Mode
+		days = dr.Days
+	}
+
+	result, err := s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET object_lock_enabled = $1, default_retention_mode = $2,
+		 default_retention_days = $3, updated_at = NOW()
+		 WHERE tenant_id = $4 AND name = $5`,
+		enabled, mode, days, t.ID, req.Bucket)
+	if err != nil {
+		s.logger.Error("update object lock config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("object lock config updated",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.Bool("enabled", enabled),
+		zap.String("mode", mode),
+		zap.Int("days", days))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Per-object retention ---
+
+func (s *Server) handleGetObjectRetention(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	resp := RetentionConfig{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+	}
+
+	if s.db != nil {
+		var mode string
+		var retainUntil sql.NullTime
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT retention_mode, retain_until_date FROM object_locks
+			 WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, req.Bucket, req.Object).Scan(&mode, &retainUntil)
+		if err == sql.ErrNoRows {
+			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, generateRequestID())
+			return
+		}
+		if err != nil {
+			s.logger.Error("query object retention", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		resp.Mode = mode
+		if retainUntil.Valid {
+			resp.RetainUntilDate = retainUntil.Time.UTC().Format(time.RFC3339)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutObjectRetention(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLockBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config RetentionConfig
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if config.Mode != "GOVERNANCE" && config.Mode != "COMPLIANCE" {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	retainUntil, err := time.Parse(time.RFC3339, config.RetainUntilDate)
+	if err != nil {
+		WriteS3Error(w, ErrInvalidRetentionPeriod, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if config.Mode == "COMPLIANCE" {
+		var existingMode string
+		var existingUntil sql.NullTime
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT retention_mode, retain_until_date FROM object_locks
+			 WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, req.Bucket, req.Object).Scan(&existingMode, &existingUntil)
+		if err == nil && existingMode == "COMPLIANCE" && existingUntil.Valid {
+			if retainUntil.Before(existingUntil.Time) {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+		}
+	}
+
+	_, err = s.db.ExecContext(r.Context(), `
+		INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			retention_mode = EXCLUDED.retention_mode,
+			retain_until_date = EXCLUDED.retain_until_date,
+			updated_at = NOW()
+	`, t.ID, req.Bucket, req.Object, config.Mode, retainUntil)
+	if err != nil {
+		s.logger.Error("upsert object retention", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("object retention set",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.String("object", req.Object),
+		zap.String("mode", config.Mode),
+		zap.Time("retain_until", retainUntil))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Per-object legal hold ---
+
+func (s *Server) handleGetObjectLegalHold(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	status := "OFF"
+	if s.db != nil {
+		var hold bool
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT legal_hold FROM object_locks
+			 WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, req.Bucket, req.Object).Scan(&hold)
+		if err == sql.ErrNoRows {
+			// No lock row — legal hold is OFF
+		} else if err != nil {
+			s.logger.Error("query legal hold", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		} else if hold {
+			status = "ON"
+		}
+	}
+
+	resp := LegalHoldConfig{
+		Xmlns:  "http://s3.amazonaws.com/doc/2006-03-01/",
+		Status: status,
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutObjectLegalHold(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLockBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config LegalHoldConfig
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if config.Status != "ON" && config.Status != "OFF" {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	hold := config.Status == "ON"
+
+	_, err = s.db.ExecContext(r.Context(), `
+		INSERT INTO object_locks (tenant_id, bucket, object_key, legal_hold, updated_at)
+		VALUES ($1, $2, $3, $4, NOW())
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			legal_hold = EXCLUDED.legal_hold,
+			updated_at = NOW()
+	`, t.ID, req.Bucket, req.Object, hold)
+	if err != nil {
+		s.logger.Error("upsert legal hold", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("legal hold updated",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.String("object", req.Object),
+		zap.String("status", config.Status))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Lock enforcement ---
+
+// checkObjectLock checks whether an object is protected by Object Lock.
+// Returns nil if the operation is allowed, or an error string if blocked.
+func checkObjectLock(ctx context.Context, db *sql.DB, tenantID, bucket, key string, bypassGovernance bool) error {
+	if db == nil {
+		return nil
+	}
+
+	var mode string
+	var retainUntil sql.NullTime
+	var hold bool
+	err := db.QueryRowContext(ctx,
+		`SELECT retention_mode, retain_until_date, legal_hold FROM object_locks
+		 WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		tenantID, bucket, key).Scan(&mode, &retainUntil, &hold)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if hold {
+		return errObjectLocked
+	}
+
+	if retainUntil.Valid && retainUntil.Time.After(time.Now()) {
+		switch mode {
+		case "COMPLIANCE":
+			return errObjectLocked
+		case "GOVERNANCE":
+			if !bypassGovernance {
+				return errObjectLocked
+			}
+		}
+	}
+
+	return nil
+}
+
+var errObjectLocked = &objectLockedError{}
+
+type objectLockedError struct{}
+
+func (e *objectLockedError) Error() string {
+	return "Object is protected by Object Lock"
+}
+
+// applyObjectLockOnPut applies lock headers or bucket defaults after a successful PUT.
+func applyObjectLockOnPut(ctx context.Context, db *sql.DB, tenantID, bucket, key string, r *http.Request) {
+	if db == nil {
+		return
+	}
+
+	lockMode := r.Header.Get("x-amz-object-lock-mode")
+	lockUntil := r.Header.Get("x-amz-object-lock-retain-until-date")
+
+	if lockMode != "" && lockUntil != "" {
+		if lockMode != "GOVERNANCE" && lockMode != "COMPLIANCE" {
+			return
+		}
+		retainUntil, err := time.Parse(time.RFC3339, lockUntil)
+		if err != nil {
+			return
+		}
+		_, _ = db.ExecContext(ctx, `
+			INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date, updated_at)
+			VALUES ($1, $2, $3, $4, $5, NOW())
+			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+				retention_mode = EXCLUDED.retention_mode,
+				retain_until_date = EXCLUDED.retain_until_date,
+				updated_at = NOW()
+		`, tenantID, bucket, key, lockMode, retainUntil)
+		return
+	}
+
+	var defaultMode string
+	var defaultDays int
+	err := db.QueryRowContext(ctx,
+		`SELECT default_retention_mode, default_retention_days FROM buckets
+		 WHERE tenant_id = $1 AND name = $2 AND object_lock_enabled = TRUE`,
+		tenantID, bucket).Scan(&defaultMode, &defaultDays)
+	if err != nil || defaultMode == "" || defaultDays <= 0 {
+		return
+	}
+
+	retainUntil := time.Now().Add(time.Duration(defaultDays) * 24 * time.Hour)
+	_, _ = db.ExecContext(ctx, `
+		INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			retention_mode = EXCLUDED.retention_mode,
+			retain_until_date = EXCLUDED.retain_until_date,
+			updated_at = NOW()
+	`, tenantID, bucket, key, defaultMode, retainUntil)
+}
+
+// isObjectLockBypass returns true if the bypass-governance-retention header is set.
+func isObjectLockBypass(r *http.Request) bool {
+	v := r.Header.Get("x-amz-bypass-governance-retention")
+	b, _ := strconv.ParseBool(v)
+	return b
+}

--- a/internal/api/s3_lock_test.go
+++ b/internal/api/s3_lock_test.go
@@ -1,0 +1,387 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type lockFixture struct {
+	server   *Server
+	adapter  *S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	tenantID string
+	tenant   *tenant.Tenant
+	tempDir  string
+	bucket   string
+}
+
+func setupLockFixture(t *testing.T) *lockFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-lock-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("lock-%s-%d", t.Name(), os.Getpid())
+	bucket := "lock-bucket"
+	email := fmt.Sprintf("lock-%s-%d@test.local", t.Name(), os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Lock Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, object_lock_enabled, default_retention_mode, default_retention_days)
+		VALUES ($1, $2, 'private', FALSE, '', 0)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
+			object_lock_enabled = FALSE, default_retention_mode = '', default_retention_days = 0
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_locks WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tn.NamespaceContainer(bucket)
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+
+	return &lockFixture{
+		server:   srv,
+		adapter:  NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		tenantID: tenantID,
+		tenant:   tn,
+		tempDir:  tempDir,
+		bucket:   bucket,
+	}
+}
+
+func (f *lockFixture) putObject(t *testing.T, key, content string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key, bytes.NewReader([]byte(content)))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, f.bucket, key)
+	require.Equal(t, http.StatusOK, w.Code, "PUT should succeed")
+	return w
+}
+
+func (f *lockFixture) deleteObject(t *testing.T, key string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandleDelete(w, req, f.bucket, key)
+	return w
+}
+
+// --- Test: bucket-level object lock configuration ---
+
+func TestObjectLock_PutGetBucketConfig(t *testing.T) {
+	f := setupLockFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+
+	// GET before enabling — should return empty config
+	req := httptest.NewRequest("GET", "/"+f.bucket+"?object-lock", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handleGetObjectLockConfiguration(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ObjectLockConfiguration
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.ObjectLockEnabled)
+	assert.Nil(t, resp.Rule)
+
+	// PUT to enable with default GOVERNANCE retention of 30 days
+	body := `<ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<ObjectLockEnabled>Enabled</ObjectLockEnabled>
+		<Rule><DefaultRetention><Mode>GOVERNANCE</Mode><Days>30</Days></DefaultRetention></Rule>
+	</ObjectLockConfiguration>`
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?object-lock", bytes.NewReader([]byte(body)))
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handlePutObjectLockConfiguration(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET again — should return enabled config
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?object-lock", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetObjectLockConfiguration(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Enabled", resp.ObjectLockEnabled)
+	require.NotNil(t, resp.Rule)
+	require.NotNil(t, resp.Rule.DefaultRetention)
+	assert.Equal(t, "GOVERNANCE", resp.Rule.DefaultRetention.Mode)
+	assert.Equal(t, 30, resp.Rule.DefaultRetention.Days)
+}
+
+// --- Test: per-object retention ---
+
+func TestObjectLock_PutGetRetention(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "retained.txt"
+	f.putObject(t, key, "data under retention")
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	retainUntil := time.Now().Add(365 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`<Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<Mode>GOVERNANCE</Mode>
+		<RetainUntilDate>%s</RetainUntilDate>
+	</Retention>`, retainUntil)
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key+"?retention", bytes.NewReader([]byte(body)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutObjectRetention(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET retention
+	req = httptest.NewRequest("GET", "/"+f.bucket+"/"+key+"?retention", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetObjectRetention(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var ret RetentionConfig
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &ret))
+	assert.Equal(t, "GOVERNANCE", ret.Mode)
+	assert.NotEmpty(t, ret.RetainUntilDate)
+}
+
+// --- Test: per-object legal hold ---
+
+func TestObjectLock_PutGetLegalHold(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "held.txt"
+	f.putObject(t, key, "data under legal hold")
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	body := `<LegalHold xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>ON</Status></LegalHold>`
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key+"?legal-hold", bytes.NewReader([]byte(body)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutObjectLegalHold(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET legal hold
+	req = httptest.NewRequest("GET", "/"+f.bucket+"/"+key+"?legal-hold", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetObjectLegalHold(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var hold LegalHoldConfig
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &hold))
+	assert.Equal(t, "ON", hold.Status)
+}
+
+// --- Test: COMPLIANCE retention blocks delete ---
+
+func TestObjectLock_ComplianceBlocksDelete(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "compliance-locked.txt"
+	f.putObject(t, key, "compliance data")
+
+	retainUntil := time.Now().Add(365 * 24 * time.Hour)
+	_, err := f.db.Exec(`
+		INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date)
+		VALUES ($1, $2, $3, 'COMPLIANCE', $4)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			retention_mode = 'COMPLIANCE', retain_until_date = $4
+	`, f.tenantID, f.bucket, key, retainUntil)
+	require.NoError(t, err)
+
+	w := f.deleteObject(t, key, nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var s3Err S3Error
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &s3Err))
+	assert.Equal(t, ErrObjectLocked, s3Err.Code)
+}
+
+// --- Test: GOVERNANCE bypass ---
+
+func TestObjectLock_GovernanceBypass(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "governance-locked.txt"
+	f.putObject(t, key, "governance data")
+
+	retainUntil := time.Now().Add(365 * 24 * time.Hour)
+	_, err := f.db.Exec(`
+		INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date)
+		VALUES ($1, $2, $3, 'GOVERNANCE', $4)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			retention_mode = 'GOVERNANCE', retain_until_date = $4
+	`, f.tenantID, f.bucket, key, retainUntil)
+	require.NoError(t, err)
+
+	// Without bypass header — should be blocked
+	w := f.deleteObject(t, key, nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	// With bypass header — should succeed
+	w = f.deleteObject(t, key, map[string]string{
+		"x-amz-bypass-governance-retention": "true",
+	})
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+// --- Test: legal hold blocks delete ---
+
+func TestObjectLock_LegalHoldBlocksDelete(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "legal-held.txt"
+	f.putObject(t, key, "legal hold data")
+
+	_, err := f.db.Exec(`
+		INSERT INTO object_locks (tenant_id, bucket, object_key, legal_hold)
+		VALUES ($1, $2, $3, TRUE)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET legal_hold = TRUE
+	`, f.tenantID, f.bucket, key)
+	require.NoError(t, err)
+
+	w := f.deleteObject(t, key, nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var s3Err S3Error
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &s3Err))
+	assert.Equal(t, ErrObjectLocked, s3Err.Code)
+
+	// Even with governance bypass, legal hold blocks
+	w = f.deleteObject(t, key, map[string]string{
+		"x-amz-bypass-governance-retention": "true",
+	})
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// --- Test: expired retention allows delete ---
+
+func TestObjectLock_ExpiredRetentionAllowsDelete(t *testing.T) {
+	f := setupLockFixture(t)
+
+	key := "expired-lock.txt"
+	f.putObject(t, key, "expired data")
+
+	pastDate := time.Now().Add(-24 * time.Hour)
+	_, err := f.db.Exec(`
+		INSERT INTO object_locks (tenant_id, bucket, object_key, retention_mode, retain_until_date)
+		VALUES ($1, $2, $3, 'COMPLIANCE', $4)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			retention_mode = 'COMPLIANCE', retain_until_date = $4
+	`, f.tenantID, f.bucket, key, pastDate)
+	require.NoError(t, err)
+
+	w := f.deleteObject(t, key, nil)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+// --- Test: default retention applied on PUT ---
+
+func TestObjectLock_DefaultRetentionApplied(t *testing.T) {
+	f := setupLockFixture(t)
+
+	// Enable object lock with GOVERNANCE default of 30 days
+	_, err := f.db.Exec(`
+		UPDATE buckets SET object_lock_enabled = TRUE,
+			default_retention_mode = 'GOVERNANCE', default_retention_days = 30
+		WHERE tenant_id = $1 AND name = $2
+	`, f.tenantID, f.bucket)
+	require.NoError(t, err)
+
+	key := "auto-retained.txt"
+	f.putObject(t, key, "auto-retention data")
+
+	// Verify lock was applied
+	var mode string
+	var retainUntil time.Time
+	err = f.db.QueryRow(`
+		SELECT retention_mode, retain_until_date FROM object_locks
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, f.bucket, key).Scan(&mode, &retainUntil)
+	require.NoError(t, err)
+	assert.Equal(t, "GOVERNANCE", mode)
+	assert.True(t, retainUntil.After(time.Now().Add(29*24*time.Hour)),
+		"retain_until_date should be ~30 days from now")
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -19,6 +19,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 025 | Bucket registry: `buckets` table, tenant `slug`+`slug_locked` columns, `backend_name` on `object_head_cache` |
 | 026 | S3 versioning: `versioning_status` on `buckets`, `object_versions` table |
 | 027 | Bucket notifications: `bucket_notifications` table for S3 event webhook config |
+| 028 | Object Lock: `object_lock_enabled`, `default_retention_mode`, `default_retention_days` on `buckets`; `object_locks` table |
 
 ## Key Tables
 
@@ -29,12 +30,13 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status` (disabled/Enabled/Suspended)
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`
 - **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT)
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`
-- **bucket_notifications** — `id (PK)`, `tenant_id`, `bucket`, `event_filter`, `target_type`, `target_url`, `enabled`, `created_at` — S3 event notification webhook config
+- **bucket_notifications** — `id (PK)`, `tenant_id`, `bucket`, `event_filter`, `target_type`, `target_url`, `enabled`, `created_at`
+- **object_locks** — `(tenant_id, bucket, object_key) PK`, `retention_mode`, `retain_until_date`, `legal_hold`, `created_at`, `updated_at`
 
 ## Connection
 

--- a/internal/database/migrations/028_object_lock.sql
+++ b/internal/database/migrations/028_object_lock.sql
@@ -1,0 +1,21 @@
+-- 028_object_lock.sql
+-- Phase 5.10.13: S3 Object Lock / WORM support
+-- Idempotent — safe to re-run on every deploy
+
+-- Per-bucket object lock configuration
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS object_lock_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS default_retention_mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS default_retention_days INT NOT NULL DEFAULT 0;
+
+-- Per-object lock state (retention + legal hold)
+CREATE TABLE IF NOT EXISTS object_locks (
+    tenant_id         TEXT NOT NULL,
+    bucket            TEXT NOT NULL,
+    object_key        TEXT NOT NULL,
+    retention_mode    TEXT NOT NULL DEFAULT '',
+    retain_until_date TIMESTAMPTZ,
+    legal_hold        BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, bucket, object_key)
+);


### PR DESCRIPTION
## Summary
- S3-compatible Object Lock (WORM) with Governance and Compliance retention modes
- Per-object retention (retain-until-date) and legal hold (ON/OFF) via standard S3 APIs
- Bucket-level default retention configuration auto-applied on PUT
- Lock enforcement on DELETE and PUT (overwrite) — blocks before engine operations
- Batch delete (`POST ?delete`) checks each key individually; locked keys reported as errors

## New files
- `internal/api/s3_lock.go` — 6 handlers (Get/Put bucket lock config, Get/Put retention, Get/Put legal hold) + `checkObjectLock` enforcement helper + `applyObjectLockOnPut` for inline lock application
- `internal/api/s3_lock_test.go` — 8 integration tests covering all lock behaviors
- `internal/database/migrations/028_object_lock.sql` — `object_locks` table + 3 columns on `buckets`

## Modified files
- `s3.go` — 6 new operations in `determineOperation` + `handleS3Request` switch
- `s3_engine_adapter.go` — lock checks in `HandleDelete` (before engine.Delete) and `HandlePut` (before engine.Put on overwrites) + lock-on-PUT application after successful write
- `s3_batch.go` — per-key lock check in `handleDeleteObjects` loop
- `s3_errors.go` — `ErrObjectLocked` (403) and `ErrInvalidRetentionPeriod` (400)

## Key behaviors
- **Compliance mode**: cannot shorten retention or delete/overwrite before expiry — absolute immutability
- **Governance mode**: blocks by default but allows bypass via `x-amz-bypass-governance-retention: true` header
- **Legal hold**: independent of retention — blocks even after retention expires; both must be clear
- **Default retention**: bucket-level config auto-applies retention to new objects when no per-object headers sent
- **Expired retention**: past retain-until-date = no lock — treated same as no lock row

## Test plan
- [x] `TestObjectLock_PutGetBucketConfig` — enable/read bucket lock config with default retention
- [x] `TestObjectLock_PutGetRetention` — set/read GOVERNANCE retention on object
- [x] `TestObjectLock_PutGetLegalHold` — set/read legal hold ON
- [x] `TestObjectLock_ComplianceBlocksDelete` — COMPLIANCE retention blocks DELETE (403 ObjectLocked)
- [x] `TestObjectLock_GovernanceBypass` — GOVERNANCE blocks DELETE, bypass header allows it
- [x] `TestObjectLock_LegalHoldBlocksDelete` — legal hold blocks DELETE regardless of bypass header
- [x] `TestObjectLock_ExpiredRetentionAllowsDelete` — past retain-until-date does not block
- [x] `TestObjectLock_DefaultRetentionApplied` — bucket default auto-applied on PUT, verified in DB