### PR TITLE
feat(drivers): unit tests for Quotaless/Geyser + unified Driver interface [Phase 5.10.3b]

### DIFF
--- a/cmd/vaultaire/main.go
+++ b/cmd/vaultaire/main.go
@@ -232,11 +232,9 @@ func main() {
 	// 6. Set primary backend (auto-detect best available)
 	storageMode := os.Getenv("STORAGE_MODE")
 	if storageMode == "" {
-		// Auto-detect: prefer Quotaless > Lyve > S3 > Geyser > local
+		// Auto-detect: prefer Quotaless > S3 > Geyser > local
 		if os.Getenv("QUOTALESS_ACCESS_KEY") != "" {
 			storageMode = "quotaless"
-		} else if os.Getenv("LYVE_ACCESS_KEY") != "" {
-			storageMode = "lyve"
 		} else if os.Getenv("S3_ACCESS_KEY") != "" {
 			storageMode = "s3"
 		} else if os.Getenv("GEYSER_ACCESS_KEY") != "" {

--- a/internal/drivers/compression.go
+++ b/internal/drivers/compression.go
@@ -100,6 +100,10 @@ func (c *CompressionDriver) List(ctx context.Context, container, prefix string) 
 	return c.backend.List(ctx, container, prefix)
 }
 
+func (c *CompressionDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return c.backend.Exists(ctx, container, artifact+".gz")
+}
+
 func (c *CompressionDriver) HealthCheck(ctx context.Context) error {
 	return c.backend.HealthCheck(ctx)
 }

--- a/internal/drivers/conformance_test.go
+++ b/internal/drivers/conformance_test.go
@@ -1,0 +1,14 @@
+package drivers
+
+import "github.com/FairForge/vaultaire/internal/engine"
+
+var (
+	_ engine.Driver = (*LocalDriver)(nil)
+	_ engine.Driver = (*S3CompatDriver)(nil)
+	_ engine.Driver = (*IDriveDriver)(nil)
+	_ engine.Driver = (*LyveDriver)(nil)
+	_ engine.Driver = (*QuotalessDriver)(nil)
+	_ engine.Driver = (*GeyserDriver)(nil)
+	_ engine.Driver = (*ThrottledDriver)(nil)
+	_ engine.Driver = (*CompressionDriver)(nil)
+)

--- a/internal/drivers/driver.go
+++ b/internal/drivers/driver.go
@@ -1,20 +1,11 @@
 package drivers
 
 import (
-	"context"
-	"io"
-
 	"github.com/FairForge/vaultaire/internal/engine"
 )
 
-// Driver is the common interface all storage drivers must implement
-type Driver interface {
-	Get(ctx context.Context, container, artifact string) (io.ReadCloser, error)
-	Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error
-	Delete(ctx context.Context, container, artifact string) error
-	List(ctx context.Context, container string, prefix string) ([]string, error)
-	Exists(ctx context.Context, container, artifact string) (bool, error)
-}
+// Driver is an alias for engine.Driver — the canonical storage backend interface.
+type Driver = engine.Driver
 
 // PutOption is a function that configures Put operations
 type PutOption func(*putOptions)

--- a/internal/drivers/fallback_test.go
+++ b/internal/drivers/fallback_test.go
@@ -62,6 +62,15 @@ func (m *MockDriver) Exists(ctx context.Context, container, artifact string) (bo
 	return true, nil
 }
 
+func (m *MockDriver) Name() string { return m.name }
+
+func (m *MockDriver) HealthCheck(_ context.Context) error {
+	if m.shouldFail {
+		return errors.New("mock driver failed")
+	}
+	return nil
+}
+
 func TestFallbackDriver(t *testing.T) {
 	t.Run("uses primary when available", func(t *testing.T) {
 		// Arrange

--- a/internal/drivers/geyser.go
+++ b/internal/drivers/geyser.go
@@ -236,6 +236,23 @@ func (d *GeyserDriver) List(ctx context.Context, container string, prefix string
 	return artifacts, nil
 }
 
+func (d *GeyserDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	tenantID := d.getTenantID(ctx)
+	key := d.buildKey(tenantID, container, artifact)
+
+	_, err := d.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		return false, fmt.Errorf("geyser exists %s: %w", key, err)
+	}
+	return true, nil
+}
+
 func (d *GeyserDriver) Name() string {
 	return "geyser"
 }

--- a/internal/drivers/geyser_test.go
+++ b/internal/drivers/geyser_test.go
@@ -1,0 +1,288 @@
+package drivers
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/common"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// geyserS3Mock mimics S3 responses for Geyser storage tests.
+type geyserS3Mock struct {
+	mu      sync.RWMutex
+	objects map[string][]byte // key -> data
+	headers map[string]http.Header
+}
+
+func newGeyserS3Mock() *geyserS3Mock {
+	return &geyserS3Mock{
+		objects: make(map[string][]byte),
+		headers: make(map[string]http.Header),
+	}
+}
+
+func (m *geyserS3Mock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, key := parseBucketKey(r.URL.Path)
+
+	switch r.Method {
+	case http.MethodPut:
+		data, _ := io.ReadAll(r.Body)
+		m.mu.Lock()
+		m.objects[key] = data
+		m.headers[key] = r.Header.Clone()
+		m.mu.Unlock()
+		w.Header().Set("ETag", `"geyser-etag"`)
+		w.WriteHeader(http.StatusOK)
+
+	case http.MethodGet:
+		if r.URL.Query().Get("list-type") == "2" {
+			m.handleList(w, r)
+			return
+		}
+		m.mu.RLock()
+		data, ok := m.objects[key]
+		m.mu.RUnlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		_, _ = w.Write(data)
+
+	case http.MethodDelete:
+		m.mu.Lock()
+		delete(m.objects, key)
+		m.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+
+	case http.MethodHead:
+		if key == "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		m.mu.RLock()
+		data, ok := m.objects[key]
+		m.mu.RUnlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		http.Error(w, "unsupported", http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *geyserS3Mock) handleList(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var entries []s3Entry
+	for k, v := range m.objects {
+		if prefix != "" && !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		entries = append(entries, s3Entry{
+			Key:          k,
+			Size:         int64(len(v)),
+			LastModified: "2026-01-01T00:00:00Z",
+			ETag:         `"geyser-etag"`,
+			StorageClass: "STANDARD",
+		})
+	}
+
+	result := listBucketResult{
+		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:        "test-bucket",
+		Prefix:      prefix,
+		IsTruncated: false,
+		Contents:    entries,
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(result)
+}
+
+func newTestGeyserDriver(t *testing.T, mock *geyserS3Mock) *GeyserDriver {
+	t.Helper()
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+
+	logger, _ := zap.NewDevelopment()
+	client := s3.New(s3.Options{
+		BaseEndpoint: aws.String(srv.URL),
+		Region:       "us-west-2",
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+		UsePathStyle: true,
+	})
+
+	return &GeyserDriver{
+		client:   client,
+		bucket:   "test-bucket",
+		tenantID: "tenant1",
+		logger:   logger,
+		endpoint: srv.URL,
+	}
+}
+
+// ── Put/Get/Delete round-trip ────────────────────────────────────────────────
+
+func TestGeyser_PutGetDeleteRoundtrip(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.Background()
+
+	// Put
+	err := driver.Put(ctx, "photos", "cat.jpg", strings.NewReader("meow"))
+	require.NoError(t, err)
+
+	// Get
+	rc, err := driver.Get(ctx, "photos", "cat.jpg")
+	require.NoError(t, err)
+	data, _ := io.ReadAll(rc)
+	_ = rc.Close()
+	assert.Equal(t, "meow", string(data))
+
+	// Delete
+	require.NoError(t, driver.Delete(ctx, "photos", "cat.jpg"))
+
+	// Get after delete should fail
+	_, err = driver.Get(ctx, "photos", "cat.jpg")
+	require.Error(t, err)
+}
+
+// ── Put materializes Content-Length ──────────────────────────────────────────
+
+func TestGeyser_PutMaterializes(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.Background()
+
+	err := driver.Put(ctx, "docs", "readme.md", strings.NewReader("hello world"))
+	require.NoError(t, err)
+
+	key := "t-tenant1/docs/readme.md"
+	mock.mu.RLock()
+	h := mock.headers[key]
+	mock.mu.RUnlock()
+	require.NotNil(t, h)
+	assert.NotEmpty(t, h.Get("Content-Length"), "Content-Length header must be set")
+}
+
+// ── Key format ───────────────────────────────────────────────────────────────
+
+func TestGeyser_KeyFormat(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "file.bin", strings.NewReader("x")))
+
+	mock.mu.RLock()
+	_, ok := mock.objects["t-tenant1/bucket/file.bin"]
+	mock.mu.RUnlock()
+	assert.True(t, ok, "key should follow t-{tenantID}/{container}/{artifact}")
+}
+
+// ── Key format with context tenant ───────────────────────────────────────────
+
+func TestGeyser_KeyFormatWithContextTenant(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.WithValue(context.Background(), common.TenantIDKey, "ctx-tenant")
+
+	require.NoError(t, driver.Put(ctx, "bucket", "file.bin", strings.NewReader("x")))
+
+	mock.mu.RLock()
+	_, ok := mock.objects["t-ctx-tenant/bucket/file.bin"]
+	mock.mu.RUnlock()
+	assert.True(t, ok, "should use tenant ID from context")
+}
+
+// ── Endpoint override ────────────────────────────────────────────────────────
+
+func TestGeyser_EndpointOverride(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	driver, err := NewGeyserDriver("k", "s", "bucket", "t",
+		logger, WithGeyserEndpoint("https://lon1.geyserdata.com"))
+	require.NoError(t, err)
+	assert.Equal(t, "https://lon1.geyserdata.com", driver.endpoint)
+}
+
+// ── Default endpoint ─────────────────────────────────────────────────────────
+
+func TestGeyser_DefaultEndpoint(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	driver, err := NewGeyserDriver("k", "s", "bucket", "t", logger)
+	require.NoError(t, err)
+	assert.Equal(t, "https://la1.geyserdata.com", driver.endpoint)
+}
+
+// ── List with prefix ─────────────────────────────────────────────────────────
+
+func TestGeyser_ListWithPrefix(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "docs", "a.txt", strings.NewReader("a")))
+	require.NoError(t, driver.Put(ctx, "docs", "b.txt", strings.NewReader("b")))
+	require.NoError(t, driver.Put(ctx, "other", "c.txt", strings.NewReader("c")))
+
+	results, err := driver.List(ctx, "docs", "")
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt"}, results)
+}
+
+// ── HealthCheck ──────────────────────────────────────────────────────────────
+
+func TestGeyser_HealthCheck(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+
+	err := driver.HealthCheck(context.Background())
+	require.NoError(t, err)
+}
+
+// ── Name ─────────────────────────────────────────────────────────────────────
+
+func TestGeyser_Name(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	assert.Equal(t, "geyser", driver.Name())
+}
+
+// ── Exists ───────────────────────────────────────────────────────────────────
+
+func TestGeyser_Exists(t *testing.T) {
+	mock := newGeyserS3Mock()
+	driver := newTestGeyserDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "yes.txt", strings.NewReader("here")))
+
+	exists, err := driver.Exists(ctx, "bucket", "yes.txt")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = driver.Exists(ctx, "bucket", "nope.txt")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/internal/drivers/idrive.go
+++ b/internal/drivers/idrive.go
@@ -363,6 +363,18 @@ func (d *IDriveDriver) Exists(ctx context.Context, container, artifact string) (
 	return true, nil
 }
 
+func (d *IDriveDriver) Name() string {
+	return "idrive"
+}
+
+func (d *IDriveDriver) HealthCheck(ctx context.Context) error {
+	_, err := d.client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return fmt.Errorf("idrive health check: %w", err)
+	}
+	return nil
+}
+
 func (d *IDriveDriver) ValidateAuth(ctx context.Context) error {
 	// Try to list buckets - this requires valid authentication
 	_, err := d.client.ListBuckets(ctx, &s3.ListBucketsInput{})

--- a/internal/drivers/lyve.go
+++ b/internal/drivers/lyve.go
@@ -176,6 +176,24 @@ func (d *LyveDriver) List(ctx context.Context, container string, prefix string) 
 	return keys, nil
 }
 
+func (d *LyveDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	tenantID := d.getTenantID(ctx)
+	key := d.buildTenantKey(tenantID, container, artifact)
+	bucket := d.getBucket()
+
+	_, err := d.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		return false, fmt.Errorf("lyve exists: %w", err)
+	}
+	return true, nil
+}
+
 func (d *LyveDriver) Name() string {
 	return "lyve"
 }

