### PR TITLE
feat(api): API version header middleware [Phase 5.11.1]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -52,6 +52,10 @@ if suggestion := bucketSuggestion(ctx, s.db, tenantID, bucket); suggestion != ""
 
 `bucketSuggestion` only queries `WHERE tenant_id = $1` — never leaks bucket names across tenants. A bucket owned by tenant A is invisible to tenant B's suggestion query.
 
+## API Versioning (Phase 5.11.1)
+
+Every response includes `X-Vaultaire-Version: YYYY-MM-DD` (Stripe-style date versioning). The `APIVersion` const in `server.go` is the source of truth. `versionMiddleware` sets the header on all responses and logs the client's version at Debug level if sent. No version translation logic yet — just header plumbing.
+
 ## Auth Flow
 
 1. `handleS3Request` checks `isPresignedRequest(r)` — if query has `X-Amz-Algorithm=AWS4-HMAC-SHA256`, routes to `verifyPresignedURL` (SigV4 query string auth)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const APIVersion = "2026-05-01"
+
 // OAuth provider endpoints.
 var (
 	googleEndpoint = oauth2.Endpoint{
@@ -205,6 +207,7 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	s.rbacService = NewRBACService(logger)
 
 	s.router.Use(s.requestIDMiddleware)
+	s.router.Use(s.versionMiddleware)
 	s.router.Use(s.rbacService.InjectUserContext)
 	s.router.Use(s.loggingMiddleware)
 
@@ -745,6 +748,16 @@ a:hover{text-decoration:underline}
 </div>
 </body>
 </html>`
+
+func (s *Server) versionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Vaultaire-Version", APIVersion)
+		if cv := r.Header.Get("X-Vaultaire-Version"); cv != "" {
+			s.logger.Debug("client API version", zap.String("client_version", cv))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
 
 func (s *Server) requestIDMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newVersionTestServer() *Server {
+	return &Server{
+		logger: zap.NewNop(),
+	}
+}
+
+func TestVersionHeader(t *testing.T) {
+	s := newVersionTestServer()
+
+	handler := s.versionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	got := rec.Header().Get("X-Vaultaire-Version")
+	require.NotEmpty(t, got, "X-Vaultaire-Version header must be present")
+}
+
+func TestVersionHeaderValue(t *testing.T) {
+	s := newVersionTestServer()
+
+	handler := s.versionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, APIVersion, rec.Header().Get("X-Vaultaire-Version"))
+}
+
+func TestVersionHeaderClientEcho(t *testing.T) {
+	s := newVersionTestServer()
+
+	handler := s.versionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	req.Header.Set("X-Vaultaire-Version", "2025-01-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, APIVersion, rec.Header().Get("X-Vaultaire-Version"))
+}


### PR DESCRIPTION
## Summary

- Adds `X-Vaultaire-Version: 2026-05-01` header to every response via global middleware (Stripe-style YYYY-MM-DD versioning)
- Logs client-sent `X-Vaultaire-Version` at Debug level for future version negotiation telemetry
- No version translation logic — this establishes the convention for future breaking change management

## Changes

- `internal/api/server.go` — `APIVersion` const, `versionMiddleware`, wired after `requestIDMiddleware`
- `internal/api/version_test.go` — 3 tests: header presence, value matches const, client echo doesn't error
- `internal/api/CLAUDE.md` — documents the versioning middleware

## Test plan

- [x] `TestVersionHeader` — response has `X-Vaultaire-Version` header
- [x] `TestVersionHeaderValue` — header value matches `APIVersion` const
- [x] `TestVersionHeaderClientEcho` — client-sent version header doesn't cause errors
- [x] `go build ./...` passes
- [x] Pre-commit hooks (fmt, test, lint) all pass