### PR TITLE
feat(s3): pre-signed URL verification for browser-direct uploads [Phase 5.10.16]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -82,6 +84,7 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -15,6 +15,8 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3_notifications.go** — Bucket notification configuration
 - **s3_copy.go** — CopyObject handler
 - **s3_list.go** — ListObjectsV2 handler
+- **s3_presign.go** — Pre-signed URL verification (SigV4 query string auth) and URL generation
+- **presigned.go** — Management API endpoint for generating pre-signed URLs (`/api/v1/presigned`)
 
 ## Error Response Pattern
 
@@ -47,9 +49,20 @@ if suggestion := bucketSuggestion(ctx, s.db, tenantID, bucket); suggestion != ""
 
 ## Auth Flow
 
-1. `handleS3Request` calls `auth.ValidateRequest(r)` which parses the Authorization header
-2. On failure, `authErrorHint` maps the error to a hint, and `WriteS3ErrorWithContext` returns it
-3. On success, tenant context is set and the request is routed to the operation handler
+1. `handleS3Request` checks `isPresignedRequest(r)` — if query has `X-Amz-Algorithm=AWS4-HMAC-SHA256`, routes to `verifyPresignedURL` (SigV4 query string auth)
+2. Otherwise calls `auth.ValidateRequest(r)` which parses the Authorization header
+3. On failure, returns appropriate S3 error (presigned errors: `ExpiredToken`, `AuthorizationQueryParametersError`, `SignatureDoesNotMatch`)
+4. On success, tenant context is set and the request is routed to the operation handler
+
+### Pre-Signed URL Verification (Phase 5.10.16)
+
+`verifyPresignedURL` validates S3 SigV4 query-string auth for browser-direct uploads:
+- Parses X-Amz-Credential to extract access key, then looks up secret key + tenant ID from `tenants` table
+- Validates expiration (X-Amz-Date + X-Amz-Expires), rejects expired requests
+- Rebuilds canonical request (excludes X-Amz-Signature from query string, uses UNSIGNED-PAYLOAD)
+- Computes signature and compares with `hmac.Equal` (constant-time)
+
+Management API at `/api/v1/presigned` (JWT-protected) generates pre-signed URLs for dashboard users without needing an AWS SDK.
 
 ## Tenant Context
 

