### PR TITLE
feat(api): idempotency keys + metadata on resources [Phase 5.11.2-5.11.3]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -21,6 +21,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
 - **management_ratelimit.go** — Per-tenant rate limiter middleware (100 req/min, token bucket, X-RateLimit-* headers)
+- **idempotency.go** — `Idempotency-Key` header middleware for management API (24h cache, replay with `Idempotency-Replayed: true`)
 - **llms_txt.go** — Static `/llms.txt` endpoint (plain-text API summary for LLMs)
 
 ## Error Response Pattern
@@ -55,6 +56,10 @@ if suggestion := bucketSuggestion(ctx, s.db, tenantID, bucket); suggestion != ""
 ## API Versioning (Phase 5.11.1)
 
 Every response includes `X-Vaultaire-Version: YYYY-MM-DD` (Stripe-style date versioning). The `APIVersion` const in `server.go` is the source of truth. `versionMiddleware` sets the header on all responses and logs the client's version at Debug level if sent. No version translation logic yet — just header plumbing.
+
+## Idempotency Keys (Phase 5.11.2)
+
+`Idempotency-Key` header on PUT/POST/DELETE management API requests. Opt-in — absent header passes through. Max 256 chars. Cached in `idempotency_cache` table (24h TTL, hourly cleanup goroutine). Only 2xx responses are cached. Replayed responses include `Idempotency-Replayed: true` header. Reusing a key with different method/path returns 409 `idempotency_key_reuse`. GET/HEAD/OPTIONS are always skipped. If db is nil, middleware passes through silently.
 
 ## Auth Flow
 

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -22,6 +22,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
 - **management_ratelimit.go** — Per-tenant rate limiter middleware (100 req/min, token bucket, X-RateLimit-* headers)
 - **idempotency.go** — `Idempotency-Key` header middleware for management API (24h cache, replay with `Idempotency-Replayed: true`)
+- **metadata.go** — S3 user metadata extraction/validation, Stripe-style merge for management API PATCH
 - **llms_txt.go** — Static `/llms.txt` endpoint (plain-text API summary for LLMs)
 
 ## Error Response Pattern
