### PR TITLE
feat(s3): rclone + JuiceFS compatibility testing [Phase 5.10.14]

### DIFF
--- a/docs/guides/juicefs-setup.md
+++ b/docs/guides/juicefs-setup.md
@@ -1,0 +1,150 @@
+# Mount stored.ge as a POSIX Filesystem with JuiceFS
+
+Turn your stored.ge S3 bucket into a full POSIX filesystem you can `cd`, `ls`, and `cat` — on any Linux VPS with 512MB of RAM.
+
+## What is JuiceFS
+
+JuiceFS is an open-source, high-performance POSIX filesystem that splits storage into two layers: a metadata engine (SQLite, Redis, or PostgreSQL) and a data backend (any S3-compatible service). Your files look and behave like local files, but the bytes live in S3. It supports file locking, extended attributes, and symlinks — things FUSE-mounted rclone cannot do.
+
+## Prerequisites
+
+- Any Linux VPS (Ubuntu 20.04+, Debian 11+, or similar) with at least 512MB RAM
+- A stored.ge account with your access key and secret key (find them in your dashboard at stored.ge)
+- A bucket created on stored.ge (you'll do this below if you haven't already)
+
+## Step 1: Install JuiceFS
+
+```bash
+curl -sSL https://d.juicefs.com/install | sh -
+```
+
+Verify the install:
+
+```bash
+juicefs version
+```
+
+## Step 2: Create a Bucket on stored.ge
+
+If you haven't already, create a bucket using the AWS CLI:
+
+```bash
+aws s3 mb s3://my-jfs-data \
+  --endpoint-url https://s3.stored.ge \
+  --region us-east-1
+```
+
+Or create one from your stored.ge dashboard.
+
+## Step 3: Format the Filesystem
+
+This tells JuiceFS how to reach your S3 data and where to store metadata. For a single-node setup, SQLite is the simplest metadata engine:
+
+```bash
+sudo mkdir -p /var/jfs
+
+juicefs format \
+  --storage s3 \
+  --bucket https://s3.stored.ge/my-jfs-data \
+  --access-key VK_YOUR_ACCESS_KEY \
+  --secret-key SK_YOUR_SECRET_KEY \
+  sqlite3:///var/jfs/meta.db \
+  myjfs
+```
+
+Replace `VK_YOUR_ACCESS_KEY` and `SK_YOUR_SECRET_KEY` with your actual stored.ge credentials. The last argument (`myjfs`) is your filesystem name.
+
+## Step 4: Mount the Filesystem
+
+```bash
+sudo mkdir -p /mnt/storedge
+
+juicefs mount sqlite3:///var/jfs/meta.db /mnt/storedge
+```
+
+JuiceFS will run in the foreground. To run it in the background, add `-d`:
+
+```bash
+juicefs mount -d sqlite3:///var/jfs/meta.db /mnt/storedge
+```
+
+## Step 5: Verify
+
+```bash
+echo "hello stored.ge" > /mnt/storedge/test.txt
+cat /mnt/storedge/test.txt
+ls -la /mnt/storedge/
+```
+
+You should see your file. It's stored on stored.ge but behaves exactly like a local file.
+
+## Automounting on Boot
+
+Create a systemd unit so your filesystem mounts automatically:
+
+```bash
+sudo tee /etc/systemd/system/juicefs-storedge.service << 'EOF'
+[Unit]
+Description=JuiceFS mount for stored.ge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/juicefs mount sqlite3:///var/jfs/meta.db /mnt/storedge --no-syslog
+ExecStop=/usr/local/bin/juicefs umount /mnt/storedge
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now juicefs-storedge
+```
+
+Check status:
+
+```bash
+sudo systemctl status juicefs-storedge
+```
+
+## Performance Tips
+
+**Enable read caching** to avoid re-downloading frequently accessed files:
+
+```bash
+juicefs mount -d \
+  --cache-dir /tmp/jfscache \
+  --cache-size 1024 \
+  sqlite3:///var/jfs/meta.db /mnt/storedge
+```
+
+This caches up to 1GB of recently read data locally. On a VPS with spare disk, bump it higher.
+
+**Prefetch for sequential reads** (media streaming, backups):
+
+```bash
+juicefs mount -d \
+  --cache-dir /tmp/jfscache \
+  --cache-size 2048 \
+  --prefetch 3 \
+  sqlite3:///var/jfs/meta.db /mnt/storedge
+```
+
+**Write buffering** is enabled by default — JuiceFS batches small writes into larger S3 uploads automatically.
+
+**For multi-node setups**, replace SQLite with Redis:
+
+```bash
+juicefs format \
+  --storage s3 \
+  --bucket https://s3.stored.ge/my-jfs-data \
+  --access-key VK_YOUR_ACCESS_KEY \
+  --secret-key SK_YOUR_SECRET_KEY \
+  redis://localhost:6379/0 \
+  myjfs
+```
+
+This lets multiple machines mount the same filesystem simultaneously with consistent metadata.

