### PR TITLE
fix(security): resolve all 18 gosec findings

### DIFF
--- a/cmd/bench-compare/main.go
+++ b/cmd/bench-compare/main.go
@@ -27,7 +27,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" // #nosec G501 — S3 ETag protocol requires MD5
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
@@ -811,7 +811,7 @@ func sha256hex(b []byte) string {
 }
 
 func md5Sum(b []byte) []byte {
-	h := md5.Sum(b) //nolint:gosec // MD5 used for S3 ETag comparison, not security
+	h := md5.Sum(b) // #nosec G401 — S3 ETag protocol requires MD5
 	return h[:]
 }
 

--- a/cmd/lighthouse-bench/main.go
+++ b/cmd/lighthouse-bench/main.go
@@ -729,7 +729,7 @@ func writeJSON(path string, v any) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }
 
 func sanitize(s string) string {

--- a/cmd/permafrost-v2/main.go
+++ b/cmd/permafrost-v2/main.go
@@ -154,7 +154,7 @@ func decorrelatedJitter(base, previous, cap time.Duration) time.Duration {
 		return base
 	}
 	span := int64(high - base)
-	return base + time.Duration(mrand.Int64N(span))
+	return base + time.Duration(mrand.Int64N(span)) // #nosec G404 — jitter backoff, not security
 }
 
 func parseRetryAfter(resp *http.Response) time.Duration {

--- a/cmd/permafrost-v3/main.go
+++ b/cmd/permafrost-v3/main.go
@@ -254,7 +254,7 @@ func decorrelatedJitter(base, previous, cap time.Duration) time.Duration {
 	if high <= base {
 		return base
 	}
-	return base + time.Duration(mrand.Int64N(int64(high-base)))
+	return base + time.Duration(mrand.Int64N(int64(high-base))) // #nosec G404 — jitter backoff, not security
 }
 
 // graphDo makes an authenticated Graph API call (HTTP/2)

--- a/cmd/pixeldrain-bench/main.go
+++ b/cmd/pixeldrain-bench/main.go
@@ -1542,7 +1542,7 @@ func writeJSON(path string, v any) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }
 
 func sanitize(s string) string {

--- a/cmd/quotaless-bench-v2/main.go
+++ b/cmd/quotaless-bench-v2/main.go
@@ -94,7 +94,7 @@ func (c *rawS3Client) signAndDo(ctx context.Context, req *http.Request) (*http.R
 	if err != nil {
 		return nil, fmt.Errorf("sign: %w", err)
 	}
-	return c.http.Do(req)
+	return c.http.Do(req) // #nosec G704 — endpoint from CLI flag
 }
 
 func (c *rawS3Client) objectURL(key string) string {
@@ -155,7 +155,7 @@ func (c *rawS3Client) getRange(ctx context.Context, key string, start, end int64
 }
 
 func (c *rawS3Client) del(ctx context.Context, key string) {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodDelete, c.objectURL(key), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodDelete, c.objectURL(key), nil) // #nosec G704 — endpoint from CLI flag
 	if req == nil {
 		return
 	}
@@ -647,7 +647,7 @@ func main() {
 
 	run.DurSec = time.Since(overall).Seconds()
 	data, _ := json.MarshalIndent(run, "", "  ")
-	if err := os.WriteFile(*outFile, data, 0o644); err != nil {
+	if err := os.WriteFile(*outFile, data, 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "write: %v\n", err)
 	}
 	fmt.Printf("\n✅ Done in %s. Results: %s\n", time.Since(overall).Round(time.Second), *outFile)

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -119,7 +119,7 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 
 	// Create container directory
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket) // #nosec G703 — bucket validated by validateBucketName
-	if err := os.MkdirAll(dirPath, 0755); err != nil {
+	if err := os.MkdirAll(dirPath, 0755); err != nil {           // #nosec G703 — bucket validated by validateBucketName
 		s.logger.Error("Failed to create container", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return
@@ -169,7 +169,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket) // #nosec G703 — bucket validated by validateBucketName
 
 	// Check if bucket exists
-	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) { // #nosec G703 — bucket validated by validateBucketName
 		reqID := generateRequestID()
 		if suggestion := bucketSuggestion(ctx, s.db, tenantID, bucket); suggestion != "" {
 			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -118,7 +118,7 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		zap.String("tenant", tenantID))
 
 	// Create container directory
-	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
+	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket) // #nosec G703 — bucket validated by validateBucketName
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		s.logger.Error("Failed to create container", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
@@ -166,7 +166,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 		zap.String("bucket", bucket),
 		zap.String("tenant", tenantID))
 
-	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket)
+	dirPath := filepath.Join("/tmp/vaultaire", tenantID, bucket) // #nosec G703 — bucket validated by validateBucketName
 
 	// Check if bucket exists
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
@@ -202,7 +202,7 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Delete the bucket
-	if err := os.RemoveAll(dirPath); err != nil {
+	if err := os.RemoveAll(dirPath); err != nil { // #nosec G703 — bucket validated by validateBucketName
 		s.logger.Error("Failed to delete bucket", zap.Error(err))
 		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 		return

--- a/internal/dashboard/handlers/billing.go
+++ b/internal/dashboard/handlers/billing.go
@@ -81,7 +81,7 @@ func HandleUpgrade(stripe *billing.StripeService, db *sql.DB, logger *zap.Logger
 			return
 		}
 
-		http.Redirect(w, r, checkoutURL, http.StatusSeeOther)
+		http.Redirect(w, r, checkoutURL, http.StatusSeeOther) // #nosec G710 — URL from Stripe API, not user input
 	}
 }
 

--- a/internal/dashboard/handlers/bucket_settings.go
+++ b/internal/dashboard/handlers/bucket_settings.go
@@ -128,7 +128,7 @@ func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap
 
 		if db == nil {
 			middleware.SetFlash(w, "error", "Database not available.")
-			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther) // #nosec G710 — hardcoded path prefix
 			return
 		}
 
@@ -141,7 +141,7 @@ func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap
 			allowed, reason := auth.CanEnablePublicRead(tier)
 			if !allowed {
 				middleware.SetFlash(w, "error", reason)
-				http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+				http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther) // #nosec G710 — hardcoded path prefix
 				return
 			}
 		}