@@ -60,6 +61,18 @@ Every response includes `X-Vaultaire-Version: YYYY-MM-DD` (Stripe-style date ver
 ## Idempotency Keys (Phase 5.11.2)
 
 `Idempotency-Key` header on PUT/POST/DELETE management API requests. Opt-in — absent header passes through. Max 256 chars. Cached in `idempotency_cache` table (24h TTL, hourly cleanup goroutine). Only 2xx responses are cached. Replayed responses include `Idempotency-Replayed: true` header. Reusing a key with different method/path returns 409 `idempotency_key_reuse`. GET/HEAD/OPTIONS are always skipped. If db is nil, middleware passes through silently.
+
+## Metadata on Resources (Phase 5.11.3)
+
+User-defined metadata on objects and buckets. Two paths:
+
+**S3 protocol**: `x-amz-meta-*` headers on PUT are extracted (prefix stripped, keys lowercased), validated (max 50 keys, 500 chars/value, 2KB total), stored in `object_head_cache.metadata` JSONB. Returned as `x-amz-meta-*` headers on GET and HEAD.
+
+**Management API**: `GET /api/v1/manage/buckets/{name}` includes `metadata` field. `PATCH /api/v1/manage/buckets/{name}` accepts `{"metadata": {...}}` with Stripe-style merge semantics (null value deletes key).
+
+Key files: `metadata.go` (extract/set/validate/merge helpers), `s3_engine_adapter.go` (PUT stores, GET returns), `s3.go` (HEAD returns), `management_routes.go` (PATCH handler).
+
+**sqlmock note**: JSONB columns must use `[]byte` (not `string`) in `AddRow` to match real PostgreSQL driver behavior when scanning into `[]byte`/`json.RawMessage`.
 
 ## Auth Flow
 

--- a/internal/api/idempotency.go
+++ b/internal/api/idempotency.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	idempotencyKeyHeader    = "Idempotency-Key"
+	idempotencyReplayHeader = "Idempotency-Replayed"
+	idempotencyKeyMaxLen    = 256
+	idempotencyTTL          = 24 * time.Hour
+)
+
+type idempotencyMiddleware struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+func newIdempotencyMiddleware(db *sql.DB, logger *zap.Logger) *idempotencyMiddleware {
+	return &idempotencyMiddleware{db: db, logger: logger}
+}
+
+func (im *idempotencyMiddleware) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		key := r.Header.Get(idempotencyKeyHeader)
+		if key == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if len(key) > idempotencyKeyMaxLen {
+			writeManagementError(w, ErrTypeInvalidRequest, "idempotency_key_too_long",
+				"idempotency key must be 256 characters or fewer", idempotencyKeyHeader)
+			return
+		}
+
+		if im.db == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		tenantID, _ := r.Context().Value(tenantIDKey).(string)
+		if tenantID == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		var cached cachedResponse
+		err := im.db.QueryRowContext(r.Context(), `
+			SELECT method, path, response_status, response_headers, response_body
+			FROM idempotency_cache
+			WHERE tenant_id = $1 AND idempotency_key = $2 AND created_at > $3
+		`, tenantID, key, time.Now().Add(-idempotencyTTL)).Scan(
+			&cached.Method, &cached.Path, &cached.Status, &cached.HeadersJSON, &cached.Body,
+		)
+
+		if err == nil {
+			if cached.Method != r.Method || cached.Path != r.URL.Path {
+				writeManagementError(w, ErrTypeConflict, "idempotency_key_reuse",
+					"idempotency key already used with a different request", idempotencyKeyHeader)
+				return
+			}
+			im.replayResponse(w, &cached)
+			return
+		}
+
+		rw := &capturingResponseWriter{
+			ResponseWriter: w,
+			body:           &bytes.Buffer{},
+		}
+
+		next.ServeHTTP(rw, r)
+
+		if rw.status >= 200 && rw.status < 300 {
+			im.cacheResponse(r.Context(), tenantID, key, r.Method, r.URL.Path, rw)
+		}
+	})
+}
+
+type cachedResponse struct {
+	Method      string
+	Path        string
+	Status      int
+	HeadersJSON []byte
+	Body        []byte
+}
+
+func (im *idempotencyMiddleware) replayResponse(w http.ResponseWriter, cached *cachedResponse) {
+	var headers map[string]string
+	if err := json.Unmarshal(cached.HeadersJSON, &headers); err == nil {
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+	}
+	w.Header().Set(idempotencyReplayHeader, "true")
+	w.WriteHeader(cached.Status)
+	_, _ = w.Write(cached.Body)
+}
+
+func (im *idempotencyMiddleware) cacheResponse(_ context.Context, tenantID, key, method, path string, rw *capturingResponseWriter) {
+	headers := make(map[string]string)
+	for k, v := range rw.Header() {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+	headersJSON, err := json.Marshal(headers)
+	if err != nil {
+		im.logger.Error("marshal idempotency headers", zap.Error(err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = im.db.ExecContext(ctx, `
+		INSERT INTO idempotency_cache (tenant_id, idempotency_key, method, path, response_status, response_headers, response_body)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, idempotency_key) DO NOTHING
+	`, tenantID, key, method, path, rw.status, headersJSON, rw.body.Bytes())
+	if err != nil {
+		im.logger.Error("cache idempotency response", zap.Error(err))
+	}
+}
+
+// StartCleanup launches a goroutine that deletes expired idempotency cache entries hourly.
+func (im *idempotencyMiddleware) StartCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, _ = im.db.ExecContext(ctx, `DELETE FROM idempotency_cache WHERE created_at < NOW() - INTERVAL '24 hours'`)
+			}
+		}
+	}()
+}
+
+// capturingResponseWriter wraps http.ResponseWriter to capture the response for caching.
+type capturingResponseWriter struct {
+	http.ResponseWriter
+	status      int
+	body        *bytes.Buffer
+	wroteHeader bool
+}
+
+func (w *capturingResponseWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+		w.ResponseWriter.WriteHeader(code)
+	}
+}
+
+func (w *capturingResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}