--- a/docs/guides/juicefs-use-cases.md
+++ b/docs/guides/juicefs-use-cases.md
@@ -1,0 +1,186 @@
+# Use Cases for JuiceFS + stored.ge on Cheap VPS
+
+Real setups you can run today on a $3/year VPS backed by stored.ge storage. Every example assumes you've already mounted stored.ge at `/mnt/storedge` following the [JuiceFS setup guide](juicefs-setup.md).
+
+## Plex / Jellyfin Media Server
+
+Stream your media library from stored.ge without filling up your VPS disk. A $3/year NAT VPS + a Vault1 plan ($4.99/month for 1TB) gives you a full media server for under $65/year.
+
+```bash
+# Point Jellyfin at the mount
+sudo ln -s /mnt/storedge/media /var/lib/jellyfin/media
+
+# Or configure in Jellyfin's dashboard:
+# Dashboard → Libraries → Add Media Library
+# Folder: /mnt/storedge/media/movies
+```
+
+Upload your media:
+
+```bash
+cp -r /path/to/movies /mnt/storedge/media/movies/
+cp -r /path/to/shows /mnt/storedge/media/tv/
+```
+
+For best streaming performance, enable the local read cache:
+
+```bash
+juicefs mount -d \
+  --cache-dir /tmp/jfscache \
+  --cache-size 4096 \
+  --prefetch 3 \
+  sqlite3:///var/jfs/meta.db /mnt/storedge
+```
+
+**Cost math**: 500GB of media on Vault1 ($4.99/mo) + BuyVM $3.50/yr VPS = ~$63/year total. Comparable Plex cloud setups on Google Drive or Dropbox run $100+/year and can revoke API access at any time.
+
+## Nextcloud External Storage
+
+You have two options: S3 object storage directly, or JuiceFS mount as local storage.
+
+**Option A: S3 objectstore (recommended for new installs)**
+
+Add to your Nextcloud `config.php`:
+
+```php
+'objectstore' => [
+    'class' => '\\OC\\Files\\ObjectStore\\S3',
+    'arguments' => [
+        'bucket' => 'nextcloud-data',
+        'key'    => 'VK_YOUR_ACCESS_KEY',
+        'secret' => 'SK_YOUR_SECRET_KEY',
+        'hostname' => 's3.stored.ge',
+        'port'   => 443,
+        'use_ssl' => true,
+        'use_path_style' => true,
+        'region'  => 'us-east-1',
+    ],
+],
+```
+
+**Option B: JuiceFS mount as local external storage**
+
+In the Nextcloud admin panel:
+
+1. Go to **Apps** → enable **External storage support**
+2. Go to **Settings** → **External storage**
+3. Add a **Local** storage pointing to `/mnt/storedge/nextcloud-files`
+
+```bash
+sudo mkdir -p /mnt/storedge/nextcloud-files
+sudo chown www-data:www-data /mnt/storedge/nextcloud-files
+```
+
+This approach gives you POSIX compatibility (file locking, symlinks) that the S3 backend doesn't support.
+
+## Immich Photo Backup
+
+Immich supports S3 as a storage backend natively. In your `.env` file:
+
+```bash
+UPLOAD_LOCATION=/mnt/storedge/immich-uploads
+
+# Or use S3 directly:
+# IMMICH_S3_ENABLED=true
+# IMMICH_S3_BUCKET=immich-photos
+# IMMICH_S3_ENDPOINT=https://s3.stored.ge
+# IMMICH_S3_ACCESS_KEY=VK_YOUR_ACCESS_KEY
+# IMMICH_S3_SECRET_KEY=SK_YOUR_SECRET_KEY
+# IMMICH_S3_REGION=us-east-1
+```
+
+The JuiceFS mount path (`UPLOAD_LOCATION`) is simpler to set up and doesn't require Immich's S3 support. Both approaches work — choose S3 direct if you want Immich to handle uploads natively, or JuiceFS if you want filesystem-level access to the photos.
+
+**Cost math**: 200GB of photos on Vault1 ($4.99/mo) is $60/year. Google One 200GB is $30/year but locks you into their ecosystem. Immich + stored.ge gives you full ownership.
+
+## Git LFS / CI Artifacts
+
+Store large binary assets (models, datasets, build artifacts) on stored.ge via Git LFS.
+
+Configure your `.lfsconfig`:
+
+```ini
+[lfs]
+  url = "https://s3.stored.ge"
+
+[lfs "storage"]
+  s3.bucket = git-lfs-artifacts
+  s3.endpoint = https://s3.stored.ge
+  s3.access_key_id = VK_YOUR_ACCESS_KEY
+  s3.secret_access_key = SK_YOUR_SECRET_KEY
+```
+
+Or use the JuiceFS mount for CI artifact caching:
+
+```bash
+# In your CI script
+ARTIFACT_DIR=/mnt/storedge/ci-artifacts/$CI_PIPELINE_ID
+
+mkdir -p $ARTIFACT_DIR
+cp -r build/output/* $ARTIFACT_DIR/
+
+# Later stages pull from the same path
+cp $ARTIFACT_DIR/app.bin /deploy/
+```
+
+Artifacts persist across CI runs without eating VPS disk space.
+
+## Database Backups
+
+Dump your PostgreSQL (or MySQL) database straight to stored.ge on a schedule:
+
+```bash
+#!/bin/bash
+# /usr/local/bin/backup-db.sh
+
+BACKUP_DIR=/mnt/storedge/backups/postgres
+DATE=$(date +%Y-%m-%d_%H%M)
+FILENAME="mydb_${DATE}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+pg_dump -U myuser mydb | gzip > "$BACKUP_DIR/$FILENAME"
+
+# Keep 30 days of backups
+find "$BACKUP_DIR" -name "*.sql.gz" -mtime +30 -delete
+
+echo "Backup complete: $FILENAME ($(du -h "$BACKUP_DIR/$FILENAME" | cut -f1))"
+```
+
+Add a cron job:
+
+```bash
+# Run daily at 3am
+echo "0 3 * * * /usr/local/bin/backup-db.sh >> /var/log/db-backup.log 2>&1" | crontab -
+```
+
+Your backups are stored off-server on stored.ge automatically. No rsync, no separate S3 upload step — `pg_dump` writes directly to the mount.
+
+## *arr Stack (Sonarr / Radarr / Lidarr)
+
+The *arr apps download media locally and then you move finished files to stored.ge for long-term storage. Don't point the download client directly at JuiceFS — downloading to a remote mount is slow.
+
+**Setup:**
+
+```bash
+# Download to local SSD (fast)
+# /downloads is on the VPS local disk
+
+# Final media storage on stored.ge
+mkdir -p /mnt/storedge/media/movies
+mkdir -p /mnt/storedge/media/tv
+mkdir -p /mnt/storedge/media/music
+```
+
+In Sonarr/Radarr settings:
+
+- **Download client** category path: `/downloads/complete`
+- **Root folder** for libraries: `/mnt/storedge/media/tv` (Sonarr) or `/mnt/storedge/media/movies` (Radarr)
+
+The *arr apps will hardlink or move completed downloads to the JuiceFS mount. For best performance, use **Copy** instead of **Hardlink** in the import settings (hardlinks don't work across filesystem boundaries):
+
+Sonarr/Radarr → Settings → Media Management:
+- **Use Hardlinks instead of Copy**: No
+- **Import using Script**: No
+
+This gives you the speed of local downloads with the storage capacity of stored.ge. A 4TB Vault3 plan ($9.99/mo) holds a serious media library at a fraction of what a large VPS disk costs.

--- a/docs/guides/rclone-setup.md
+++ b/docs/guides/rclone-setup.md
@@ -1,0 +1,224 @@
+# How to Use stored.ge with rclone
+
+Connect rclone to stored.ge for file syncing, mounting, and serving — works on Linux, macOS, and Windows.
+
+## What is rclone
+
+rclone is a command-line tool for managing files on cloud storage. It supports over 70 backends, including any S3-compatible service. Think of it as rsync for the cloud — you get `copy`, `sync`, `mount`, and even `serve` (WebDAV, SFTP, FTP) against your stored.ge buckets.
+
+## Step 1: Install rclone
+
+```bash
+# Linux / macOS
+curl https://rclone.org/install.sh | sudo bash
+
+# Or via package manager
+# Ubuntu/Debian: sudo apt install rclone
+# macOS: brew install rclone
+# Windows: choco install rclone
+```
+
+Verify:
+
+```bash
+rclone version
+```
+
+## Step 2: Configure stored.ge Remote
+
+Run the interactive config:
+
+```bash
+rclone config
+```
+
+Follow the prompts:
+
+```
+n) New remote
+name> storedge
+Storage> s3
+provider> Other
+env_auth> false
+access_key_id> VK_YOUR_ACCESS_KEY
+secret_access_key> SK_YOUR_SECRET_KEY
+region> us-east-1
+endpoint> https://s3.stored.ge
+location_constraint> (leave blank, press Enter)
+acl> private
+Edit advanced config?> n
+```
+
+This creates the following entry in `~/.config/rclone/rclone.conf`:
+
+```ini
+[storedge]
+type = s3
+provider = Other
+access_key_id = VK_YOUR_ACCESS_KEY
+secret_access_key = SK_YOUR_SECRET_KEY
+region = us-east-1
+endpoint = https://s3.stored.ge
+acl = private
+```
+
+You can also create this file directly instead of using the interactive setup.
+
+## Step 3: Basic Operations
+
+**List buckets:**
+
+```bash
+rclone lsd storedge:
+```
+
+**List files in a bucket:**
+
+```bash
+rclone ls storedge:my-bucket
+```
+
+**Copy files to stored.ge:**
+
+```bash
+# Single file
+rclone copy ./report.pdf storedge:my-bucket/reports/
+
+# Entire directory
+rclone copy ./photos storedge:my-bucket/photos/ --transfers 8
+```
+
+**Sync a directory** (make remote match local, deleting extra files on remote):
+
+```bash
+rclone sync ./local-folder storedge:my-bucket/backup/ --transfers 8
+```
+
+**Download files:**
+
+```bash
+rclone copy storedge:my-bucket/photos/ ./downloaded-photos/
+```
+
+**Delete a file:**
+
+```bash
+rclone delete storedge:my-bucket/old-file.txt
+```
+
+## Step 4: Mount as a Filesystem
+
+Mount your stored.ge bucket as a local directory:
+
+```bash
+mkdir -p /mnt/storedge
+
+rclone mount storedge:my-bucket /mnt/storedge \
+  --vfs-cache-mode full \
+  --vfs-cache-max-size 10G \
+  --dir-cache-time 5m \
+  --daemon
+```
+
+Now you can use `/mnt/storedge` like a normal directory:
+
+```bash
+ls /mnt/storedge/
+cp file.txt /mnt/storedge/
+```
+
+To unmount:
+
+```bash
+fusermount -u /mnt/storedge
+```
+
+## Step 5: Serve via WebDAV, SFTP, or FTP
+
+Turn your stored.ge bucket into a WebDAV server accessible from any file manager:
+
+```bash
+rclone serve webdav storedge:my-bucket --addr :8080
+```
+
+Access it at `http://your-server:8080` from any WebDAV client (Windows Explorer, macOS Finder, Cyberduck).
+
+**SFTP server:**
+
+```bash
+rclone serve sftp storedge:my-bucket --addr :2222 --user myuser --pass mypass
+```
+
+**FTP server:**
+
+```bash
+rclone serve ftp storedge:my-bucket --addr :2121 --user myuser --pass mypass
+```
+
+This is useful for giving access to people who don't have rclone or S3 clients.
+
+## Automounting on Boot
+
+Create a systemd unit:
+
+```bash
+sudo tee /etc/systemd/system/rclone-storedge.service << 'EOF'
+[Unit]
+Description=rclone mount for stored.ge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/rclone mount storedge:my-bucket /mnt/storedge \
+  --vfs-cache-mode full \
+  --vfs-cache-max-size 10G \
+  --dir-cache-time 5m \
+  --allow-other
+ExecStop=/bin/fusermount -u /mnt/storedge
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now rclone-storedge
+```
+
+Make sure `/etc/fuse.conf` has `user_allow_other` uncommented for `--allow-other` to work.
+
+## Performance Tips
+
+**Increase parallelism** for large transfers:
+
+```bash
+rclone copy ./data storedge:my-bucket/ \
+  --transfers 16 \
+  --checkers 8 \
+  --s3-upload-concurrency 4
+```
+
+**VFS cache modes** (for mount):
+
+| Mode | Behavior | Best for |
+|------|----------|----------|
+| `off` | No caching, direct S3 reads | Rare access, save disk |
+| `minimal` | Cache open files only | Light usage |
+| `writes` | Cache writes, stream reads | Write-heavy workloads |
+| `full` | Cache everything | General use, media streaming |
+
+**Bandwidth limiting** (useful on metered connections):
+
+```bash
+rclone copy ./data storedge:my-bucket/ --bwlimit 50M
+```
+
+**Dry run** before destructive syncs:
+
+```bash
+rclone sync ./local storedge:my-bucket/ --dry-run
+```
+
+This shows what would be uploaded/deleted without actually doing it.

--- a/internal/api/compat_test_helpers.go
+++ b/internal/api/compat_test_helpers.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+func NewTestServer(eng *engine.CoreEngine, db *sql.DB, logger *zap.Logger) *Server {
+	return &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+}
+
+func (s *Server) HandleHeadObject(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	s.handleHeadObject(w, r, &S3Request{Bucket: bucket, Object: object})
+}
+
+func (s *Server) HandleCopyObject(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	s.handleCopyObject(w, r, &S3Request{Bucket: bucket, Object: object})
+}
+
+func (s *Server) HandleInitiateMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	s.handleInitiateMultipartUpload(w, r, bucket, object)
+}
+
+func (s *Server) HandleUploadPart(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	s.handleUploadPart(w, r, bucket, object)
+}
+
+func (s *Server) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, object string) {
+	s.handleCompleteMultipartUpload(w, r, bucket, object)
+}