@@ -154,18 +154,18 @@ func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap
 		if err != nil {
 			logger.Error("update bucket settings", zap.Error(err))
 			middleware.SetFlash(w, "error", "Failed to save settings.")
-			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+			http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther) // #nosec G710 — hardcoded path prefix
 			return
 		}
 
 		rows, _ := result.RowsAffected()
 		if rows == 0 {
 			middleware.SetFlash(w, "error", "Bucket not found.")
-			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther) // #nosec G710 — static path
 			return
 		}
 
 		middleware.SetFlash(w, "success", "Bucket settings saved.")
-		http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther)
+		http.Redirect(w, r, fmt.Sprintf("/dashboard/buckets/%s/settings", bucketName), http.StatusSeeOther) // #nosec G710 — hardcoded path prefix
 	}
 }

--- a/internal/dashboard/handlers/mfa.go
+++ b/internal/dashboard/handlers/mfa.go
@@ -173,7 +173,7 @@ func HandleAdminResetMFA(authSvc *auth.AuthService, logger *zap.Logger) http.Han
 			return
 		}
 
-		http.Redirect(w, r, "/admin/tenants/"+tenantID, http.StatusSeeOther)
+		http.Redirect(w, r, "/admin/tenants/"+tenantID, http.StatusSeeOther) // #nosec G710 — admin-only, tenantID from chi URL param
 	}
 }
 


### PR DESCRIPTION
## Summary

- Annotates 15 false positives with `#nosec` + explanation across bench tools and production code
- Tightens WriteFile permissions from `0644` → `0600` in 3 benchmark tools
- Fixes standalone gosec annotation format (`#nosec` instead of `//nolint:gosec`) in bench-compare

## Findings resolved

| Rule | Files | Fix |
|------|-------|-----|
| G404 weak RNG | permafrost-v2, permafrost-v3 | `#nosec` — jitter backoff, not security |
| G704 SSRF | quotaless-bench-v2 (x2) | `#nosec` — endpoint from CLI flag |
| G306 WriteFile perms | quotaless-bench-v2, pixeldrain-bench, lighthouse-bench | `0644` → `0600` |
| G501/G401 MD5 | bench-compare (x2) | `#nosec` — S3 ETag protocol requires MD5 |
| G703 path traversal | s3_buckets.go (x3) | `#nosec` — bucket validated by `validateBucketName` |
| G710 open redirect | bucket_settings.go (x5), billing.go, mfa.go | `#nosec` — hardcoded prefixes / Stripe API / admin-only |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/api/... -short` passes
- [x] Pre-commit hooks (fmt, test, lint) all pass
- [ ] CI gosec check should now pass with 0 new issues