--- a/internal/api/idempotency_test.go
+++ b/internal/api/idempotency_test.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newIdempotencyTestRouter(t *testing.T) (chi.Router, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	logger := zap.NewNop()
+	im := newIdempotencyMiddleware(db, logger)
+
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), tenantIDKey, "test-tenant")
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	r.Use(im.Middleware)
+
+	r.Post("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "created"})
+	})
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	r.Delete("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"deleted": "true"})
+	})
+	r.Post("/error", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "bad"})
+	})
+
+	return r, mock, func() { _ = db.Close() }
+}
+
+func TestIdempotency_FirstRequest(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-1", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}))
+
+	mock.ExpectExec(`INSERT INTO idempotency_cache`).
+		WithArgs("test-tenant", "key-1", "POST", "/test", 201, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req.Header.Set(idempotencyKeyHeader, "key-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Empty(t, w.Header().Get(idempotencyReplayHeader))
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "created", resp["status"])
+}
+
+func TestIdempotency_ReplayedRequest(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	cachedHeaders, _ := json.Marshal(map[string]string{"Content-Type": "application/json"})
+	cachedBody, _ := json.Marshal(map[string]string{"status": "created"})
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-replay", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}).
+			AddRow("POST", "/test", 201, cachedHeaders, cachedBody))
+
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req.Header.Set(idempotencyKeyHeader, "key-replay")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "true", w.Header().Get(idempotencyReplayHeader))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "created", resp["status"])
+}
+
+func TestIdempotency_DifferentKey(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-a", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}))
+
+	mock.ExpectExec(`INSERT INTO idempotency_cache`).
+		WithArgs("test-tenant", "key-a", "POST", "/test", 201, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-b", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}))
+
+	mock.ExpectExec(`INSERT INTO idempotency_cache`).
+		WithArgs("test-tenant", "key-b", "POST", "/test", 201, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req1 := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req1.Header.Set(idempotencyKeyHeader, "key-a")
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusCreated, w1.Code)
+	assert.Empty(t, w1.Header().Get(idempotencyReplayHeader))
+
+	req2 := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req2.Header.Set(idempotencyKeyHeader, "key-b")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusCreated, w2.Code)
+	assert.Empty(t, w2.Header().Get(idempotencyReplayHeader))
+}
+
+func TestIdempotency_SkipGET(t *testing.T) {
+	r, _, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set(idempotencyKeyHeader, "key-get")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(idempotencyReplayHeader))
+}
+
+func TestIdempotency_NoHeader(t *testing.T) {
+	r, _, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Empty(t, w.Header().Get(idempotencyReplayHeader))
+}
+
+func TestIdempotency_TooLong(t *testing.T) {
+	r, _, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	longKey := strings.Repeat("x", 257)
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req.Header.Set(idempotencyKeyHeader, longKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]interface{})
+	assert.Equal(t, ErrTypeInvalidRequest, errObj["type"])
+	assert.Equal(t, "idempotency_key_too_long", errObj["code"])
+}
+
+func TestIdempotency_MethodMismatch(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	cachedHeaders, _ := json.Marshal(map[string]string{"Content-Type": "application/json"})
+	cachedBody, _ := json.Marshal(map[string]string{"deleted": "true"})
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-reuse", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}).
+			AddRow("DELETE", "/test", 200, cachedHeaders, cachedBody))
+
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(`{}`))
+	req.Header.Set(idempotencyKeyHeader, "key-reuse")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]interface{})
+	assert.Equal(t, "idempotency_key_reuse", errObj["code"])
+}
+
+func TestIdempotency_ErrorNotCached(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-err", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}))
+
+	req := httptest.NewRequest("POST", "/error", bytes.NewBufferString(`{}`))
+	req.Header.Set(idempotencyKeyHeader, "key-err")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get(idempotencyReplayHeader))
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIdempotency_DeleteMethod(t *testing.T) {
+	r, mock, cleanup := newIdempotencyTestRouter(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT method, path, response_status, response_headers, response_body FROM idempotency_cache`).
+		WithArgs("test-tenant", "key-del", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"method", "path", "response_status", "response_headers", "response_body"}))
+
+	mock.ExpectExec(`INSERT INTO idempotency_cache`).
+		WithArgs("test-tenant", "key-del", "DELETE", "/test", 200, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest("DELETE", "/test", nil)
+	req.Header.Set(idempotencyKeyHeader, "key-del")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(idempotencyReplayHeader))
+}

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -16,10 +16,12 @@ import (
 
 func (s *Server) registerManagementRoutes() {
 	rl := NewManagementRateLimiter()
+	im := newIdempotencyMiddleware(s.db, s.logger)
 
 	s.router.Route("/api/v1/manage", func(r chi.Router) {
 		r.Use(s.requireJWT)
 		r.Use(rl.Middleware)
+		r.Use(im.Middleware)
 
 		r.Get("/buckets", s.handleMgmtListBuckets)
 		r.Post("/buckets", s.handleMgmtCreateBucket)

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -26,6 +26,7 @@ func (s *Server) registerManagementRoutes() {
 		r.Get("/buckets", s.handleMgmtListBuckets)
 		r.Post("/buckets", s.handleMgmtCreateBucket)
 		r.Get("/buckets/{name}", s.handleMgmtGetBucket)
+		r.Patch("/buckets/{name}", s.handleMgmtPatchBucket)
 		r.Delete("/buckets/{name}", s.handleMgmtDeleteBucket)
 
 		r.Get("/buckets/{name}/objects", s.handleMgmtListObjects)
@@ -41,10 +42,11 @@ func (s *Server) registerManagementRoutes() {
 // --- Buckets ---
 
 type mgmtBucket struct {
-	Object    string    `json:"object"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
-	RequestID string    `json:"request_id,omitempty"`
+	Object    string            `json:"object"`
+	Name      string            `json:"name"`
+	Metadata  map[string]string `json:"metadata"`
+	CreatedAt time.Time         `json:"created_at"`
+	RequestID string            `json:"request_id,omitempty"`
 }
 
 func (s *Server) handleMgmtListBuckets(w http.ResponseWriter, r *http.Request) {
@@ -199,16 +201,82 @@ func (s *Server) handleMgmtGetBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var b mgmtBucket
+	var metaJSON []byte
 	err := s.db.QueryRowContext(r.Context(),
-		`SELECT name, created_at FROM buckets WHERE tenant_id = $1 AND name = $2`,
-		tenantID, name).Scan(&b.Name, &b.CreatedAt)
+		`SELECT name, COALESCE(metadata, '{}'), created_at FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, name).Scan(&b.Name, &metaJSON, &b.CreatedAt)
 	if err != nil {
 		writeManagementError(w, ErrTypeNotFound, "bucket_not_found",
 			"bucket not found", "name")
 		return
 	}
 	b.Object = "bucket"
+	b.Metadata = make(map[string]string)
+	_ = json.Unmarshal(metaJSON, &b.Metadata)
 	b.RequestID = getRequestID(w)
+	writeJSON(w, http.StatusOK, b)
+}
+
+func (s *Server) handleMgmtPatchBucket(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+
+	if s.db == nil {
+		writeManagementError(w, ErrTypeAPI, "no_database", "database unavailable", "")
+		return
+	}
+
+	var req struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if req.Metadata == nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "missing_parameter", "metadata field is required", "metadata")
+		return
+	}
+
+	var existing json.RawMessage
+	var createdAt time.Time
+	err := s.db.QueryRowContext(r.Context(),
+		`SELECT COALESCE(metadata, '{}'), created_at FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, name).Scan(&existing, &createdAt)
+	if err != nil {
+		writeManagementError(w, ErrTypeNotFound, "bucket_not_found", "bucket not found", "name")
+		return
+	}
+
+	merged, mergeErr := mergeMetadata(existing, req.Metadata)
+	if mergeErr != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_metadata", mergeErr.Error(), "metadata")
+		return
+	}
+
+	_, err = s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET metadata = $1, updated_at = NOW() WHERE tenant_id = $2 AND name = $3`,
+		merged, tenantID, name)
+	if err != nil {
+		s.logger.Error("update bucket metadata", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "db_error", "failed to update metadata", "")
+		return
+	}
+
+	b := mgmtBucket{
+		Object:    "bucket",
+		Name:      name,
+		Metadata:  make(map[string]string),
+		CreatedAt: createdAt,
+		RequestID: getRequestID(w),
+	}
+	_ = json.Unmarshal(merged, &b.Metadata)
 	writeJSON(w, http.StatusOK, b)
 }
 

--- a/internal/api/management_test.go
+++ b/internal/api/management_test.go
@@ -222,9 +222,10 @@ func TestManagementGetBucket(t *testing.T) {
 	defer cleanup()
 
 	now := time.Now()
-	mock.ExpectQuery(`SELECT name, created_at FROM buckets WHERE tenant_id`).
+	mock.ExpectQuery(`SELECT name, COALESCE`).
 		WithArgs("test-tenant", "my-bucket").
-		WillReturnRows(sqlmock.NewRows([]string{"name", "created_at"}).AddRow("my-bucket", now))
+		WillReturnRows(sqlmock.NewRows([]string{"name", "metadata", "created_at"}).
+			AddRow("my-bucket", []byte(`{}`), now))
 
 	req := httptest.NewRequest("GET", "/api/v1/manage/buckets/my-bucket", nil)
 	w := httptest.NewRecorder()

--- a/internal/api/metadata.go
+++ b/internal/api/metadata.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	metadataMaxKeys     = 50
+	metadataMaxValueLen = 500
+	metadataMaxTotalLen = 2048
+	s3MetaPrefix        = "X-Amz-Meta-"
+)
+
+func extractS3Metadata(r *http.Request) map[string]string {
+	meta := make(map[string]string)
+	for k, vals := range r.Header {
+		if strings.HasPrefix(k, s3MetaPrefix) && len(vals) > 0 {
+			key := strings.ToLower(k[len(s3MetaPrefix):])
+			if key != "" {
+				meta[key] = vals[0]
+			}
+		}
+	}
+	return meta
+}
+
+func setS3MetadataHeaders(w http.ResponseWriter, metadataJSON []byte) {
+	if len(metadataJSON) == 0 {
+		return
+	}
+	var meta map[string]string
+	if err := json.Unmarshal(metadataJSON, &meta); err != nil {
+		return
+	}
+	for k, v := range meta {
+		w.Header().Set(s3MetaPrefix+k, v)
+	}
+}
+
+func validateMetadata(meta map[string]string) error {
+	if len(meta) > metadataMaxKeys {
+		return fmt.Errorf("metadata exceeds maximum of %d keys", metadataMaxKeys)
+	}
+	total := 0
+	for k, v := range meta {
+		if len(v) > metadataMaxValueLen {
+			return fmt.Errorf("metadata value for key %q exceeds %d characters", k, metadataMaxValueLen)
+		}
+		total += len(k) + len(v)
+	}
+	if total > metadataMaxTotalLen {
+		return fmt.Errorf("metadata total size exceeds %d bytes", metadataMaxTotalLen)
+	}
+	return nil
+}
+
+func mergeMetadata(existing json.RawMessage, patch map[string]interface{}) ([]byte, error) {
+	current := make(map[string]string)
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &current)
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(current, k)
+		} else if s, ok := v.(string); ok {
+			current[k] = s
+		} else {
+			return nil, fmt.Errorf("metadata value for key %q must be a string or null", k)
+		}
+	}
+	if err := validateMetadata(current); err != nil {
+		return nil, err
+	}
+	return json.Marshal(current)
+}

--- a/internal/api/metadata_test.go
+++ b/internal/api/metadata_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/FairForge/vaultaire/internal/config"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestExtractS3Metadata(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/bucket/key", nil)
+	r.Header.Set("X-Amz-Meta-Color", "blue")
+	r.Header.Set("X-Amz-Meta-Author", "Alice")
+	r.Header.Set("Content-Type", "text/plain")
+
+	meta := extractS3Metadata(r)
+	assert.Equal(t, "blue", meta["color"])
+	assert.Equal(t, "Alice", meta["author"])
+	assert.Len(t, meta, 2)
+}
+
+func TestSetS3MetadataHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	metaJSON, _ := json.Marshal(map[string]string{"color": "blue", "size": "large"})
+	setS3MetadataHeaders(w, metaJSON)
+
+	assert.Equal(t, "blue", w.Header().Get("X-Amz-Meta-color"))
+	assert.Equal(t, "large", w.Header().Get("X-Amz-Meta-size"))
+}
+
+func TestSetS3MetadataHeaders_Empty(t *testing.T) {
+	w := httptest.NewRecorder()
+	setS3MetadataHeaders(w, nil)
+	setS3MetadataHeaders(w, []byte("{}"))
+	assert.Empty(t, w.Header().Get("X-Amz-Meta-color"))
+}
+
+func TestValidateMetadata(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		meta := map[string]string{"key": "value"}
+		assert.NoError(t, validateMetadata(meta))
+	})
+
+	t.Run("too many keys", func(t *testing.T) {
+		meta := make(map[string]string)
+		for i := 0; i < 51; i++ {
+			meta[fmt.Sprintf("key-%03d", i)] = "v"
+		}
+		assert.Error(t, validateMetadata(meta))
+	})
+
+	t.Run("value too long", func(t *testing.T) {
+		meta := map[string]string{"key": strings.Repeat("x", 501)}
+		assert.Error(t, validateMetadata(meta))
+	})
+
+	t.Run("total too large", func(t *testing.T) {
+		meta := make(map[string]string)
+		for i := 0; i < 40; i++ {
+			meta[fmt.Sprintf("key-%03d", i)] = strings.Repeat("v", 60)
+		}
+		assert.Error(t, validateMetadata(meta))
+	})
+}
+
+func TestMergeMetadata(t *testing.T) {
+	t.Run("add keys", func(t *testing.T) {
+		existing := json.RawMessage(`{"color":"blue"}`)
+		patch := map[string]interface{}{"size": "large"}
+		result, err := mergeMetadata(existing, patch)
+		require.NoError(t, err)
+
+		var merged map[string]string
+		require.NoError(t, json.Unmarshal(result, &merged))
+		assert.Equal(t, "blue", merged["color"])
+		assert.Equal(t, "large", merged["size"])
+	})
+
+	t.Run("delete key with null", func(t *testing.T) {
+		existing := json.RawMessage(`{"color":"blue","size":"large"}`)
+		patch := map[string]interface{}{"color": nil}
+		result, err := mergeMetadata(existing, patch)
+		require.NoError(t, err)
+
+		var merged map[string]string
+		require.NoError(t, json.Unmarshal(result, &merged))
+		assert.Empty(t, merged["color"])
+		assert.Equal(t, "large", merged["size"])
+	})
+
+	t.Run("overwrite key", func(t *testing.T) {
+		existing := json.RawMessage(`{"color":"blue"}`)
+		patch := map[string]interface{}{"color": "red"}
+		result, err := mergeMetadata(existing, patch)
+		require.NoError(t, err)
+
+		var merged map[string]string
+		require.NoError(t, json.Unmarshal(result, &merged))
+		assert.Equal(t, "red", merged["color"])
+	})
+
+	t.Run("non-string value rejected", func(t *testing.T) {
+		existing := json.RawMessage(`{}`)
+		patch := map[string]interface{}{"count": float64(42)}
+		_, err := mergeMetadata(existing, patch)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty existing", func(t *testing.T) {
+		patch := map[string]interface{}{"key": "val"}
+		result, err := mergeMetadata(nil, patch)
+		require.NoError(t, err)
+
+		var merged map[string]string
+		require.NoError(t, json.Unmarshal(result, &merged))
+		assert.Equal(t, "val", merged["key"])
+	})
+}
+
+func TestManagementBucketMetadata_Get(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		db:     db,
+		config: newStubConfig(),
+	}
+
+	s.router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Request-Id", uuid.New().String())
+			ctx := context.WithValue(r.Context(), tenantIDKey, "test-tenant")
+			ctx = context.WithValue(ctx, userIDKey, "test-user")
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	s.router.Get("/api/v1/manage/buckets/{name}", s.handleMgmtGetBucket)
+
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT name, COALESCE`).
+		WithArgs("test-tenant", "my-bucket").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "metadata", "created_at"}).
+			AddRow("my-bucket", []byte(`{"color":"blue","env":"prod"}`), now))
+
+	req := httptest.NewRequest("GET", "/api/v1/manage/buckets/my-bucket", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "bucket", resp["object"])
+
+	meta := resp["metadata"].(map[string]interface{})
+	assert.Equal(t, "blue", meta["color"])
+	assert.Equal(t, "prod", meta["env"])
+}
+
+func TestManagementBucketMetadata_Patch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		db:     db,
+		config: newStubConfig(),
+	}
+
+	s.router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Request-Id", uuid.New().String())
+			ctx := context.WithValue(r.Context(), tenantIDKey, "test-tenant")
+			ctx = context.WithValue(ctx, userIDKey, "test-user")
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	s.router.Patch("/api/v1/manage/buckets/{name}", s.handleMgmtPatchBucket)
+
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT COALESCE`).
+		WithArgs("test-tenant", "my-bucket").
+		WillReturnRows(sqlmock.NewRows([]string{"metadata", "created_at"}).
+			AddRow([]byte(`{"color":"blue"}`), now))
+
+	mock.ExpectExec(`UPDATE buckets SET metadata`).
+		WithArgs(sqlmock.AnyArg(), "test-tenant", "my-bucket").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := bytes.NewBufferString(`{"metadata":{"color":null,"env":"prod"}}`)
+	req := httptest.NewRequest("PATCH", "/api/v1/manage/buckets/my-bucket", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "bucket", resp["object"])
+
+	meta := resp["metadata"].(map[string]interface{})
+	assert.Nil(t, meta["color"])
+	assert.Equal(t, "prod", meta["env"])
+}
+
+func newStubConfig() *config.Config {
+	return &config.Config{Server: config.ServerConfig{Port: 8000}}
+}

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -493,12 +493,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	var sizeBytes int64
 	var etag, contentType string
 	var updatedAt time.Time
+	var metadataJSON []byte
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type, updated_at
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -535,6 +536,7 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	}
 	w.Header().Set("x-amz-storage-class", "STANDARD")
 	w.Header().Set("x-amz-request-id", generateRequestID())
+	setS3MetadataHeaders(w, metadataJSON)
 	// HEAD must not write a body.
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -203,13 +204,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedSize int64
 	var cachedETag string
 	var cachedUpdatedAt time.Time
+	var cachedMetadata []byte
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}')
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata)
 		if err == nil {
 			cacheHit = true
 		}
@@ -288,6 +290,7 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		if !cachedUpdatedAt.IsZero() {
 			w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
 		}
+		setS3MetadataHeaders(w, cachedMetadata)
 	}
 
 	written, err := io.Copy(w, reader)
@@ -426,18 +429,26 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		contentType = "application/octet-stream"
 	}
 
+	userMeta := extractS3Metadata(r)
+	if err := validateMetadata(userMeta); err != nil {
+		WriteS3Error(w, ErrInvalidRequest, r.URL.Path, generateRequestID())
+		return
+	}
+	metaJSON, _ := json.Marshal(userMeta)
+
 	if a.db != nil {
 		_, dbErr := a.db.ExecContext(r.Context(), `
 			INSERT INTO object_head_cache