--- a/tests/compatibility/s3_compat_test.go
+++ b/tests/compatibility/s3_compat_test.go
@@ -1,0 +1,551 @@
+package compatibility
+
+import (
+	"bytes"
+	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
+	"database/sql"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/api"
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type compatFixture struct {
+	server   *api.Server
+	adapter  *api.S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	tenantID string
+	tenant   *tenant.Tenant
+	tempDir  string
+	bucket   string
+}
+
+func setupCompatFixture(t *testing.T) *compatFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	ensureCompatTables(t, db)
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-compat-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("compat-%s-%d", t.Name(), os.Getpid())
+	bucket := "compat-bucket"
+	email := fmt.Sprintf("compat-%s-%d@test.local", t.Name(), os.Getpid())
+
+	// Clean up any leftovers from a prior run with the same tenant ID.
+	_, _ = db.Exec("DELETE FROM multipart_parts WHERE upload_id IN (SELECT upload_id FROM multipart_uploads WHERE tenant_id = $1)", tenantID)
+	_, _ = db.Exec("DELETE FROM multipart_uploads WHERE tenant_id = $1", tenantID)
+	_, _ = db.Exec("DELETE FROM object_versions WHERE tenant_id = $1", tenantID)
+	_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+	_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+	_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Compat Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, versioning_status)
+		VALUES ($1, $2, 'private', 'disabled')
+		ON CONFLICT (tenant_id, name) DO UPDATE SET versioning_status = 'disabled'
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM multipart_parts WHERE upload_id IN (SELECT upload_id FROM multipart_uploads WHERE tenant_id = $1)", tenantID)
+		_, _ = db.Exec("DELETE FROM multipart_uploads WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_versions WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tn.NamespaceContainer(bucket)
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	srv := api.NewTestServer(eng, db, logger)
+
+	return &compatFixture{
+		server:   srv,
+		adapter:  api.NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		tenantID: tenantID,
+		tenant:   tn,
+		tempDir:  tempDir,
+		bucket:   bucket,
+	}
+}
+
+func (f *compatFixture) put(t *testing.T, key, contentType string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key, bytes.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = int64(len(body))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, f.bucket, key)
+	return w
+}
+
+func (f *compatFixture) get(t *testing.T, key string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/"+f.bucket+"/"+key, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, f.bucket, key)
+	return w
+}
+
+func (f *compatFixture) head(t *testing.T, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("HEAD", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.HandleHeadObject(w, req, f.bucket, key)
+	return w
+}
+
+func (f *compatFixture) del(t *testing.T, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.adapter.HandleDelete(w, req, f.bucket, key)
+	return w
+}
+
+func (f *compatFixture) listV2(t *testing.T, params map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/" + f.bucket + "?list-type=2"
+	for k, v := range params {
+		url += "&" + k + "=" + v
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.adapter.HandleListV2(w, req, f.bucket)
+	return w
+}
+
+func md5hex(data []byte) string {
+	h := md5.Sum(data) // #nosec G401
+	return hex.EncodeToString(h[:])
+}
+
+func ensureCompatTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ddl := []string{
+		`CREATE TABLE IF NOT EXISTS multipart_uploads (
+			upload_id TEXT NOT NULL PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			bucket TEXT NOT NULL,
+			object_key TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE IF NOT EXISTS multipart_parts (
+			upload_id TEXT NOT NULL REFERENCES multipart_uploads(upload_id) ON DELETE CASCADE,
+			part_number INT NOT NULL,
+			etag TEXT NOT NULL,
+			size_bytes BIGINT NOT NULL,
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (upload_id, part_number)
+		)`,
+	}
+	for _, stmt := range ddl {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+}
+
+// --- Test groups ---
+
+func TestCompat_BasicCRUD(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	key := "compat/basic-crud.txt"
+	body := []byte("hello from rclone compatibility test")
+	expectedETag := md5hex(body)
+
+	// PUT
+	w := f.put(t, key, "text/plain", body)
+	require.Equal(t, http.StatusOK, w.Code, "PUT should succeed")
+	putETag := w.Header().Get("ETag")
+	assert.Contains(t, putETag, expectedETag, "PUT ETag should contain MD5 of body")
+
+	// GET — verify body
+	w = f.get(t, key, nil)
+	require.Equal(t, http.StatusOK, w.Code, "GET should succeed")
+	assert.Equal(t, body, w.Body.Bytes(), "GET body should match PUT body")
+
+	// HEAD — verify metadata
+	w = f.head(t, key)
+	require.Equal(t, http.StatusOK, w.Code, "HEAD should succeed")
+	assert.Equal(t, strconv.Itoa(len(body)), w.Header().Get("Content-Length"),
+		"HEAD Content-Length should match body size")
+	headETag := w.Header().Get("ETag")
+	assert.Contains(t, headETag, expectedETag, "HEAD ETag should match")
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"),
+		"HEAD Content-Type should match PUT")
+
+	// DELETE
+	w = f.del(t, key)
+	require.Equal(t, http.StatusNoContent, w.Code, "DELETE should return 204")
+
+	// GET after DELETE → 404
+	w = f.get(t, key, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code, "GET after DELETE should return 404")
+}
+
+func TestCompat_MultipartUpload(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	key := "compat/multipart.bin"
+	partSize := 6 * 1024 * 1024 // 6MB per part (exceeds 5MB minimum)
+	part1Data := bytes.Repeat([]byte("A"), partSize)
+	part2Data := bytes.Repeat([]byte("B"), partSize)
+
+	// Initiate
+	initReq := httptest.NewRequest("POST", "/"+f.bucket+"/"+key+"?uploads", nil)
+	ctx := tenant.WithTenant(initReq.Context(), f.tenant)
+	initReq = initReq.WithContext(ctx)
+	initW := httptest.NewRecorder()
+	f.server.HandleInitiateMultipartUpload(initW, initReq, f.bucket, key)
+	require.Equal(t, http.StatusOK, initW.Code, "InitiateMultipartUpload should succeed")
+
+	var initResult struct {
+		XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
+		Bucket   string   `xml:"Bucket"`
+		Key      string   `xml:"Key"`
+		UploadID string   `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(initW.Body.Bytes(), &initResult))
+	uploadID := initResult.UploadID
+	require.NotEmpty(t, uploadID, "upload ID should not be empty")
+
+	// UploadPart 1
+	part1Req := httptest.NewRequest("PUT",
+		"/"+f.bucket+"/"+key+"?partNumber=1&uploadId="+uploadID,
+		bytes.NewReader(part1Data))
+	ctx = tenant.WithTenant(part1Req.Context(), f.tenant)
+	part1Req = part1Req.WithContext(ctx)
+	part1W := httptest.NewRecorder()
+	f.server.HandleUploadPart(part1W, part1Req, f.bucket, key)
+	require.Equal(t, http.StatusOK, part1W.Code, "UploadPart 1 should succeed")
+	part1ETag := part1W.Header().Get("ETag")
+	require.NotEmpty(t, part1ETag)
+
+	// UploadPart 2
+	part2Req := httptest.NewRequest("PUT",
+		"/"+f.bucket+"/"+key+"?partNumber=2&uploadId="+uploadID,
+		bytes.NewReader(part2Data))
+	ctx = tenant.WithTenant(part2Req.Context(), f.tenant)
+	part2Req = part2Req.WithContext(ctx)
+	part2W := httptest.NewRecorder()
+	f.server.HandleUploadPart(part2W, part2Req, f.bucket, key)
+	require.Equal(t, http.StatusOK, part2W.Code, "UploadPart 2 should succeed")
+	part2ETag := part2W.Header().Get("ETag")
+	require.NotEmpty(t, part2ETag)
+
+	// CompleteMultipartUpload
+	completeBody := fmt.Sprintf(`<CompleteMultipartUpload>
+		<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
+		<Part><PartNumber>2</PartNumber><ETag>%s</ETag></Part>
+	</CompleteMultipartUpload>`, part1ETag, part2ETag)
+
+	completeReq := httptest.NewRequest("POST",
+		"/"+f.bucket+"/"+key+"?uploadId="+uploadID,
+		strings.NewReader(completeBody))
+	ctx = tenant.WithTenant(completeReq.Context(), f.tenant)
+	completeReq = completeReq.WithContext(ctx)
+	completeW := httptest.NewRecorder()
+	f.server.HandleCompleteMultipartUpload(completeW, completeReq, f.bucket, key)
+	require.Equal(t, http.StatusOK, completeW.Code, "CompleteMultipartUpload should succeed")
+
+	var completeResult struct {
+		XMLName xml.Name `xml:"CompleteMultipartUploadResult"`
+		ETag    string   `xml:"ETag"`
+	}
+	require.NoError(t, xml.Unmarshal(completeW.Body.Bytes(), &completeResult))
+	assert.NotEmpty(t, completeResult.ETag, "complete should return an ETag")
+	assert.Contains(t, completeResult.ETag, "-2", "multipart ETag should end with -2")
+
+	// GET assembled object — verify concatenated body
+	w := f.get(t, key, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	expected := append(part1Data, part2Data...)
+	assert.Equal(t, len(expected), w.Body.Len(),
+		"assembled object size should equal sum of parts")
+	assert.Equal(t, expected, w.Body.Bytes(),
+		"assembled object should be part1 + part2")
+
+	// Cleanup
+	f.del(t, key)
+}
+
+func TestCompat_ListObjects(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	// PUT 5 objects with a common prefix
+	prefix := "compat-prefix/"
+	keys := []string{
+		prefix + "alpha.txt",
+		prefix + "bravo.txt",
+		prefix + "charlie.txt",
+		prefix + "delta.txt",
+		prefix + "echo.txt",
+	}
+	for _, k := range keys {
+		w := f.put(t, k, "text/plain", []byte("data-"+k))
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			f.del(t, k)
+		}
+	})
+
+	// ListObjectsV2 — all 5 should appear
+	w := f.listV2(t, map[string]string{"prefix": prefix})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var listResult api.ListBucketV2Result
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &listResult))
+	assert.Equal(t, 5, len(listResult.Contents),
+		"all 5 objects should be listed")
+
+	returnedKeys := make([]string, len(listResult.Contents))
+	for i, c := range listResult.Contents {
+		returnedKeys[i] = c.Key
+	}
+	for _, k := range keys {
+		assert.Contains(t, returnedKeys, k, "key %s should be in listing", k)
+	}
+
+	// PUT objects at a different prefix
+	otherKey := "other-prefix/file.txt"
+	w = f.put(t, otherKey, "text/plain", []byte("other"))
+	require.Equal(t, http.StatusOK, w.Code)
+	t.Cleanup(func() { f.del(t, otherKey) })
+
+	// ListObjectsV2 with prefix filter — only the 5
+	w = f.listV2(t, map[string]string{"prefix": prefix})
+	require.Equal(t, http.StatusOK, w.Code)
+	var filteredResult api.ListBucketV2Result
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &filteredResult))
+	assert.Equal(t, 5, len(filteredResult.Contents),
+		"prefix filter should exclude other-prefix/")
+
+	// ListObjectsV2 with max-keys=2 — verify truncation
+	w = f.listV2(t, map[string]string{"prefix": prefix, "max-keys": "2"})
+	require.Equal(t, http.StatusOK, w.Code)
+	var truncResult api.ListBucketV2Result
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &truncResult))
+	assert.Equal(t, 2, len(truncResult.Contents),
+		"max-keys=2 should return exactly 2 objects")
+	assert.True(t, truncResult.IsTruncated,
+		"listing should be truncated when max-keys < total objects")
+	assert.NotEmpty(t, truncResult.NextContinuationToken,
+		"truncated listing should include NextContinuationToken")
+}
+
+func TestCompat_CopyObject(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	srcKey := "compat/copy-source.txt"
+	dstKey := "compat/copy-dest.txt"
+	body := []byte("copy me via x-amz-copy-source")
+
+	// PUT source
+	w := f.put(t, srcKey, "text/plain", body)
+	require.Equal(t, http.StatusOK, w.Code)
+	t.Cleanup(func() {
+		f.del(t, srcKey)
+		f.del(t, dstKey)
+	})
+
+	// CopyObject: PUT dest with x-amz-copy-source
+	copyReq := httptest.NewRequest("PUT", "/"+f.bucket+"/"+dstKey, nil)
+	copyReq.Header.Set("x-amz-copy-source", "/"+f.bucket+"/"+srcKey)
+	ctx := tenant.WithTenant(copyReq.Context(), f.tenant)
+	copyReq = copyReq.WithContext(ctx)
+	copyW := httptest.NewRecorder()
+	f.server.HandleCopyObject(copyW, copyReq, f.bucket, dstKey)
+	require.Equal(t, http.StatusOK, copyW.Code, "CopyObject should succeed")
+
+	// Verify CopyObjectResult XML
+	var copyResult struct {
+		XMLName xml.Name `xml:"CopyObjectResult"`
+		ETag    string   `xml:"ETag"`
+	}
+	require.NoError(t, xml.Unmarshal(copyW.Body.Bytes(), &copyResult))
+	assert.NotEmpty(t, copyResult.ETag, "CopyObjectResult should have an ETag")
+
+	// GET destination — verify body matches source
+	w = f.get(t, dstKey, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, body, w.Body.Bytes(), "copied object body should match source")
+
+	// Source should still exist
+	w = f.get(t, srcKey, nil)
+	require.Equal(t, http.StatusOK, w.Code, "source should still exist after copy")
+	assert.Equal(t, body, w.Body.Bytes())
+}
+
+func TestCompat_BucketOperations(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	newBucket := "compat-ops-test"
+
+	// CreateBucket
+	createReq := httptest.NewRequest("PUT", "/"+newBucket, nil)
+	ctx := tenant.WithTenant(createReq.Context(), f.tenant)
+	createReq = createReq.WithContext(ctx)
+	createW := httptest.NewRecorder()
+	f.server.CreateBucket(createW, createReq)
+	require.Equal(t, http.StatusOK, createW.Code, "CreateBucket should succeed")
+
+	// ListBuckets — verify it appears
+	listReq := httptest.NewRequest("GET", "/", nil)
+	ctx = tenant.WithTenant(listReq.Context(), f.tenant)
+	listReq = listReq.WithContext(ctx)
+	listW := httptest.NewRecorder()
+	f.server.ListBuckets(listW, listReq)
+	require.Equal(t, http.StatusOK, listW.Code, "ListBuckets should succeed")
+
+	var listResult api.ListBucketsResponse
+	require.NoError(t, xml.Unmarshal(listW.Body.Bytes(), &listResult))
+	found := false
+	for _, b := range listResult.Buckets.Bucket {
+		if b.Name == newBucket {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "new bucket should appear in ListBuckets")
+
+	// DeleteBucket
+	delReq := httptest.NewRequest("DELETE", "/"+newBucket, nil)
+	ctx = tenant.WithTenant(delReq.Context(), f.tenant)
+	delReq = delReq.WithContext(ctx)
+	delW := httptest.NewRecorder()
+	f.server.DeleteBucket(delW, delReq)
+	require.Equal(t, http.StatusNoContent, delW.Code, "DeleteBucket should return 204")
+}
+
+func TestCompat_ConditionalRequests(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	key := "compat/conditional.txt"
+	body := []byte("conditional request test body")
+	expectedETag := md5hex(body)
+
+	// PUT
+	w := f.put(t, key, "text/plain", body)
+	require.Equal(t, http.StatusOK, w.Code)
+	t.Cleanup(func() { f.del(t, key) })
+
+	// HEAD — verify ETag is quoted (rclone parses this strictly)
+	w = f.head(t, key)
+	require.Equal(t, http.StatusOK, w.Code)
+	headETag := w.Header().Get("ETag")
+	assert.True(t, strings.HasPrefix(headETag, `"`), "ETag must start with quote")
+	assert.True(t, strings.HasSuffix(headETag, `"`), "ETag must end with quote")
+	assert.Contains(t, headETag, expectedETag, "ETag should contain the MD5 hash")
+
+	// GET with If-None-Match (matching ETag) → 304
+	w = f.get(t, key, map[string]string{"If-None-Match": headETag})
+	assert.Equal(t, http.StatusNotModified, w.Code,
+		"GET with matching If-None-Match should return 304")
+
+	// GET with If-None-Match (different ETag) → 200 with body
+	w = f.get(t, key, map[string]string{"If-None-Match": `"0000000000000000"`})
+	require.Equal(t, http.StatusOK, w.Code,
+		"GET with non-matching If-None-Match should return 200")
+	assert.Equal(t, body, w.Body.Bytes(), "body should be returned on 200")
+}
+
+func TestCompat_RangeRequests(t *testing.T) {
+	f := setupCompatFixture(t)
+
+	key := "compat/range.bin"
+	body := make([]byte, 10240) // 10KB
+	for i := range body {
+		body[i] = byte(i % 256)
+	}
+
+	// PUT
+	w := f.put(t, key, "application/octet-stream", body)
+	require.Equal(t, http.StatusOK, w.Code)
+	t.Cleanup(func() { f.del(t, key) })
+
+	// Range: bytes=0-999 → 206 + exactly 1000 bytes
+	w = f.get(t, key, map[string]string{"Range": "bytes=0-999"})
+	assert.Equal(t, http.StatusPartialContent, w.Code,
+		"range request should return 206")
+	assert.Equal(t, 1000, w.Body.Len(),
+		"range bytes=0-999 should return exactly 1000 bytes")
+	assert.Equal(t, body[:1000], w.Body.Bytes(),
+		"range content should match expected byte slice")
+	assert.Contains(t, w.Header().Get("Content-Range"), "bytes 0-999/10240",
+		"Content-Range header should be set correctly")
+
+	// Range: bytes=1000-1999 → correct middle slice
+	w = f.get(t, key, map[string]string{"Range": "bytes=1000-1999"})
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, 1000, w.Body.Len())
+	assert.Equal(t, body[1000:2000], w.Body.Bytes(),
+		"second range should return the correct byte slice")
+	assert.Contains(t, w.Header().Get("Content-Range"), "bytes 1000-1999/10240")
+}


### PR DESCRIPTION
## Summary
- **Compatibility test suite** (`tests/compatibility/s3_compat_test.go`) — 7 test groups exercising all S3 operations rclone and JuiceFS depend on: basic CRUD, multipart upload (6MB parts), ListObjectsV2 with pagination/prefix/truncation, CopyObject, bucket CRUD, conditional requests (If-None-Match → 304, quoted ETag verification), and range requests (206 partial content)
- **Test helper exports** (`internal/api/compat_test_helpers.go`) — thin exported wrappers so the compatibility suite (separate package) can call Server methods like HandleHeadObject and HandleCopyObject
- **Three marketing-ready guides** in `docs/guides/` targeting r/selfhosted and LowEndTalk:
  - `juicefs-setup.md` — mount stored.ge as POSIX filesystem with JuiceFS (SQLite metadata, systemd, caching)
  - `juicefs-use-cases.md` — 6 use cases: Plex/Jellyfin, Nextcloud, Immich, Git LFS, database backups, *arr stack
  - `rclone-setup.md` — rclone config, sync/copy/mount/serve (WebDAV/SFTP/FTP), systemd, performance tuning

## Test plan
- [x] All 7 compatibility tests pass with DATABASE_URL (`go test -v -race ./tests/compatibility/`)
- [x] Tests skip cleanly without DATABASE_URL
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] Pre-commit hooks pass (go fmt, go test, golangci-lint)
- [x] Existing `internal/api` tests unaffected