--- a/internal/drivers/quotaless.go
+++ b/internal/drivers/quotaless.go
@@ -222,6 +222,32 @@ func (d *QuotalessDriver) List(ctx context.Context, container string, prefix str
 	return cleaned, nil
 }
 
+// Exists checks if an object exists with retry logic
+func (d *QuotalessDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	fullPath := fmt.Sprintf("%s/%s/%s", d.rootPath, container, artifact)
+
+	var lastErr error
+	for attempt := 0; attempt < d.maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt*attempt) * time.Second
+			d.logger.Warn("retrying exists",
+				zap.Int("attempt", attempt+1),
+				zap.String("path", fullPath),
+				zap.Duration("backoff", backoff),
+				zap.Error(lastErr))
+			time.Sleep(backoff)
+		}
+
+		exists, err := d.S3Driver.Exists(ctx, "data", fullPath)
+		if err == nil {
+			return exists, nil
+		}
+		lastErr = err
+	}
+
+	return false, fmt.Errorf("exists failed after %d attempts: %w", d.maxRetries, lastErr)
+}
+
 // HealthCheck with timeout and retry
 func (d *QuotalessDriver) HealthCheck(ctx context.Context) error {
 	// Create a timeout context for health check

--- a/internal/drivers/quotaless_test.go
+++ b/internal/drivers/quotaless_test.go
@@ -1,0 +1,343 @@
+package drivers
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// s3Mock is a minimal S3-compatible HTTP handler for unit tests.
+type s3Mock struct {
+	mu       sync.RWMutex
+	objects  map[string][]byte // bucket/key -> data
+	requests atomic.Int32
+	failN    int // fail the first N requests
+}
+
+type listBucketResult struct {
+	XMLName     xml.Name  `xml:"ListBucketResult"`
+	Xmlns       string    `xml:"xmlns,attr"`
+	Name        string    `xml:"Name"`
+	Prefix      string    `xml:"Prefix"`
+	IsTruncated bool      `xml:"IsTruncated"`
+	Contents    []s3Entry `xml:"Contents"`
+}
+
+type s3Entry struct {
+	Key          string `xml:"Key"`
+	Size         int64  `xml:"Size"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+func newS3Mock() *s3Mock {
+	return &s3Mock{objects: make(map[string][]byte)}
+}
+
+func (m *s3Mock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	n := int(m.requests.Add(1))
+	if n <= m.failN {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	bucket, key := parseBucketKey(r.URL.Path)
+
+	switch r.Method {
+	case http.MethodPut:
+		data, _ := io.ReadAll(r.Body)
+		m.mu.Lock()
+		m.objects[bucket+"/"+key] = data
+		m.mu.Unlock()
+		w.Header().Set("ETag", `"mock-etag"`)
+		w.WriteHeader(http.StatusOK)
+
+	case http.MethodGet:
+		if r.URL.Query().Get("list-type") == "2" {
+			m.handleListV2(w, r, bucket)
+			return
+		}
+		m.mu.RLock()
+		data, ok := m.objects[bucket+"/"+key]
+		m.mu.RUnlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		_, _ = w.Write(data)
+
+	case http.MethodDelete:
+		m.mu.Lock()
+		delete(m.objects, bucket+"/"+key)
+		m.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+
+	case http.MethodHead:
+		m.mu.RLock()
+		data, ok := m.objects[bucket+"/"+key]
+		m.mu.RUnlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		http.Error(w, "unsupported", http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *s3Mock) handleListV2(w http.ResponseWriter, r *http.Request, bucket string) {
+	prefix := r.URL.Query().Get("prefix")
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var entries []s3Entry
+	for k, v := range m.objects {
+		if !strings.HasPrefix(k, bucket+"/") {
+			continue
+		}
+		objKey := k[len(bucket)+1:]
+		if prefix != "" && !strings.HasPrefix(objKey, prefix) {
+			continue
+		}
+		entries = append(entries, s3Entry{
+			Key:          objKey,
+			Size:         int64(len(v)),
+			LastModified: time.Now().UTC().Format(time.RFC3339),
+			ETag:         `"mock-etag"`,
+			StorageClass: "STANDARD",
+		})
+	}
+
+	result := listBucketResult{
+		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:        bucket,
+		Prefix:      prefix,
+		IsTruncated: false,
+		Contents:    entries,
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(result)
+}
+
+func parseBucketKey(path string) (string, string) {
+	path = strings.TrimPrefix(path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+func newTestQuotalessDriver(t *testing.T, mock *s3Mock) (*QuotalessDriver, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+
+	logger, _ := zap.NewDevelopment()
+	driver, err := NewQuotalessDriver("test-key", "test-secret", srv.URL, logger)
+	require.NoError(t, err)
+	return driver, srv
+}
+
+// ── Endpoint discrimination ──────────────────────────────────────────────────
+
+func TestQuotaless_EndpointDiscrimination(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	mock := newS3Mock()
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	cases := []struct {
+		endpoint  string
+		wantMulti bool
+	}{
+		{"https://srv1.quotaless.cloud:8000", true},
+		{"https://us.quotaless.cloud:8000", true},
+		{"https://nl.quotaless.cloud:8000", true},
+		{"https://sg.quotaless.cloud:8000", true},
+		{"https://quotaless.cloud:8000", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			driver, err := NewQuotalessDriver("k", "s", tc.endpoint, logger)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMulti, driver.useMultipart,
+				"endpoint %s: useMultipart", tc.endpoint)
+		})
+	}
+}
+
+// ── Root path prefix ─────────────────────────────────────────────────────────
+
+func TestQuotaless_RootPathPrefix(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "mybucket", "myfile.txt", strings.NewReader("hello")))
+
+	mock.mu.RLock()
+	_, ok := mock.objects["data/personal-files/mybucket/myfile.txt"]
+	mock.mu.RUnlock()
+	assert.True(t, ok, "expected key with personal-files prefix in mock store")
+}
+
+// ── Retry on failure ─────────────────────────────────────────────────────────
+
+func TestQuotaless_RetryOnFailure(t *testing.T) {
+	mock := newS3Mock()
+	mock.failN = 2 // first 2 requests fail, 3rd succeeds
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	err := driver.Put(ctx, "bucket", "file.txt", strings.NewReader("data"))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, int(mock.requests.Load()), 3)
+}
+
+// ── Exhausted retries ────────────────────────────────────────────────────────
+
+func TestQuotaless_ExhaustedRetries(t *testing.T) {
+	mock := newS3Mock()
+	mock.failN = 100 // always fail
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	err := driver.Put(ctx, "bucket", "file.txt", strings.NewReader("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after 3 attempts")
+}
+
+// ── Chunk size defaults ──────────────────────────────────────────────────────
+
+func TestQuotaless_ChunkSizeDefaults(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+
+	assert.Equal(t, int64(50*1024*1024), driver.chunkSize)
+	assert.Equal(t, int64(100*1024*1024), driver.uploadCutoff)
+}
+
+// ── Health check ─────────────────────────────────────────────────────────────
+
+func TestQuotaless_HealthCheck(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+
+	err := driver.HealthCheck(context.Background())
+	require.NoError(t, err)
+}
+
+// ── List strips prefix ───────────────────────────────────────────────────────
+
+func TestQuotaless_ListStripsPrefix(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "a.txt", strings.NewReader("aaa")))
+	require.NoError(t, driver.Put(ctx, "bucket", "b.txt", strings.NewReader("bbb")))
+
+	results, err := driver.List(ctx, "bucket", "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt"}, results)
+}
+
+// ── Get round-trip ───────────────────────────────────────────────────────────
+
+func TestQuotaless_GetRoundtrip(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "hello.txt", strings.NewReader("world")))
+
+	rc, err := driver.Get(ctx, "bucket", "hello.txt")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(data))
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+
+func TestQuotaless_Delete(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "del.txt", strings.NewReader("data")))
+	require.NoError(t, driver.Delete(ctx, "bucket", "del.txt"))
+
+	mock.mu.RLock()
+	_, ok := mock.objects["data/personal-files/bucket/del.txt"]
+	mock.mu.RUnlock()
+	assert.False(t, ok, "object should be deleted")
+}
+
+// ── Exists ───────────────────────────────────────────────────────────────────
+
+func TestQuotaless_Exists(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "exists.txt", strings.NewReader("yes")))
+
+	exists, err := driver.Exists(ctx, "bucket", "exists.txt")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = driver.Exists(ctx, "bucket", "nope.txt")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// ── Name ─────────────────────────────────────────────────────────────────────
+
+func TestQuotaless_Name(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	assert.Equal(t, "quotaless", driver.Name())
+}
+
+// ── Get retry ────────────────────────────────────────────────────────────────
+
+func TestQuotaless_GetRetryOnFailure(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	mock.mu.Lock()
+	mock.objects["data/personal-files/bucket/retry.txt"] = []byte("retried")
+	mock.mu.Unlock()
+
+	mock.failN = 1 // first request fails
+	rc, err := driver.Get(ctx, "bucket", "retry.txt")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	assert.Equal(t, "retried", string(data))
+}

--- a/internal/drivers/regional_failover.go
+++ b/internal/drivers/regional_failover.go
@@ -14,8 +14,8 @@ import (
 
 // RegionalFailover implements automatic failover between regions
 type RegionalFailover struct {
-	primary   Driver
-	secondary Driver
+	primary   RegionDriver
+	secondary RegionDriver
 	logger    *zap.Logger
 
 	primaryHealthy   atomic.Bool

--- a/internal/drivers/s3.go
+++ b/internal/drivers/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
@@ -120,6 +121,21 @@ func (d *S3Driver) List(ctx context.Context, container, prefix string) ([]string
 		keys = append(keys, *obj.Key)
 	}
 	return keys, nil
+}
+
+// Exists checks if an object exists in S3
+func (d *S3Driver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	_, err := d.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(container),
+		Key:    aws.String(artifact),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		return false, fmt.Errorf("exists %s/%s: %w", container, artifact, err)
+	}
+	return true, nil
 }
 
 // S3MultipartUpload represents an S3 multipart upload

--- a/internal/drivers/s3compat.go
+++ b/internal/drivers/s3compat.go
@@ -146,6 +146,23 @@ func (d *S3CompatDriver) List(ctx context.Context, container, prefix string) ([]
 	return artifacts, nil
 }
 
+// Exists checks if an artifact exists
+func (d *S3CompatDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	key := d.buildKey(container, artifact)
+
+	_, err := d.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		return false, fmt.Errorf("exists %s: %w", key, err)
+	}
+	return true, nil
+}
+
 // HealthCheck verifies connectivity
 func (d *S3CompatDriver) HealthCheck(ctx context.Context) error {
 	// Try to list the bucket root - this should always work

--- a/internal/drivers/throttle.go
+++ b/internal/drivers/throttle.go
@@ -76,6 +76,10 @@ func (t *ThrottledDriver) List(ctx context.Context, container, prefix string) ([
 	return t.backend.List(ctx, container, prefix)
 }
 
+func (t *ThrottledDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return t.backend.Exists(ctx, container, artifact)
+}
+
 func (t *ThrottledDriver) HealthCheck(ctx context.Context) error {
 	return t.backend.HealthCheck(ctx)
 }

--- a/internal/engine/interface.go
+++ b/internal/engine/interface.go
@@ -41,6 +41,7 @@ type Driver interface {
 	Put(ctx context.Context, container, artifact string, data io.Reader, opts ...PutOption) error
 	Delete(ctx context.Context, container, artifact string) error
 	List(ctx context.Context, container, prefix string) ([]string, error)
+	Exists(ctx context.Context, container, artifact string) (bool, error)
 	HealthCheck(ctx context.Context) error
 }
 

--- a/internal/engine/quota_test.go
+++ b/internal/engine/quota_test.go
@@ -63,6 +63,10 @@ func (m *MockDriver) List(ctx context.Context, container, prefix string) ([]stri
 	return nil, nil
 }
 
+func (m *MockDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return true, nil
+}
+
 func (m *MockDriver) HealthCheck(ctx context.Context) error {
 	return nil
 }

--- a/internal/engine/replicator_test.go
+++ b/internal/engine/replicator_test.go
@@ -36,6 +36,10 @@ func (t *TestDriver) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
+func (t *TestDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return true, nil
+}
+
 func (t *TestDriver) Name() string {
 	return "test"
 }


### PR DESCRIPTION
## Summary

- **Quotaless unit tests** (`quotaless_test.go`, 11 tests): endpoint discrimination, rootPath prefix, retry logic with backoff + exhaustion, chunk size defaults, health check, list prefix stripping, full CRUD round-trip, and Exists — all via httptest.NewServer S3 mock (no live Quotaless needed)
- **Geyser storage tests** (`geyser_test.go`, 10 tests): Put/Get/Delete round-trip, Content-Length materialization verification, key format `t-{tenantID}/{container}/{artifact}`, context tenant override, endpoint configuration (default LA + London override), list filtering, health check, Name, and Exists
- **Driver interface reconciliation**: added `Exists()` to `engine.Driver` (canonical interface), aliased `drivers.Driver → engine.Driver`, added `Exists()` to all 7 drivers (S3, S3Compat, Lyve, Quotaless, Geyser, Throttled, Compression), added `Name()`/`HealthCheck()` to IDriveDriver, compile-time conformance checks for all 8 driver types
- **Lyve auto-detect removed**: priority is now Quotaless > S3 > Geyser > local; Lyve driver still works when `LYVE_ACCESS_KEY` is explicitly set

## Ops TODO (not code)
- Provision Geyser London bucket via Geyser console and update production `.env`

## Test plan
- [x] All 11 Quotaless tests pass with `-race`
- [x] All 10 Geyser storage tests pass with `-race`
- [x] Compile-time conformance checks verify all 8 drivers satisfy `engine.Driver`
- [x] Full `go build ./...` clean
- [x] `golangci-lint run` clean on changed packages
- [x] Pre-commit hooks pass (go fmt, go test, golangci-lint)
- [ ] CI `build-and-test` passes