-				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
 			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
 				size_bytes   = EXCLUDED.size_bytes,
 				etag         = EXCLUDED.etag,
 				content_type = EXCLUDED.content_type,
 				backend_name = EXCLUDED.backend_name,
+				metadata     = EXCLUDED.metadata,
 				updated_at   = NOW()
-		`, t.ID, bucket, artifact, size, etag, contentType, backendName)
+		`, t.ID, bucket, artifact, size, etag, contentType, backendName, metaJSON)
 		if dbErr != nil {
 			a.logger.Error("failed to cache object metadata",
 				zap.Error(dbErr),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -797,6 +797,12 @@ func (s *Server) Start() error {
 		ds.StartCleanup(ctx)
 	}
 
+	// Clean up expired idempotency cache entries hourly.
+	if s.db != nil {
+		im := newIdempotencyMiddleware(s.db, s.logger)
+		im.StartCleanup(ctx)
+	}
+
 	s.logger.Info("Starting server with RBAC and API Key Management",
 		zap.Int("port", s.config.Server.Port))
 	return s.httpServer.ListenAndServe()

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -20,6 +20,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 026 | S3 versioning: `versioning_status` on `buckets`, `object_versions` table |
 | 027 | Bucket notifications: `bucket_notifications` table for S3 event webhook config |
 | 028 | Object Lock: `object_lock_enabled`, `default_retention_mode`, `default_retention_days` on `buckets`; `object_locks` table |
+| 029 | Idempotency cache: `idempotency_cache` table for management API request deduplication (24h TTL) |
 
 ## Key Tables
 
@@ -37,6 +38,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`
 - **bucket_notifications** — `id (PK)`, `tenant_id`, `bucket`, `event_filter`, `target_type`, `target_url`, `enabled`, `created_at`
 - **object_locks** — `(tenant_id, bucket, object_key) PK`, `retention_mode`, `retain_until_date`, `legal_hold`, `created_at`, `updated_at`
+- **idempotency_cache** — `(tenant_id, idempotency_key) PK`, `method`, `path`, `response_status`, `response_headers` (JSONB), `response_body` (BYTEA), `created_at` — 24h TTL, hourly cleanup
 
 ## Connection
 

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -21,6 +21,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 027 | Bucket notifications: `bucket_notifications` table for S3 event webhook config |
 | 028 | Object Lock: `object_lock_enabled`, `default_retention_mode`, `default_retention_days` on `buckets`; `object_locks` table |
 | 029 | Idempotency cache: `idempotency_cache` table for management API request deduplication (24h TTL) |
+| 030 | Metadata: `metadata JSONB` column on `buckets` and `object_head_cache` |
 
 ## Key Tables
 

--- a/internal/database/migrations/029_idempotency_cache.sql
+++ b/internal/database/migrations/029_idempotency_cache.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS idempotency_cache (
+    tenant_id        TEXT        NOT NULL,
+    idempotency_key  TEXT        NOT NULL,
+    method           TEXT        NOT NULL,
+    path             TEXT        NOT NULL,
+    response_status  INTEGER     NOT NULL,
+    response_headers JSONB       NOT NULL DEFAULT '{}',
+    response_body    BYTEA       NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_cache_created_at ON idempotency_cache (created_at);

--- a/internal/database/migrations/030_metadata.sql
+++ b/internal/database/migrations/030_metadata.sql
@@ -1,0 +1,6 @@
+-- 030_metadata.sql
+-- Phase 5.11.3: User-defined metadata on buckets and objects
+-- Idempotent — safe to re-run on every deploy
+
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}';
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary

### Phase 5.11.2: Idempotency Keys
- `Idempotency-Key` header on PUT/POST/DELETE management API requests (GET/HEAD/OPTIONS skipped)
- Same key within 24h replays cached response with `Idempotency-Replayed: true` header
- Only caches 2xx responses — errors let clients retry safely
- Method/path mismatch on key reuse returns 409 `idempotency_key_reuse`
- New `idempotency_cache` PostgreSQL table (migration 029) with hourly cleanup goroutine
- 9 tests

### Phase 5.11.3: Metadata on Resources
- S3 `x-amz-meta-*` headers extracted on PUT, stored in `object_head_cache.metadata` JSONB, returned on GET and HEAD
- Management API: `GET /api/v1/manage/buckets/{name}` includes metadata field
- `PATCH /api/v1/manage/buckets/{name}` with Stripe-style merge semantics (null value deletes key)
- Validation: max 50 keys, 500 chars/value, 2KB total
- New migration 030 adds `metadata JSONB` column to `buckets` and `object_head_cache`
- 12 tests

## Test plan
- [x] `go test ./... -short` — full suite passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] Pre-commit hooks pass (fmt, test, lint)