--- a/internal/api/presigned.go
+++ b/internal/api/presigned.go
@@ -1,33 +1,77 @@
 package api
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
-
-func generateToken() string {
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
-}
 
 func (s *Server) handleGetPresignedURL(w http.ResponseWriter, r *http.Request) {
 	bucket := r.URL.Query().Get("bucket")
 	key := r.URL.Query().Get("key")
+	method := r.URL.Query().Get("method")
+	expiresStr := r.URL.Query().Get("expires")
 
-	// Build public URL (no auth needed for 1 hour)
-	publicURL := fmt.Sprintf("http://localhost:8000/%s/%s?token=%s&expires=%d",
-		bucket, key,
-		generateToken(),
-		time.Now().Add(time.Hour).Unix())
+	if bucket == "" || key == "" {
+		http.Error(w, `{"error":"bucket and key are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if method == "" {
+		method = "GET"
+	}
+	if method != "GET" && method != "PUT" {
+		http.Error(w, `{"error":"method must be GET or PUT"}`, http.StatusBadRequest)
+		return
+	}
+
+	expiresSec := 3600
+	if expiresStr != "" {
+		var err error
+		expiresSec, err = strconv.Atoi(expiresStr)
+		if err != nil || expiresSec < 1 || expiresSec > presignMaxExpires {
+			http.Error(w, `{"error":"expires must be between 1 and 604800 seconds"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	tenantID, ok := r.Context().Value(tenantIDKey).(string)
+	if !ok || tenantID == "" {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	if s.db == nil {
+		http.Error(w, `{"error":"database not available"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var accessKey, secretKey string
+	err := s.db.QueryRowContext(r.Context(),
+		`SELECT access_key, secret_key FROM tenants WHERE id = $1`, tenantID,
+	).Scan(&accessKey, &secretKey)
+	if err != nil {
+		http.Error(w, `{"error":"tenant credentials not found"}`, http.StatusNotFound)
+		return
+	}
+
+	baseURL := s.getBaseURL()
+
+	presignedURL, expiresAt := generatePresignedS3URL(baseURL, accessKey, secretKey, bucket, key, method, expiresSec)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"url":     publicURL,
-		"expires": time.Now().Add(time.Hour).Format(time.RFC3339),
+		"url":        presignedURL,
+		"expires_at": expiresAt.Format(time.RFC3339),
+		"method":     method,
 	})
+}
+
+func (s *Server) getBaseURL() string {
+	port := 8000
+	if s.config != nil {
+		port = s.config.Server.Port
+	}
+	return getPublicEndpoint(port)
 }

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -222,25 +222,46 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if !s.testMode {
-		auth := auth.NewAuth(s.db, s.logger)
-		tenantID, err = auth.ValidateRequest(r)
-		if err != nil {
-			s.logger.Error("authentication failed",
-				zap.Error(err),
-				zap.String("path", r.URL.Path))
+		if isPresignedRequest(r) {
+			tenantID, err = s.verifyPresignedURL(r)
+			if err != nil {
+				s.logger.Error("presigned URL verification failed",
+					zap.Error(err),
+					zap.String("path", r.URL.Path))
 
-			errCode := ErrAccessDenied
-			if strings.Contains(err.Error(), "invalid authorization format") ||
-				strings.Contains(err.Error(), "parse") {
-				errCode = ErrSignatureDoesNotMatch
+				errCode := err.Error()
+				reqID := generateRequestID()
+				switch errCode {
+				case ErrExpiredPresignedRequest, ErrSignatureDoesNotMatch,
+					ErrAccessDenied, ErrAuthorizationQueryParametersError,
+					ErrInvalidPresignExpires:
+					WriteS3Error(w, errCode, r.URL.Path, reqID)
+				default:
+					WriteS3Error(w, ErrAccessDenied, r.URL.Path, reqID)
+				}
+				return
 			}
-			reqID := generateRequestID()
-			if hint := authErrorHint(err.Error()); hint != "" {
-				WriteS3ErrorWithContext(w, errCode, r.URL.Path, reqID, WithSuggestion(hint))
-			} else {
-				WriteS3Error(w, errCode, r.URL.Path, reqID)
+		} else {
+			auth := auth.NewAuth(s.db, s.logger)
+			tenantID, err = auth.ValidateRequest(r)
+			if err != nil {
+				s.logger.Error("authentication failed",
+					zap.Error(err),
+					zap.String("path", r.URL.Path))
+
+				errCode := ErrAccessDenied
+				if strings.Contains(err.Error(), "invalid authorization format") ||
+					strings.Contains(err.Error(), "parse") {
+					errCode = ErrSignatureDoesNotMatch
+				}
+				reqID := generateRequestID()
+				if hint := authErrorHint(err.Error()); hint != "" {
+					WriteS3ErrorWithContext(w, errCode, r.URL.Path, reqID, WithSuggestion(hint))
+				} else {
+					WriteS3Error(w, errCode, r.URL.Path, reqID)
+				}
+				return
 			}
-			return
 		}
 	} else {
 		if t, err := tenant.FromContext(r.Context()); err == nil && t != nil {

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -21,98 +21,107 @@ type S3Error struct {
 
 // S3 Error codes
 const (
-	ErrNoSuchBucket           = "NoSuchBucket"
-	ErrNoSuchKey              = "NoSuchKey"
-	ErrBucketAlreadyExists    = "BucketAlreadyExists"
-	ErrBucketNotEmpty         = "BucketNotEmpty"
-	ErrInvalidBucketName      = "InvalidBucketName"
-	ErrInvalidObjectName      = "InvalidObjectName"
-	ErrAccessDenied           = "AccessDenied"
-	ErrInvalidRequest         = "InvalidRequest"
-	ErrIncompleteBody         = "IncompleteBody"
-	ErrInternalError          = "InternalError"
-	ErrNotImplemented         = "NotImplemented"
-	ErrMissingContentLength   = "MissingContentLength"
-	ErrRequestTimeout         = "RequestTimeout"
-	ErrBadDigest              = "BadDigest"
-	ErrEntityTooLarge         = "EntityTooLarge"
-	ErrMalformedXML           = "MalformedXML"
-	ErrMethodNotAllowed       = "MethodNotAllowed"
-	ErrSignatureDoesNotMatch  = "SignatureDoesNotMatch"
-	ErrAccountSuspended       = "AccountSuspended"
-	ErrSlowDown               = "SlowDown"
-	ErrNoSuchUpload           = "NoSuchUpload"
-	ErrInvalidPart            = "InvalidPart"
-	ErrInvalidPartOrder       = "InvalidPartOrder"
-	ErrEntityTooSmall         = "EntityTooSmall"
-	ErrInvalidPartNumber      = "InvalidPartNumber"
-	ErrNoSuchVersion          = "NoSuchVersion"
-	ErrObjectLocked           = "ObjectLocked"
-	ErrInvalidRetentionPeriod = "InvalidRetentionPeriod"
+	ErrNoSuchBucket                      = "NoSuchBucket"
+	ErrNoSuchKey                         = "NoSuchKey"
+	ErrBucketAlreadyExists               = "BucketAlreadyExists"
+	ErrBucketNotEmpty                    = "BucketNotEmpty"
+	ErrInvalidBucketName                 = "InvalidBucketName"
+	ErrInvalidObjectName                 = "InvalidObjectName"
+	ErrAccessDenied                      = "AccessDenied"
+	ErrInvalidRequest                    = "InvalidRequest"
+	ErrIncompleteBody                    = "IncompleteBody"
+	ErrInternalError                     = "InternalError"
+	ErrNotImplemented                    = "NotImplemented"
+	ErrMissingContentLength              = "MissingContentLength"
+	ErrRequestTimeout                    = "RequestTimeout"
+	ErrBadDigest                         = "BadDigest"
+	ErrEntityTooLarge                    = "EntityTooLarge"
+	ErrMalformedXML                      = "MalformedXML"
+	ErrMethodNotAllowed                  = "MethodNotAllowed"
+	ErrSignatureDoesNotMatch             = "SignatureDoesNotMatch"
+	ErrAccountSuspended                  = "AccountSuspended"
+	ErrSlowDown                          = "SlowDown"
+	ErrNoSuchUpload                      = "NoSuchUpload"
+	ErrInvalidPart                       = "InvalidPart"
+	ErrInvalidPartOrder                  = "InvalidPartOrder"
+	ErrEntityTooSmall                    = "EntityTooSmall"
+	ErrInvalidPartNumber                 = "InvalidPartNumber"
+	ErrNoSuchVersion                     = "NoSuchVersion"
+	ErrObjectLocked                      = "ObjectLocked"
+	ErrInvalidRetentionPeriod            = "InvalidRetentionPeriod"
+	ErrExpiredPresignedRequest           = "ExpiredToken"
+	ErrAuthorizationQueryParametersError = "AuthorizationQueryParametersError"
+	ErrInvalidPresignExpires             = "AuthorizationQueryParametersError_Expires"
 )
 
 // Error messages
 var errorMessages = map[string]string{
-	ErrNoSuchBucket:           "The specified bucket does not exist",
-	ErrNoSuchKey:              "The specified key does not exist",
-	ErrBucketAlreadyExists:    "The requested bucket name is not available",
-	ErrBucketNotEmpty:         "The bucket you tried to delete is not empty",
-	ErrInvalidBucketName:      "The specified bucket is not valid",
-	ErrInvalidObjectName:      "The specified object name is not valid",
-	ErrAccessDenied:           "Access denied",
-	ErrInvalidRequest:         "Invalid request",
-	ErrIncompleteBody:         "You did not provide the number of bytes specified by the Content-Length HTTP header",
-	ErrInternalError:          "We encountered an internal error. Please try again",
-	ErrNotImplemented:         "A feature you requested is not yet implemented",
-	ErrMissingContentLength:   "You must provide the Content-Length HTTP header",
-	ErrRequestTimeout:         "Your socket connection to the server was not read from or written to within the timeout period",
-	ErrBadDigest:              "The Content-MD5 you specified did not match what we received",
-	ErrEntityTooLarge:         "Your proposed upload exceeds the maximum allowed size",
-	ErrMalformedXML:           "The XML you provided was not well-formed or did not validate against our published schema",
-	ErrMethodNotAllowed:       "The specified method is not allowed against this resource",
-	ErrSignatureDoesNotMatch:  "The request signature we calculated does not match the signature you provided",
-	ErrAccountSuspended:       "Your account has been suspended. Contact support for assistance.",
-	ErrSlowDown:               "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
-	ErrNoSuchUpload:           "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
-	ErrInvalidPart:            "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-	ErrInvalidPartOrder:       "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
-	ErrEntityTooSmall:         "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
-	ErrInvalidPartNumber:      "Part number must be an integer between 1 and 10000, inclusive.",
-	ErrNoSuchVersion:          "The version ID specified in the request does not match an existing version.",
-	ErrObjectLocked:           "Object is protected by Object Lock",
-	ErrInvalidRetentionPeriod: "The retention period specified is not valid",
+	ErrNoSuchBucket:                      "The specified bucket does not exist",
+	ErrNoSuchKey:                         "The specified key does not exist",
+	ErrBucketAlreadyExists:               "The requested bucket name is not available",
+	ErrBucketNotEmpty:                    "The bucket you tried to delete is not empty",
+	ErrInvalidBucketName:                 "The specified bucket is not valid",
+	ErrInvalidObjectName:                 "The specified object name is not valid",
+	ErrAccessDenied:                      "Access denied",
+	ErrInvalidRequest:                    "Invalid request",
+	ErrIncompleteBody:                    "You did not provide the number of bytes specified by the Content-Length HTTP header",
+	ErrInternalError:                     "We encountered an internal error. Please try again",
+	ErrNotImplemented:                    "A feature you requested is not yet implemented",
+	ErrMissingContentLength:              "You must provide the Content-Length HTTP header",
+	ErrRequestTimeout:                    "Your socket connection to the server was not read from or written to within the timeout period",
+	ErrBadDigest:                         "The Content-MD5 you specified did not match what we received",
+	ErrEntityTooLarge:                    "Your proposed upload exceeds the maximum allowed size",
+	ErrMalformedXML:                      "The XML you provided was not well-formed or did not validate against our published schema",
+	ErrMethodNotAllowed:                  "The specified method is not allowed against this resource",
+	ErrSignatureDoesNotMatch:             "The request signature we calculated does not match the signature you provided",
+	ErrAccountSuspended:                  "Your account has been suspended. Contact support for assistance.",
+	ErrSlowDown:                          "Monthly bandwidth limit exceeded. Upgrade your plan or wait for the next billing cycle.",
+	ErrNoSuchUpload:                      "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+	ErrInvalidPart:                       "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+	ErrInvalidPartOrder:                  "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+	ErrEntityTooSmall:                    "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
+	ErrInvalidPartNumber:                 "Part number must be an integer between 1 and 10000, inclusive.",
+	ErrNoSuchVersion:                     "The version ID specified in the request does not match an existing version.",
+	ErrObjectLocked:                      "Object is protected by Object Lock",
+	ErrInvalidRetentionPeriod:            "The retention period specified is not valid",
+	ErrExpiredPresignedRequest:           "Request has expired",
+	ErrAuthorizationQueryParametersError: "Query-string authentication requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-SignedHeaders, and X-Amz-Signature parameters",
+	ErrInvalidPresignExpires:             "X-Amz-Expires must be between 1 and 604800 seconds",
 }
 
 // HTTP status codes for errors
 var errorStatusCodes = map[string]int{
-	ErrNoSuchBucket:           http.StatusNotFound,
-	ErrNoSuchKey:              http.StatusNotFound,
-	ErrBucketAlreadyExists:    http.StatusConflict,
-	ErrBucketNotEmpty:         http.StatusConflict,
-	ErrInvalidBucketName:      http.StatusBadRequest,
-	ErrInvalidObjectName:      http.StatusBadRequest,
-	ErrAccessDenied:           http.StatusForbidden,
-	ErrInvalidRequest:         http.StatusBadRequest,
-	ErrIncompleteBody:         http.StatusBadRequest,
-	ErrInternalError:          http.StatusInternalServerError,
-	ErrNotImplemented:         http.StatusNotImplemented,
-	ErrMissingContentLength:   http.StatusLengthRequired,
-	ErrRequestTimeout:         http.StatusRequestTimeout,
-	ErrBadDigest:              http.StatusBadRequest,
-	ErrEntityTooLarge:         http.StatusRequestEntityTooLarge,
-	ErrMalformedXML:           http.StatusBadRequest,
-	ErrMethodNotAllowed:       http.StatusMethodNotAllowed,
-	ErrSignatureDoesNotMatch:  http.StatusForbidden,
-	ErrAccountSuspended:       http.StatusForbidden,
-	ErrSlowDown:               http.StatusTooManyRequests,
-	ErrNoSuchUpload:           http.StatusNotFound,
-	ErrInvalidPart:            http.StatusBadRequest,
-	ErrInvalidPartOrder:       http.StatusBadRequest,
-	ErrEntityTooSmall:         http.StatusBadRequest,
-	ErrInvalidPartNumber:      http.StatusBadRequest,
-	ErrNoSuchVersion:          http.StatusNotFound,
-	ErrObjectLocked:           http.StatusForbidden,
-	ErrInvalidRetentionPeriod: http.StatusBadRequest,
+	ErrNoSuchBucket:                      http.StatusNotFound,
+	ErrNoSuchKey:                         http.StatusNotFound,
+	ErrBucketAlreadyExists:               http.StatusConflict,
+	ErrBucketNotEmpty:                    http.StatusConflict,
+	ErrInvalidBucketName:                 http.StatusBadRequest,
+	ErrInvalidObjectName:                 http.StatusBadRequest,
+	ErrAccessDenied:                      http.StatusForbidden,
+	ErrInvalidRequest:                    http.StatusBadRequest,
+	ErrIncompleteBody:                    http.StatusBadRequest,
+	ErrInternalError:                     http.StatusInternalServerError,
+	ErrNotImplemented:                    http.StatusNotImplemented,
+	ErrMissingContentLength:              http.StatusLengthRequired,
+	ErrRequestTimeout:                    http.StatusRequestTimeout,
+	ErrBadDigest:                         http.StatusBadRequest,
+	ErrEntityTooLarge:                    http.StatusRequestEntityTooLarge,
+	ErrMalformedXML:                      http.StatusBadRequest,
+	ErrMethodNotAllowed:                  http.StatusMethodNotAllowed,
+	ErrSignatureDoesNotMatch:             http.StatusForbidden,
+	ErrAccountSuspended:                  http.StatusForbidden,
+	ErrSlowDown:                          http.StatusTooManyRequests,
+	ErrNoSuchUpload:                      http.StatusNotFound,
+	ErrInvalidPart:                       http.StatusBadRequest,
+	ErrInvalidPartOrder:                  http.StatusBadRequest,
+	ErrEntityTooSmall:                    http.StatusBadRequest,
+	ErrInvalidPartNumber:                 http.StatusBadRequest,
+	ErrNoSuchVersion:                     http.StatusNotFound,
+	ErrObjectLocked:                      http.StatusForbidden,
+	ErrInvalidRetentionPeriod:            http.StatusBadRequest,
+	ErrExpiredPresignedRequest:           http.StatusForbidden,
+	ErrAuthorizationQueryParametersError: http.StatusBadRequest,
+	ErrInvalidPresignExpires:             http.StatusBadRequest,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_presign.go
+++ b/internal/api/s3_presign.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	presignAlgorithm     = "AWS4-HMAC-SHA256"
+	presignTimeFormat    = "20060102T150405Z"
+	presignDateFormat    = "20060102"
+	presignService       = "s3"
+	presignAWS4Request   = "aws4_request"
+	presignMaxExpires    = 604800
+	presignDefaultRegion = "us-east-1"
+)
+
+func isPresignedRequest(r *http.Request) bool {
+	return r.URL.Query().Get("X-Amz-Algorithm") == presignAlgorithm
+}
+
+func (s *Server) verifyPresignedURL(r *http.Request) (string, error) {
+	q := r.URL.Query()
+
+	algorithm := q.Get("X-Amz-Algorithm")
+	credential := q.Get("X-Amz-Credential")
+	amzDate := q.Get("X-Amz-Date")
+	expiresStr := q.Get("X-Amz-Expires")
+	signedHeaders := q.Get("X-Amz-SignedHeaders")
+	signature := q.Get("X-Amz-Signature")
+
+	if algorithm == "" || credential == "" || amzDate == "" ||
+		expiresStr == "" || signedHeaders == "" || signature == "" {
+		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+	}
+
+	expires, err := strconv.Atoi(expiresStr)
+	if err != nil || expires < 1 || expires > presignMaxExpires {
+		return "", fmt.Errorf("%s", ErrInvalidPresignExpires)
+	}
+
+	credParts := strings.Split(credential, "/")
+	if len(credParts) != 5 || credParts[3] != presignService || credParts[4] != presignAWS4Request {
+		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+	}
+	accessKey := credParts[0]
+	credDate := credParts[1]
+	region := credParts[2]
+
+	reqTime, err := time.Parse(presignTimeFormat, amzDate)
+	if err != nil {
+		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+	}
+
+	if time.Now().UTC().After(reqTime.Add(time.Duration(expires) * time.Second)) {
+		return "", fmt.Errorf("%s", ErrExpiredPresignedRequest)
+	}
+
+	if s.db == nil {
+		return "", fmt.Errorf("%s: database not available", ErrAccessDenied)
+	}
+
+	var secretKey, tenantID string
+	err = s.db.QueryRow(
+		`SELECT secret_key, id FROM tenants WHERE access_key = $1`, accessKey,
+	).Scan(&secretKey, &tenantID)
+	if err != nil {
+		return "", fmt.Errorf("%s", ErrAccessDenied)
+	}
+
+	canonicalURI := uriEncodePath(r.URL.Path)
+
+	canonicalQueryString := buildPresignCanonicalQuery(q)
+
+	headers := strings.Split(signedHeaders, ";")
+	sort.Strings(headers)
+	var canonicalHeadersBuf strings.Builder
+	for _, h := range headers {
+		key := strings.ToLower(strings.TrimSpace(h))
+		var val string
+		if key == "host" {
+			val = r.Host
+		} else {
+			val = r.Header.Get(h)
+		}
+		canonicalHeadersBuf.WriteString(key)
+		canonicalHeadersBuf.WriteByte(':')
+		canonicalHeadersBuf.WriteString(strings.TrimSpace(val))
+		canonicalHeadersBuf.WriteByte('\n')
+	}
+
+	canonicalRequest := strings.Join([]string{
+		r.Method,
+		canonicalURI,
+		canonicalQueryString,
+		canonicalHeadersBuf.String(),
+		signedHeaders,
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", credDate, region, presignService, presignAWS4Request)
+
+	hash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		presignAlgorithm,
+		amzDate,
+		credentialScope,
+		hex.EncodeToString(hash[:]),
+	}, "\n")
+
+	signingKey := presignDeriveKey(secretKey, credDate, region)
+	expectedSig := hex.EncodeToString(presignHMAC(signingKey, []byte(stringToSign)))
+
+	if !hmac.Equal([]byte(expectedSig), []byte(signature)) {
+		return "", fmt.Errorf("%s", ErrSignatureDoesNotMatch)
+	}
+
+	return tenantID, nil
+}
+
+func buildPresignCanonicalQuery(values url.Values) string {
+	var keys []string
+	for k := range values {
+		if k == "X-Amz-Signature" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var pairs []string
+	for _, k := range keys {
+		vs := make([]string, len(values[k]))
+		copy(vs, values[k])
+		sort.Strings(vs)
+		for _, v := range vs {
+			pairs = append(pairs, url.QueryEscape(k)+"="+url.QueryEscape(v))
+		}
+	}
+	return strings.Join(pairs, "&")
+}
+
+func uriEncodePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = uriEncodeSegment(seg)
+	}
+	return strings.Join(segments, "/")
+}
+
+func uriEncodeSegment(s string) string {
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isURIUnreserved(c) {
+			buf.WriteByte(c)
+		} else {
+			fmt.Fprintf(&buf, "%%%02X", c)
+		}
+	}
+	return buf.String()
+}
+
+func isURIUnreserved(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '~'
+}
+
+func presignDeriveKey(secretKey, date, region string) []byte {
+	kDate := presignHMAC([]byte("AWS4"+secretKey), []byte(date))
+	kRegion := presignHMAC(kDate, []byte(region))
+	kService := presignHMAC(kRegion, []byte(presignService))
+	return presignHMAC(kService, []byte(presignAWS4Request))
+}
+
+func presignHMAC(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func generatePresignedS3URL(baseURL, accessKey, secretKey, bucket, key, method string, expiresSec int) (string, time.Time) {
+	now := time.Now().UTC()
+	date := now.Format(presignDateFormat)
+	amzDate := now.Format(presignTimeFormat)
+	expiresAt := now.Add(time.Duration(expiresSec) * time.Second)
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", date, presignDefaultRegion, presignService, presignAWS4Request)
+	credential := fmt.Sprintf("%s/%s", accessKey, credentialScope)
+
+	path := "/" + bucket + "/" + key
+	canonicalURI := uriEncodePath(path)
+
+	host := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+
+	q := url.Values{}
+	q.Set("X-Amz-Algorithm", presignAlgorithm)
+	q.Set("X-Amz-Credential", credential)
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", strconv.Itoa(expiresSec))
+	q.Set("X-Amz-SignedHeaders", "host")
+
+	canonicalQueryString := buildPresignCanonicalQuery(q)
+
+	canonicalRequest := strings.Join([]string{
+		method,
+		canonicalURI,
+		canonicalQueryString,
+		"host:" + host + "\n",
+		"host",
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	hash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		presignAlgorithm,
+		amzDate,
+		credentialScope,
+		hex.EncodeToString(hash[:]),
+	}, "\n")
+
+	signingKey := presignDeriveKey(secretKey, date, presignDefaultRegion)
+	signature := hex.EncodeToString(presignHMAC(signingKey, []byte(stringToSign)))
+
+	q.Set("X-Amz-Signature", signature)
+
+	fullURL := baseURL + path + "?" + q.Encode()
+	return fullURL, expiresAt
+}

--- a/internal/api/s3_presign_test.go
+++ b/internal/api/s3_presign_test.go
@@ -1,0 +1,510 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/FairForge/vaultaire/internal/config"
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	testAccessKey       = "AKIAIOSFODNN7EXAMPLE"
+	testSecretKey       = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	testPresignTenantID = "tenant-presign-test"
+	testRegion          = "us-east-1"
+)
+
+func signPresignedURL(method, path, host, accessKey, secretKey string, expiresSec int, amzDate time.Time) url.Values {
+	date := amzDate.Format(presignDateFormat)
+	amzDateStr := amzDate.Format(presignTimeFormat)
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", date, testRegion, presignService, presignAWS4Request)
+	credential := fmt.Sprintf("%s/%s", accessKey, credentialScope)
+
+	q := url.Values{}
+	q.Set("X-Amz-Algorithm", presignAlgorithm)
+	q.Set("X-Amz-Credential", credential)
+	q.Set("X-Amz-Date", amzDateStr)
+	q.Set("X-Amz-Expires", strconv.Itoa(expiresSec))
+	q.Set("X-Amz-SignedHeaders", "host")
+
+	canonicalQueryString := buildTestCanonicalQuery(q)
+	canonicalURI := uriEncodePath(path)
+
+	canonicalRequest := strings.Join([]string{
+		method,
+		canonicalURI,
+		canonicalQueryString,
+		"host:" + host + "\n",
+		"host",
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	hash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		presignAlgorithm,
+		amzDateStr,
+		credentialScope,
+		hex.EncodeToString(hash[:]),
+	}, "\n")
+
+	signingKey := testDeriveKey(secretKey, date, testRegion)
+	signature := hex.EncodeToString(testHMACSign(signingKey, []byte(stringToSign)))
+
+	q.Set("X-Amz-Signature", signature)
+	return q
+}
+
+func buildTestCanonicalQuery(values url.Values) string {
+	var keys []string
+	for k := range values {
+		if k == "X-Amz-Signature" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var pairs []string
+	for _, k := range keys {
+		vs := make([]string, len(values[k]))
+		copy(vs, values[k])
+		sort.Strings(vs)
+		for _, v := range vs {
+			pairs = append(pairs, url.QueryEscape(k)+"="+url.QueryEscape(v))
+		}
+	}
+	return strings.Join(pairs, "&")
+}
+
+func testDeriveKey(secretKey, date, region string) []byte {
+	kDate := testHMACSign([]byte("AWS4"+secretKey), []byte(date))
+	kRegion := testHMACSign(kDate, []byte(region))
+	kService := testHMACSign(kRegion, []byte(presignService))
+	return testHMACSign(kService, []byte(presignAWS4Request))
+}
+
+func testHMACSign(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func newMockDB(t *testing.T) (*Server, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	logger, _ := zap.NewDevelopment()
+	s := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		db:       db,
+		testMode: false,
+		config:   &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	cleanup := func() { _ = db.Close() }
+	return s, mock, cleanup
+}
+
+func expectTenantLookup(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
+			AddRow(testSecretKey, testPresignTenantID))
+}
+
+func TestIsPresignedRequest(t *testing.T) {
+	t.Run("with algorithm param", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/bucket/key?X-Amz-Algorithm=AWS4-HMAC-SHA256", nil)
+		assert.True(t, isPresignedRequest(r))
+	})
+
+	t.Run("without algorithm param", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/bucket/key", nil)
+		assert.False(t, isPresignedRequest(r))
+	})
+
+	t.Run("wrong algorithm", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/bucket/key?X-Amz-Algorithm=WRONG", nil)
+		assert.False(t, isPresignedRequest(r))
+	})
+}
+
+func TestVerifyPresignedURL_MissingParams(t *testing.T) {
+	s, _, cleanup := newMockDB(t)
+	defer cleanup()
+
+	r := httptest.NewRequest("GET", "/bucket/key?X-Amz-Algorithm=AWS4-HMAC-SHA256", nil)
+	r.Host = "localhost:8000"
+
+	_, err := s.verifyPresignedURL(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrAuthorizationQueryParametersError)
+}
+
+func TestVerifyPresignedURL_ExpiresOutOfRange(t *testing.T) {
+	s, _, cleanup := newMockDB(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		expires string
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"too large", "999999"},
+		{"non-numeric", "abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := url.Values{}
+			q.Set("X-Amz-Algorithm", presignAlgorithm)
+			q.Set("X-Amz-Credential", "key/20260429/us-east-1/s3/aws4_request")
+			q.Set("X-Amz-Date", "20260429T120000Z")
+			q.Set("X-Amz-Expires", tt.expires)
+			q.Set("X-Amz-SignedHeaders", "host")
+			q.Set("X-Amz-Signature", "deadbeef")
+
+			r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
+			r.Host = "localhost:8000"
+
+			_, err := s.verifyPresignedURL(r)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), ErrInvalidPresignExpires)
+		})
+	}
+}
+
+func TestVerifyPresignedURL_InvalidAccessKey(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs("NONEXISTENT000000000").
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}))
+
+	now := time.Now().UTC()
+	q := signPresignedURL("GET", "/bucket/key", "localhost:8000", "NONEXISTENT000000000", testSecretKey, 3600, now)
+
+	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	_, err := s.verifyPresignedURL(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrAccessDenied)
+}
+
+func TestVerifyPresignedURL_Expired(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	expectTenantLookup(mock)
+
+	pastTime := time.Now().UTC().Add(-2 * time.Hour)
+	q := signPresignedURL("GET", "/bucket/key", "localhost:8000", testAccessKey, testSecretKey, 1, pastTime)
+
+	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	_, err := s.verifyPresignedURL(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrExpiredPresignedRequest)
+}
+
+func TestVerifyPresignedURL_InvalidSignature(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	expectTenantLookup(mock)
+
+	now := time.Now().UTC()
+	q := signPresignedURL("GET", "/bucket/key", "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+	q.Set("X-Amz-Signature", "0000000000000000000000000000000000000000000000000000000000000000")
+
+	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	_, err := s.verifyPresignedURL(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrSignatureDoesNotMatch)
+}
+
+func TestVerifyPresignedURL_ValidGET(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	expectTenantLookup(mock)
+
+	now := time.Now().UTC()
+	q := signPresignedURL("GET", "/my-bucket/my-object.txt", "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+
+	r := httptest.NewRequest("GET", "/my-bucket/my-object.txt?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	tenantID, err := s.verifyPresignedURL(r)
+	require.NoError(t, err)
+	assert.Equal(t, testPresignTenantID, tenantID)
+}
+
+func TestVerifyPresignedURL_ValidPUT(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	expectTenantLookup(mock)
+
+	now := time.Now().UTC()
+	q := signPresignedURL("PUT", "/upload-bucket/data.bin", "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+
+	r := httptest.NewRequest("PUT", "/upload-bucket/data.bin?"+q.Encode(), bytes.NewReader([]byte("file content")))
+	r.Host = "localhost:8000"
+
+	tenantID, err := s.verifyPresignedURL(r)
+	require.NoError(t, err)
+	assert.Equal(t, testPresignTenantID, tenantID)
+}
+
+func TestVerifyPresignedURL_PathWithSpecialChars(t *testing.T) {
+	s, mock, cleanup := newMockDB(t)
+	defer cleanup()
+
+	expectTenantLookup(mock)
+
+	now := time.Now().UTC()
+	// Sign with the decoded path since verifier uses r.URL.Path (decoded by Go)
+	path := "/my-bucket/my-file_v2.0~final.txt"
+	q := signPresignedURL("GET", path, "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+
+	r := httptest.NewRequest("GET", path+"?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	tenantID, err := s.verifyPresignedURL(r)
+	require.NoError(t, err)
+	assert.Equal(t, testPresignTenantID, tenantID)
+}
+
+func TestPresignedURL_Integration(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tempDir, err := os.MkdirTemp("", "presign-integration-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	logger, _ := zap.NewDevelopment()
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng := engine.NewEngine(nil, logger, nil)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	s := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: false,
+		config:   &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+	s.router.HandleFunc("/*", s.handleS3Request)
+
+	bucket := "integration-test"
+	bucketPath := filepath.Join(tempDir, testPresignTenantID+"_"+bucket)
+	require.NoError(t, os.MkdirAll(bucketPath, 0755))
+
+	testContent := "hello from presigned upload"
+	objectKey := "test-upload.txt"
+
+	// PUT
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
+			AddRow(testSecretKey, testPresignTenantID))
+	mock.ExpectQuery(`SELECT suspended_at FROM tenants WHERE id`).
+		WithArgs(testPresignTenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"suspended_at"}))
+
+	now := time.Now().UTC()
+	putQ := signPresignedURL("PUT", "/"+bucket+"/"+objectKey, "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+
+	putReq := httptest.NewRequest("PUT", "/"+bucket+"/"+objectKey+"?"+putQ.Encode(),
+		bytes.NewReader([]byte(testContent)))
+	putReq.Host = "localhost:8000"
+	putReq.ContentLength = int64(len(testContent))
+
+	putW := httptest.NewRecorder()
+	s.router.ServeHTTP(putW, putReq)
+	assert.Equal(t, http.StatusOK, putW.Code, "PUT via presigned URL should succeed")
+
+	// GET
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
+			AddRow(testSecretKey, testPresignTenantID))
+	mock.ExpectQuery(`SELECT suspended_at FROM tenants WHERE id`).
+		WithArgs(testPresignTenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"suspended_at"}))
+
+	now = time.Now().UTC()
+	getQ := signPresignedURL("GET", "/"+bucket+"/"+objectKey, "localhost:8000", testAccessKey, testSecretKey, 3600, now)
+
+	getReq := httptest.NewRequest("GET", "/"+bucket+"/"+objectKey+"?"+getQ.Encode(), nil)
+	getReq.Host = "localhost:8000"
+
+	getW := httptest.NewRecorder()
+	s.router.ServeHTTP(getW, getReq)
+	assert.Equal(t, http.StatusOK, getW.Code, "GET via presigned URL should succeed")
+
+	body, err := io.ReadAll(getW.Body)
+	require.NoError(t, err)
+	assert.Equal(t, testContent, string(body))
+}
+
+func TestPresignedURL_ExpiredIntegration(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger, _ := zap.NewDevelopment()
+	s := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		db:       db,
+		testMode: false,
+		config:   &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+	s.router.HandleFunc("/*", s.handleS3Request)
+
+	// Expect tenant lookup, but expiry should fail first
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
+			AddRow(testSecretKey, testPresignTenantID))
+
+	pastTime := time.Now().UTC().Add(-1 * time.Hour)
+	q := signPresignedURL("GET", "/bucket/key", "localhost:8000", testAccessKey, testSecretKey, 1, pastTime)
+
+	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
+	r.Host = "localhost:8000"
+
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var s3Err S3Error
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &s3Err))
+	assert.Equal(t, ErrExpiredPresignedRequest, s3Err.Code)
+}
+
+func TestHandleGetPresignedURL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger, _ := zap.NewDevelopment()
+	s := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		db:       db,
+		testMode: false,
+		config:   &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	mock.ExpectQuery(`SELECT access_key, secret_key FROM tenants WHERE id`).
+		WithArgs(testPresignTenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"access_key", "secret_key"}).
+			AddRow(testAccessKey, testSecretKey))
+
+	r := httptest.NewRequest("GET", "/api/v1/presigned?bucket=mybucket&key=myfile.txt&method=PUT&expires=7200", nil)
+	ctx := context.WithValue(r.Context(), tenantIDKey, testPresignTenantID)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.handleGetPresignedURL(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp["url"], "X-Amz-Signature")
+	assert.Contains(t, resp["url"], "X-Amz-Algorithm")
+	assert.Equal(t, "PUT", resp["method"])
+	assert.NotEmpty(t, resp["expires_at"])
+
+	_, err = time.Parse(time.RFC3339, resp["expires_at"])
+	require.NoError(t, err)
+
+	// Verify the generated URL can be validated
+	parsedURL, err := url.Parse(resp["url"])
+	require.NoError(t, err)
+
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
+			AddRow(testSecretKey, testPresignTenantID))
+
+	verifyReq := httptest.NewRequest("PUT", parsedURL.RequestURI(), bytes.NewReader([]byte("data")))
+	verifyReq.Host = parsedURL.Host
+
+	verifiedTenantID, err := s.verifyPresignedURL(verifyReq)
+	require.NoError(t, err)
+	assert.Equal(t, testPresignTenantID, verifiedTenantID)
+}
+
+func TestHandleGetPresignedURL_MissingParams(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		config: &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	r := httptest.NewRequest("GET", "/api/v1/presigned?bucket=mybucket", nil)
+	ctx := context.WithValue(r.Context(), tenantIDKey, testPresignTenantID)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.handleGetPresignedURL(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleGetPresignedURL_InvalidMethod(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		config: &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	r := httptest.NewRequest("GET", "/api/v1/presigned?bucket=mybucket&key=file&method=DELETE", nil)
+	ctx := context.WithValue(r.Context(), tenantIDKey, testPresignTenantID)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s.handleGetPresignedURL(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
## Summary

- Add S3-compatible SigV4 query-string authentication so GET/PUT requests signed with pre-signed URLs are validated and routed to normal S3 handlers — enables browser-direct uploads without exposing credentials
- Replace the stub `/api/v1/presigned` management endpoint with one that generates real SigV4 pre-signed URLs from tenant credentials
- Add new AWS-compatible error codes: `ExpiredToken` (403), `AuthorizationQueryParametersError` (400)

## What changed

| File | Change |
|------|--------|
| `s3_presign.go` | **New** — `isPresignedRequest`, `verifyPresignedURL` (SigV4 query-string verifier), `generatePresignedS3URL`, URI encoding helpers |
| `s3.go` | Auth flow now checks `isPresignedRequest(r)` before header-based auth — presigned requests skip `Authorization` header entirely |
| `s3_errors.go` | Three new error codes: `ExpiredToken`, `AuthorizationQueryParametersError`, `AuthorizationQueryParametersError_Expires` |
| `presigned.go` | Replaced fake token stub with real SigV4 URL generator (bucket, key, method, expires params; JWT-protected) |
| `s3_presign_test.go` | 14 tests: detection, valid GET/PUT, expired, bad signature, bad access key, missing params, expires out of range, special chars, full PUT→GET integration, expired integration, management endpoint round-trip |

## Security

- Signature comparison uses `hmac.Equal` (constant-time) to prevent timing attacks
- Expiration enforced: `X-Amz-Expires` must be 1–604800 seconds
- Canonical query string excludes `X-Amz-Signature` per AWS spec
- Payload hash is always `UNSIGNED-PAYLOAD` (standard for pre-signed URLs)
- Tenant credentials looked up from `tenants` table — no cross-tenant access possible

## Test plan

- [x] `TestIsPresignedRequest` — detection with/without/wrong algorithm param
- [x] `TestVerifyPresignedURL_ValidGET` — valid GET signature verified, correct tenant returned
- [x] `TestVerifyPresignedURL_ValidPUT` — valid PUT signature verified
- [x] `TestVerifyPresignedURL_Expired` — backdated request rejected with `ExpiredToken`
- [x] `TestVerifyPresignedURL_InvalidSignature` — tampered signature rejected with `SignatureDoesNotMatch`
- [x] `TestVerifyPresignedURL_InvalidAccessKey` — nonexistent key rejected with `AccessDenied`
- [x] `TestVerifyPresignedURL_MissingParams` — incomplete query params rejected with `AuthorizationQueryParametersError`
- [x] `TestVerifyPresignedURL_ExpiresOutOfRange` — 0, -1, 999999, "abc" all rejected
- [x] `TestVerifyPresignedURL_PathWithSpecialChars` — tildes, dots, underscores in path
- [x] `TestPresignedURL_Integration` — full PUT→GET round trip via presigned URLs with sqlmock
- [x] `TestPresignedURL_ExpiredIntegration` — expired request returns 403 XML with correct error code
- [x] `TestHandleGetPresignedURL` — management endpoint generates URLs that pass verification
- [x] `TestHandleGetPresignedURL_MissingParams` — missing key returns 400
- [x] `TestHandleGetPresignedURL_InvalidMethod` — DELETE method returns 400
- [x] Full test suite passes: `go test ./... -short -count=1` — zero failures
- [x] `golangci-lint run ./internal/api/...` — zero issues