### PR TITLE
feat(auth): restricted API keys with scoped permissions [Phase 5.11.4]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Vaultaire is a universal storage orchestration engine providing a unified S3-com
 - **`.private/VAULT_SERIES_ECONOMICS.md`** — Vault1/3/5/10/18/50/100 tiers with overselling, LET marketing, per-tier COGS
 - **`.private/ADVANCED_ARCHITECTURE.md`** — FastCDC, global content index, convergent encryption, federation protocol, seamless node addition
 - **`.private/PRODUCT_LINEUP.md`** — Full 7-product catalog, COGS, margins, use cases, pricing strategy
+- **`.private/IDRIVE_RESELLER_API.md`** — Complete iDrive e2 Reseller API reference, all endpoints, pricing, 6-phase integration plan
+- **`.private/TIER_STRATEGY.md`** — Three-tier GTM: Vault (archive), Standard (smart), Performance (B2 killer). Selling model, use cases, novel features
 - **`.private/PERMAFROST_TESTING_RESULTS.md`** — OneDrive benchmark results v1→v2→v3 (HTTP/1.1 + Range = 214 MB/s fleet)
 - **`internal/drivers/onedrive_README.md`** — OneDrive integration + dual-transport pattern (HTTP/2 for API, HTTP/1.1 for CDN)
 - **`internal/drivers/quotaless_README.md`** — Quotaless backend ops manual
@@ -51,23 +53,34 @@ make fmt                  # go fmt + gofmt -s -w
 ```
 API Layer (internal/api)      S3 protocol translation, auth middleware, HTTP handlers
 Engine Layer (internal/engine) Backend orchestration, tiering, replication, caching, ML routing
-Driver Layer (internal/drivers) Storage provider implementations (local, s3, lyve, quotaless, onedrive)
+Driver Layer (internal/drivers) Storage provider implementations (local, s3, lyve, quotaless, onedrive, geyser, idrive)
 ```
 
 ### Entry Point
 
-`cmd/vaultaire/main.go` — initializes drivers from environment variables, connects to PostgreSQL (optional, degrades gracefully), starts the HTTP server. Storage mode auto-detected: Quotaless > Lyve > S3 > local.
+`cmd/vaultaire/main.go` — initializes drivers from environment variables, connects to PostgreSQL (optional, degrades gracefully), starts the HTTP server. Storage mode auto-detected: Quotaless > S3 > Geyser > local. iDrive requires explicit env vars (not yet in auto-detect).
 
 ### Dual Terminology
 
 External (S3-compatible): Bucket, Object, Key
 Internal: Container, Artifact, Path
 
-The `storage.Backend` interface is the sacred contract all drivers implement.
+The `engine.Driver` interface (in `internal/engine/interface.go`) is the sacred contract all drivers implement: `Name`, `Get`, `Put`, `Delete`, `List`, `Exists`, `HealthCheck`.
 
 ### Key Database Tables
 
-Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries the `tenants` table (not `api_keys` or `users`) — `access_key` and `secret_key` live there.
+Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries `tenants` first (primary key, full access), then falls back to `api_keys` for scoped VLT_ keys.
+
+Other critical tables (31 migrations through `031_scoped_keys.sql`):
+- `object_head_cache` — HEAD/GET metadata cache (~1ms), content-type, ETag, metadata JSONB
+- `buckets` — bucket registry with visibility, CORS, cache TTL, metadata JSONB, slug
+- `multipart_uploads`, `multipart_parts` — in-progress multipart state
+- `object_versions` — versioning support (version_id, is_latest, delete markers)
+- `object_locks` — Object Lock / WORM retention and legal holds
+- `idempotency_cache` — management API idempotency keys (24h TTL)
+- `stripe_events` — webhook event dedup
+- `dashboard_sessions` — PostgreSQL-backed sessions with IP/user-agent tracking
+- `oauth_accounts` — OAuth provider links (Google, GitHub)
 
 Migrations are in `internal/database/migrations/`.
 
@@ -138,6 +151,13 @@ GitHub Actions Deploy (`.github/workflows/deploy.yml`):
 | `GITHUB_CLIENT_ID` | — | GitHub OAuth App client ID |
 | `GITHUB_CLIENT_SECRET` | — | GitHub OAuth App client secret |
 | `VAULTAIRE_BASE_URL` | http://localhost:8000 | Base URL for OAuth callbacks |
+| `JWT_SECRET` | — | **Required** — JWT signing key for API auth |
+| `VERIFY_SECRET` | — | HMAC secret for email verification tokens |
+| `GEYSER_ACCESS_KEY`, `GEYSER_SECRET_KEY` | — | Geyser tape S3 credentials |
+| `GEYSER_BUCKET`, `GEYSER_ENDPOINT` | — | Geyser bucket name and endpoint URL |
+| `IDRIVE_ACCESS_KEY`, `IDRIVE_SECRET_KEY` | — | iDrive E2 S3 credentials |
+| `IDRIVE_ENDPOINT`, `IDRIVE_REGION` | — | iDrive endpoint and region |
+| `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_SECRET`, `ONEDRIVE_TENANT_ID` | — | OneDrive OAuth (future) |
 
 ## Production
 

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -78,8 +78,13 @@ Key files: `metadata.go` (extract/set/validate/merge helpers), `s3_engine_adapte
 
 1. `handleS3Request` checks `isPresignedRequest(r)` — if query has `X-Amz-Algorithm=AWS4-HMAC-SHA256`, routes to `verifyPresignedURL` (SigV4 query string auth)
 2. Otherwise calls `auth.ValidateRequest(r)` which parses the Authorization header
-3. On failure, returns appropriate S3 error (presigned errors: `ExpiredToken`, `AuthorizationQueryParametersError`, `SignatureDoesNotMatch`)
-4. On success, tenant context is set and the request is routed to the operation handler
+3. Both paths return `(tenantID, *auth.KeyScope, error)` — scope carries permissions, bucket restrictions, IP allowlist, and expiration
+4. On failure, returns appropriate S3 error (presigned errors: `ExpiredToken`, `AuthorizationQueryParametersError`, `SignatureDoesNotMatch`)
+5. On success, scope enforcement runs before operation routing:
+   - `IsKeyExpired` → 403 `ExpiredToken`
+   - `CheckIPAllowlist` with `extractClientIP(r)` (CF-Connecting-IP > X-Forwarded-For > RemoteAddr) → 403 `AccessDenied`
+   - After `ParseRequest`: `CheckPermission` and `CheckBucketScope` → 403 `AccessDenied` with suggestion hint
+6. Tenant context is set and the request is routed to the operation handler
 
 ### Pre-Signed URL Verification (Phase 5.10.16)
 

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -446,13 +446,15 @@ func (s *Server) handleMgmtListKeys(w http.ResponseWriter, r *http.Request) {
 	items := make([]interface{}, len(keys))
 	for i, k := range keys {
 		items[i] = map[string]interface{}{
-			"object":      "api_key",
-			"id":          k.ID,
-			"name":        k.Name,
-			"key":         k.Key,
-			"permissions": k.Permissions,
-			"expires_at":  k.ExpiresAt,
-			"created_at":  k.CreatedAt,
+			"object":       "api_key",
+			"id":           k.ID,
+			"name":         k.Name,
+			"key":          k.Key,
+			"permissions":  k.Permissions,
+			"bucket_scope": k.BucketScope,
+			"ip_allowlist": k.IPAllowlist,
+			"expires_at":   k.ExpiresAt,
+			"created_at":   k.CreatedAt,
 		}
 	}
 
@@ -467,34 +469,53 @@ func (s *Server) handleMgmtCreateKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name        string   `json:"name"`
-		Permissions []string `json:"permissions"`
+		Name        string     `json:"name"`
+		Permissions []string   `json:"permissions"`
+		BucketScope []string   `json:"bucket_scope"`
+		IPAllowlist []string   `json:"ip_allowlist"`
+		ExpiresAt   *time.Time `json:"expires_at"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
 		return
 	}
 
-	key, err := s.auth.GenerateAPIKey(r.Context(), userID, req.Name)
+	if len(req.Permissions) > 0 {
+		if err := auth.ValidatePermissions(req.Permissions); err != nil {
+			writeManagementError(w, ErrTypeInvalidRequest, "invalid_permissions", err.Error(), "permissions")
+			return
+		}
+	}
+
+	var opts *auth.KeyCreateOptions
+	if len(req.Permissions) > 0 || len(req.BucketScope) > 0 || len(req.IPAllowlist) > 0 || req.ExpiresAt != nil {
+		opts = &auth.KeyCreateOptions{
+			Permissions: req.Permissions,
+			BucketScope: req.BucketScope,
+			IPAllowlist: req.IPAllowlist,
+			ExpiresAt:   req.ExpiresAt,
+		}
+	}
+
+	key, err := s.auth.GenerateAPIKey(r.Context(), userID, req.Name, opts)
 	if err != nil {
 		s.logger.Error("management create key", zap.Error(err))
 		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to create API key", "")
 		return
 	}
 
-	if len(req.Permissions) > 0 {
-		key.Permissions = req.Permissions
-	}
-
 	resp := map[string]interface{}{
-		"object":      "api_key",
-		"id":          key.ID,
-		"name":        key.Name,
-		"key":         key.Key,
-		"secret":      key.Secret,
-		"permissions": key.Permissions,
-		"created_at":  key.CreatedAt,
-		"request_id":  getRequestID(w),
+		"object":       "api_key",
+		"id":           key.ID,
+		"name":         key.Name,
+		"key":          key.Key,
+		"secret":       key.Secret,
+		"permissions":  key.Permissions,
+		"bucket_scope": key.BucketScope,
+		"ip_allowlist": key.IPAllowlist,
+		"expires_at":   key.ExpiresAt,
+		"created_at":   key.CreatedAt,
+		"request_id":   getRequestID(w),
 	}
 	writeJSON(w, http.StatusCreated, resp)
 }

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -219,11 +220,12 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var tenantID string
+	var scope *auth.KeyScope
 	var err error
 
 	if !s.testMode {
 		if isPresignedRequest(r) {
-			tenantID, err = s.verifyPresignedURL(r)
+			tenantID, scope, err = s.verifyPresignedURL(r)
 			if err != nil {
 				s.logger.Error("presigned URL verification failed",
 					zap.Error(err),
@@ -242,8 +244,8 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			auth := auth.NewAuth(s.db, s.logger)
-			tenantID, err = auth.ValidateRequest(r)
+			a := auth.NewAuth(s.db, s.logger)
+			tenantID, scope, err = a.ValidateRequest(r)
 			if err != nil {
 				s.logger.Error("authentication failed",
 					zap.Error(err),
@@ -264,14 +266,28 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if t, err := tenant.FromContext(r.Context()); err == nil && t != nil {
+		if t, tErr := tenant.FromContext(r.Context()); tErr == nil && t != nil {
 			tenantID = t.ID
 		} else {
 			tenantID = "test"
 		}
+		scope = &auth.KeyScope{Permissions: []string{"*"}}
 		s.logger.Debug("test mode - skipping auth",
 			zap.String("tenant_id", tenantID),
 			zap.String("path", r.URL.Path))
+	}
+
+	// Enforce key expiration and IP allowlist before any further processing.
+	if scope != nil {
+		if auth.IsKeyExpired(scope.ExpiresAt) {
+			WriteS3Error(w, ErrExpiredPresignedRequest, r.URL.Path, generateRequestID())
+			return
+		}
+		if !auth.CheckIPAllowlist(scope.IPAllowlist, extractClientIP(r)) {
+			WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+				WithSuggestion("This key is restricted by IP address."))
+			return
+		}
 	}
 
 	if tenantID != "" {
@@ -309,6 +325,20 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s3Req.TenantID = tenantID
+
+	// Enforce permission and bucket scope now that we know the operation.
+	if scope != nil {
+		if !auth.CheckPermission(scope.Permissions, s3Req.Operation) {
+			WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+				WithSuggestion(fmt.Sprintf("This key does not have %s access.", s3Req.Operation)))
+			return
+		}
+		if s3Req.Bucket != "" && !auth.CheckBucketScope(scope.BucketScope, s3Req.Bucket) {
+			WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+				WithSuggestion(fmt.Sprintf("This key is restricted to buckets: %s", strings.Join(scope.BucketScope, ", "))))
+			return
+		}
+	}
 
 	if tenantID == "" {
 		tenantID = "default"
@@ -581,4 +611,24 @@ func isTenantSuspended(ctx context.Context, db *sql.DB, tenantID string) bool {
 		return false // fail open — if we can't check, allow access
 	}
 	return suspendedAt.Valid
+}
+
+// extractClientIP returns the real client IP, checking proxy headers
+// in priority order: CF-Connecting-IP (Cloudflare) > X-Forwarded-For
+// (HAProxy) > RemoteAddr.
+func extractClientIP(r *http.Request) string {
+	if ip := r.Header.Get("CF-Connecting-IP"); ip != "" {
+		return ip
+	}
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if idx := strings.Index(xff, ","); idx > 0 {
+			return strings.TrimSpace(xff[:idx])
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }

--- a/internal/api/s3_presign.go
+++ b/internal/api/s3_presign.go
@@ -3,7 +3,9 @@ package api
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	"github.com/lib/pq"
 )
 
 const (
@@ -27,7 +32,7 @@ func isPresignedRequest(r *http.Request) bool {
 	return r.URL.Query().Get("X-Amz-Algorithm") == presignAlgorithm
 }
 
-func (s *Server) verifyPresignedURL(r *http.Request) (string, error) {
+func (s *Server) verifyPresignedURL(r *http.Request) (string, *auth.KeyScope, error) {
 	q := r.URL.Query()
 
 	algorithm := q.Get("X-Amz-Algorithm")
@@ -39,17 +44,17 @@ func (s *Server) verifyPresignedURL(r *http.Request) (string, error) {
 
 	if algorithm == "" || credential == "" || amzDate == "" ||
 		expiresStr == "" || signedHeaders == "" || signature == "" {
-		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+		return "", nil, fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
 	}
 
 	expires, err := strconv.Atoi(expiresStr)
 	if err != nil || expires < 1 || expires > presignMaxExpires {
-		return "", fmt.Errorf("%s", ErrInvalidPresignExpires)
+		return "", nil, fmt.Errorf("%s", ErrInvalidPresignExpires)
 	}
 
 	credParts := strings.Split(credential, "/")
 	if len(credParts) != 5 || credParts[3] != presignService || credParts[4] != presignAWS4Request {
-		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+		return "", nil, fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
 	}
 	accessKey := credParts[0]
 	credDate := credParts[1]
@@ -57,23 +62,60 @@ func (s *Server) verifyPresignedURL(r *http.Request) (string, error) {
 
 	reqTime, err := time.Parse(presignTimeFormat, amzDate)
 	if err != nil {
-		return "", fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
+		return "", nil, fmt.Errorf("%s", ErrAuthorizationQueryParametersError)
 	}
 
 	if time.Now().UTC().After(reqTime.Add(time.Duration(expires) * time.Second)) {
-		return "", fmt.Errorf("%s", ErrExpiredPresignedRequest)
+		return "", nil, fmt.Errorf("%s", ErrExpiredPresignedRequest)
 	}
 
 	if s.db == nil {
-		return "", fmt.Errorf("%s: database not available", ErrAccessDenied)
+		return "", nil, fmt.Errorf("%s: database not available", ErrAccessDenied)
 	}
 
+	// Look up credentials and scope. Try primary tenant key first, then scoped API keys.
 	var secretKey, tenantID string
+	var scope *auth.KeyScope
+
 	err = s.db.QueryRow(
 		`SELECT secret_key, id FROM tenants WHERE access_key = $1`, accessKey,
 	).Scan(&secretKey, &tenantID)
-	if err != nil {
-		return "", fmt.Errorf("%s", ErrAccessDenied)
+	if err == sql.ErrNoRows {
+		// Try scoped API key — requires secret_key stored for signature verification.
+		var permJSON []byte
+		var bucketScope, ipAllowlist pq.StringArray
+		var expiresAtDB sql.NullTime
+		err = s.db.QueryRow(`
+			SELECT ak.secret_key, t.id,
+			       COALESCE(ak.permissions, '["*"]'::jsonb),
+			       COALESCE(ak.bucket_scope, '{}'),
+			       COALESCE(ak.ip_allowlist, '{}'),
+			       ak.expires_at
+			FROM api_keys ak
+			JOIN users u ON u.id = ak.user_id
+			JOIN tenants t ON t.email = u.email
+			WHERE ak.key_id = $1
+		`, accessKey).Scan(&secretKey, &tenantID, &permJSON, &bucketScope, &ipAllowlist, &expiresAtDB)
+		if err != nil {
+			return "", nil, fmt.Errorf("%s", ErrAccessDenied)
+		}
+		if secretKey == "" {
+			return "", nil, fmt.Errorf("%s", ErrAccessDenied)
+		}
+		scope = &auth.KeyScope{
+			BucketScope: []string(bucketScope),
+			IPAllowlist: []string(ipAllowlist),
+		}
+		if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
+			scope.Permissions = []string{"*"}
+		}
+		if expiresAtDB.Valid {
+			scope.ExpiresAt = &expiresAtDB.Time
+		}
+	} else if err != nil {
+		return "", nil, fmt.Errorf("%s", ErrAccessDenied)
+	} else {
+		scope = &auth.KeyScope{Permissions: []string{"*"}}
 	}
 
 	canonicalURI := uriEncodePath(r.URL.Path)
@@ -120,10 +162,10 @@ func (s *Server) verifyPresignedURL(r *http.Request) (string, error) {
 	expectedSig := hex.EncodeToString(presignHMAC(signingKey, []byte(stringToSign)))
 
 	if !hmac.Equal([]byte(expectedSig), []byte(signature)) {
-		return "", fmt.Errorf("%s", ErrSignatureDoesNotMatch)
+		return "", nil, fmt.Errorf("%s", ErrSignatureDoesNotMatch)
 	}
 
-	return tenantID, nil
+	return tenantID, scope, nil
 }
 
 func buildPresignCanonicalQuery(values url.Values) string {

--- a/internal/api/s3_presign_test.go
+++ b/internal/api/s3_presign_test.go
@@ -162,7 +162,7 @@ func TestVerifyPresignedURL_MissingParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "/bucket/key?X-Amz-Algorithm=AWS4-HMAC-SHA256", nil)
 	r.Host = "localhost:8000"
 
-	_, err := s.verifyPresignedURL(r)
+	_, _, err := s.verifyPresignedURL(r)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ErrAuthorizationQueryParametersError)
 }
@@ -194,7 +194,7 @@ func TestVerifyPresignedURL_ExpiresOutOfRange(t *testing.T) {
 			r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
 			r.Host = "localhost:8000"
 
-			_, err := s.verifyPresignedURL(r)
+			_, _, err := s.verifyPresignedURL(r)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), ErrInvalidPresignExpires)
 		})
@@ -215,7 +215,7 @@ func TestVerifyPresignedURL_InvalidAccessKey(t *testing.T) {
 	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
 	r.Host = "localhost:8000"
 
-	_, err := s.verifyPresignedURL(r)
+	_, _, err := s.verifyPresignedURL(r)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ErrAccessDenied)
 }
@@ -232,7 +232,7 @@ func TestVerifyPresignedURL_Expired(t *testing.T) {
 	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
 	r.Host = "localhost:8000"
 
-	_, err := s.verifyPresignedURL(r)
+	_, _, err := s.verifyPresignedURL(r)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ErrExpiredPresignedRequest)
 }
@@ -250,7 +250,7 @@ func TestVerifyPresignedURL_InvalidSignature(t *testing.T) {
 	r := httptest.NewRequest("GET", "/bucket/key?"+q.Encode(), nil)
 	r.Host = "localhost:8000"
 
-	_, err := s.verifyPresignedURL(r)
+	_, _, err := s.verifyPresignedURL(r)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ErrSignatureDoesNotMatch)
 }
@@ -267,7 +267,7 @@ func TestVerifyPresignedURL_ValidGET(t *testing.T) {
 	r := httptest.NewRequest("GET", "/my-bucket/my-object.txt?"+q.Encode(), nil)
 	r.Host = "localhost:8000"
 
-	tenantID, err := s.verifyPresignedURL(r)
+	tenantID, _, err := s.verifyPresignedURL(r)
 	require.NoError(t, err)
 	assert.Equal(t, testPresignTenantID, tenantID)
 }
@@ -284,7 +284,7 @@ func TestVerifyPresignedURL_ValidPUT(t *testing.T) {
 	r := httptest.NewRequest("PUT", "/upload-bucket/data.bin?"+q.Encode(), bytes.NewReader([]byte("file content")))
 	r.Host = "localhost:8000"
 
-	tenantID, err := s.verifyPresignedURL(r)
+	tenantID, _, err := s.verifyPresignedURL(r)
 	require.NoError(t, err)
 	assert.Equal(t, testPresignTenantID, tenantID)
 }
@@ -303,7 +303,7 @@ func TestVerifyPresignedURL_PathWithSpecialChars(t *testing.T) {
 	r := httptest.NewRequest("GET", path+"?"+q.Encode(), nil)
 	r.Host = "localhost:8000"
 
-	tenantID, err := s.verifyPresignedURL(r)
+	tenantID, _, err := s.verifyPresignedURL(r)
 	require.NoError(t, err)
 	assert.Equal(t, testPresignTenantID, tenantID)
 }
@@ -470,7 +470,7 @@ func TestHandleGetPresignedURL(t *testing.T) {
 	verifyReq := httptest.NewRequest("PUT", parsedURL.RequestURI(), bytes.NewReader([]byte("data")))
 	verifyReq.Host = parsedURL.Host
 
-	verifiedTenantID, err := s.verifyPresignedURL(verifyReq)
+	verifiedTenantID, _, err := s.verifyPresignedURL(verifyReq)
 	require.NoError(t, err)
 	assert.Equal(t, testPresignTenantID, verifiedTenantID)
 }

--- a/internal/api/user_api.go
+++ b/internal/api/user_api.go
@@ -145,7 +145,7 @@ func (s *Server) handleCreateUserAPIKey(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Generate key
-	key, err := s.auth.GenerateAPIKey(r.Context(), userID, req.Name)
+	key, err := s.auth.GenerateAPIKey(r.Context(), userID, req.Name, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -7,7 +7,9 @@ Authentication service for Vaultaire. Handles user registration, login, JWT toke
 - **AuthService** — stateful service with in-memory maps for O(1) lookups. Backed by PostgreSQL for persistence.
 - **User** — `{ID, Email, PasswordHash, Company, TenantID}`
 - **Tenant** — `{ID, UserID, AccessKey, SecretKey}` — S3 auth queries `keyIndex[accessKey]`
-- **APIKey** — `{ID, UserID, TenantID, Key, Secret, Hash}`
+- **APIKey** — `{ID, UserID, TenantID, Key, Secret, Hash, Permissions, BucketScope, IPAllowlist, ExpiresAt}`
+- **KeyScope** — `{Permissions, BucketScope, IPAllowlist, ExpiresAt}` — returned from auth lookups for scope enforcement
+- **KeyCreateOptions** — optional scope params for `GenerateAPIKey`
 
 ## Critical Methods
 
@@ -49,8 +51,23 @@ Password reset rate limiting is in-memory (per-email, 3/hour, sliding window). T
 | `users` | email | *User | Login lookup |
 | `userIndex` | userID | *User | ID-based lookup |
 | `tenants` | tenantID | *Tenant | Tenant lookup |
-| `keyIndex` | accessKey | *Tenant | S3 auth (hot path) |
-| `apiKeys` | key | *APIKey | API key validation |
+| `keyIndex` | accessKey | *Tenant | S3 auth (hot path). Includes scoped VLT_ keys mapped to owning tenant. |
+| `apiKeys` | key | *APIKey | API key validation. Carries scope data (Permissions, BucketScope, IPAllowlist, ExpiresAt). |
+
+## Scoped API Keys (Phase 5.11.4)
+
+`scoped_keys.go` — permission check functions reusable by S3 enforcement and future STS (Phase 5.11.5):
+- `CheckPermission(keyPerms, operation)` — `["*"]` allows all; otherwise exact match
+- `CheckBucketScope(scopes, bucket)` — empty = unrestricted
+- `CheckIPAllowlist(allowlist, clientIP)` — supports CIDR and exact IP; empty = unrestricted
+- `IsKeyExpired(expiresAt)` — nil = never expires
+- `ValidatePermissions(perms)` — validates against `ValidPermissions` map (all S3 operation names from `determineOperation`)
+
+`GenerateAPIKey(ctx, userID, name, *KeyCreateOptions)` — accepts scope options. Persists to `api_keys` table with scope columns. Adds key to `keyIndex` so scoped VLT_ keys can authenticate S3 requests.
+
+`LoadFromDB` — loads `api_keys` table with scope columns (permissions JSONB, bucket_scope TEXT[], ip_allowlist TEXT[], expires_at TIMESTAMPTZ, secret_key TEXT). Populates both `apiKeys` and `keyIndex` maps.
+
+`Auth.ValidateRequest` (handlers.go) — returns `(tenantID, *KeyScope, error)`. Queries `tenants` first (primary key, full access), falls back to `api_keys` JOIN users+tenants for scoped keys.
 
 ## Slug Generation + Bucket Backfill (`slug.go`, `backfill.go`)
 

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -6,11 +6,14 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // APIKey represents an API key for S3 access
@@ -23,6 +26,8 @@ type APIKey struct {
 	Secret      string            `json:"secret,omitempty"`
 	Hash        string            `json:"-" db:"secret_hash"`
 	Permissions []string          `json:"permissions" db:"permissions"`
+	BucketScope []string          `json:"bucket_scope" db:"bucket_scope"`
+	IPAllowlist []string          `json:"ip_allowlist" db:"ip_allowlist"`
 	ExpiresAt   *time.Time        `json:"expires_at,omitempty" db:"expires_at"`
 	LastUsed    *time.Time        `json:"last_used,omitempty" db:"last_used"`
 	CreatedAt   time.Time         `json:"created_at" db:"created_at"`
@@ -32,8 +37,9 @@ type APIKey struct {
 	LastIP      string            `json:"last_ip,omitempty" db:"last_ip"`
 }
 
-// GenerateAPIKey creates a new API key for a user
-func (a *AuthService) GenerateAPIKey(ctx context.Context, userID, name string) (*APIKey, error) {
+// GenerateAPIKey creates a new API key for a user.
+// opts may be nil for full-access keys.
+func (a *AuthService) GenerateAPIKey(ctx context.Context, userID, name string, opts *KeyCreateOptions) (*APIKey, error) {
 	user, exists := a.userIndex[userID]
 	if !exists {
 		return nil, fmt.Errorf("user not found")
@@ -57,12 +63,45 @@ func (a *AuthService) GenerateAPIKey(ctx context.Context, userID, name string) (
 		Key:         accessKey,
 		Secret:      secretKey,
 		Hash:        hash,
-		Permissions: []string{"s3:*"},
+		Permissions: []string{"*"},
 		CreatedAt:   time.Now(),
 		Metadata:    make(map[string]string),
 	}
 
+	if opts != nil {
+		if len(opts.Permissions) > 0 {
+			apiKey.Permissions = opts.Permissions
+		}
+		apiKey.BucketScope = opts.BucketScope
+		apiKey.IPAllowlist = opts.IPAllowlist
+		apiKey.ExpiresAt = opts.ExpiresAt
+	}
+
 	a.apiKeys[accessKey] = apiKey
+
+	if tenant, ok := a.tenants[user.TenantID]; ok {
+		a.keyIndex[accessKey] = tenant
+	}
+
+	if a.sqlDB != nil {
+		secretHash, hashErr := bcrypt.GenerateFromPassword([]byte(secretKey), bcrypt.DefaultCost)
+		if hashErr != nil {
+			return nil, fmt.Errorf("hash api key secret: %w", hashErr)
+		}
+		permJSON, _ := json.Marshal(apiKey.Permissions)
+		_, err = a.sqlDB.ExecContext(ctx, `
+			INSERT INTO api_keys (id, user_id, name, key_id, secret_hash, secret_key,
+			                      permissions, bucket_scope, ip_allowlist, expires_at, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			ON CONFLICT (key_id) DO NOTHING
+		`, apiKey.ID, userID, name, accessKey, string(secretHash), secretKey,
+			permJSON, pq.Array(apiKey.BucketScope), pq.Array(apiKey.IPAllowlist),
+			apiKey.ExpiresAt, apiKey.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("persist api key: %w", err)
+		}
+	}
+
 	return apiKey, nil
 }
 
@@ -183,7 +222,7 @@ func (a *AuthService) ListAPIKeys(ctx context.Context, userID string) ([]*APIKey
 
 // GenerateAPIKeyWithAudit creates a new API key with audit logging
 func (a *AuthService) GenerateAPIKeyWithAudit(ctx context.Context, userID, name, ip, userAgent string) (*APIKey, error) {
-	key, err := a.GenerateAPIKey(ctx, userID, name)
+	key, err := a.GenerateAPIKey(ctx, userID, name, nil)
 
 	if a.auditLogger != nil {
 		event := APIKeyAuditEvent{

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -20,7 +20,7 @@ func TestAPIKeyGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("generates API key with new format", func(t *testing.T) {
-		key, err := auth.GenerateAPIKey(ctx, user.ID, "Test Key")
+		key, err := auth.GenerateAPIKey(ctx, user.ID, "Test Key", nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, key.Key)
@@ -28,11 +28,11 @@ func TestAPIKeyGeneration(t *testing.T) {
 		assert.Len(t, key.Secret, 40)
 		assert.Equal(t, "Test Key", key.Name)
 		assert.Equal(t, user.TenantID, key.TenantID)
-		assert.Equal(t, []string{"s3:*"}, key.Permissions)
+		assert.Equal(t, []string{"*"}, key.Permissions)
 	})
 
 	t.Run("validates API key", func(t *testing.T) {
-		key, err := auth.GenerateAPIKey(ctx, user.ID, "Validate Test")
+		key, err := auth.GenerateAPIKey(ctx, user.ID, "Validate Test", nil)
 		require.NoError(t, err)
 
 		// Valid key
@@ -51,7 +51,7 @@ func TestAPIKeyGeneration(t *testing.T) {
 
 	t.Run("rotates API key", func(t *testing.T) {
 		// Create original key
-		originalKey, err := auth.GenerateAPIKey(ctx, user.ID, "Original")
+		originalKey, err := auth.GenerateAPIKey(ctx, user.ID, "Original", nil)
 		require.NoError(t, err)
 
 		// Rotate it
@@ -65,7 +65,7 @@ func TestAPIKeyGeneration(t *testing.T) {
 	})
 
 	t.Run("revokes API key", func(t *testing.T) {
-		key, err := auth.GenerateAPIKey(ctx, user.ID, "Revoke Test")
+		key, err := auth.GenerateAPIKey(ctx, user.ID, "Revoke Test", nil)
 		require.NoError(t, err)
 
 		// Revoke key
@@ -79,7 +79,7 @@ func TestAPIKeyGeneration(t *testing.T) {
 	})
 
 	t.Run("handles key expiration", func(t *testing.T) {
-		key, err := auth.GenerateAPIKey(ctx, user.ID, "Expire Test")
+		key, err := auth.GenerateAPIKey(ctx, user.ID, "Expire Test", nil)
 		require.NoError(t, err)
 
 		// Set expiration to past
@@ -95,9 +95,9 @@ func TestAPIKeyGeneration(t *testing.T) {
 
 	t.Run("lists user API keys", func(t *testing.T) {
 		// Create a few keys
-		_, err := auth.GenerateAPIKey(ctx, user.ID, "Key 1")
+		_, err := auth.GenerateAPIKey(ctx, user.ID, "Key 1", nil)
 		require.NoError(t, err)
-		_, err = auth.GenerateAPIKey(ctx, user.ID, "Key 2")
+		_, err = auth.GenerateAPIKey(ctx, user.ID, "Key 2", nil)
 		require.NoError(t, err)
 
 		keys, err := auth.ListAPIKeys(ctx, user.ID)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -187,6 +189,63 @@ func (a *AuthService) LoadFromDB(ctx context.Context) error {
 		return fmt.Errorf("iterate tenants: %w", err)
 	}
 
+	// Load API keys with scope data. Adds each key to apiKeys and keyIndex
+	// so that scoped VLT_ keys can authenticate S3 requests.
+	akRows, err := a.sqlDB.QueryContext(ctx, `
+		SELECT id, user_id, name, key_id, secret_hash,
+		       COALESCE(secret_key, ''),
+		       COALESCE(permissions, '["*"]'::jsonb),
+		       COALESCE(bucket_scope, '{}'),
+		       COALESCE(ip_allowlist, '{}'),
+		       expires_at, last_used, created_at
+		FROM api_keys
+	`)
+	if err != nil {
+		return fmt.Errorf("load api keys: %w", err)
+	}
+	defer func() { _ = akRows.Close() }()
+
+	for akRows.Next() {
+		var (
+			k           APIKey
+			permJSON    []byte
+			bucketScope pq.StringArray
+			ipAllowlist pq.StringArray
+			expiresAt   sql.NullTime
+			lastUsed    sql.NullTime
+		)
+		if err := akRows.Scan(&k.ID, &k.UserID, &k.Name, &k.Key, &k.Hash,
+			&k.Secret, &permJSON, &bucketScope, &ipAllowlist,
+			&expiresAt, &lastUsed, &k.CreatedAt); err != nil {
+			return fmt.Errorf("scan api key: %w", err)
+		}
+
+		if err := json.Unmarshal(permJSON, &k.Permissions); err != nil {
+			k.Permissions = []string{"*"}
+		}
+		k.BucketScope = []string(bucketScope)
+		k.IPAllowlist = []string(ipAllowlist)
+		if expiresAt.Valid {
+			k.ExpiresAt = &expiresAt.Time
+		}
+		if lastUsed.Valid {
+			k.LastUsed = &lastUsed.Time
+		}
+		k.Metadata = make(map[string]string)
+
+		if u, ok := a.userIndex[k.UserID]; ok {
+			k.TenantID = u.TenantID
+			if tenant, ok := a.tenants[u.TenantID]; ok {
+				a.keyIndex[k.Key] = tenant
+			}
+		}
+
+		a.apiKeys[k.Key] = &k
+	}
+	if err := akRows.Err(); err != nil {
+		return fmt.Errorf("iterate api keys: %w", err)
+	}
+
 	return nil
 }
 
@@ -257,7 +316,7 @@ func (a *AuthService) CreateUserWithTenant(ctx context.Context, email, password,
 	user.TenantID = tenant.ID
 
 	// Create primary API key
-	apiKey, err := a.GenerateAPIKey(ctx, user.ID, "primary")
+	apiKey, err := a.GenerateAPIKey(ctx, user.ID, "primary", nil)
 	if err != nil {
 		apiKey = &APIKey{
 			ID:        uuid.New().String(),

--- a/internal/auth/db.go
+++ b/internal/auth/db.go
@@ -65,9 +65,9 @@ func (a *DBAuthService) SaveAPIKey(ctx context.Context, apiKey *APIKey) error {
 	return nil
 }
 
-func (a *DBAuthService) GenerateAPIKey(ctx context.Context, userID, name string) (*APIKey, error) {
+func (a *DBAuthService) GenerateAPIKey(ctx context.Context, userID, name string, opts *KeyCreateOptions) (*APIKey, error) {
 	// Generate using parent method
-	apiKey, err := a.AuthService.GenerateAPIKey(ctx, userID, name)
+	apiKey, err := a.AuthService.GenerateAPIKey(ctx, userID, name, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"go.uber.org/zap"
 )
 
@@ -49,8 +49,10 @@ func NewAuth(db *sql.DB, logger *zap.Logger) *Auth {
 	}
 }
 
-// ValidateRequest validates an S3 request and returns the tenant ID
-func (a *Auth) ValidateRequest(r *http.Request) (string, error) {
+// ValidateRequest validates an S3 request and returns the tenant ID and key scope.
+func (a *Auth) ValidateRequest(r *http.Request) (string, *KeyScope, error) {
+	fullAccess := &KeyScope{Permissions: []string{"*"}}
+
 	// Check for test API key first (only in non-production)
 	apiKey := r.Header.Get("X-API-Key")
 	if apiKey == "test-key-chaos-testing" {
@@ -63,7 +65,7 @@ func (a *Auth) ValidateRequest(r *http.Request) (string, error) {
 			a.logger.Debug("test authentication accepted",
 				zap.String("tenant_id", tenantID),
 				zap.String("api_key", "test-key"))
-			return tenantID, nil
+			return tenantID, fullAccess, nil
 		}
 	}
 
@@ -77,9 +79,9 @@ func (a *Auth) ValidateRequest(r *http.Request) (string, error) {
 		}
 		// For testing without auth, allow but use test-tenant
 		if a.db == nil {
-			return "test-tenant", nil
+			return "test-tenant", fullAccess, nil
 		}
-		return "", fmt.Errorf("missing authorization")
+		return "", nil, fmt.Errorf("missing authorization")
 	}
 
 	// Parse AWS Signature v4 format (used by AWS CLI/SDKs)
@@ -87,7 +89,7 @@ func (a *Auth) ValidateRequest(r *http.Request) (string, error) {
 		accessKey, _, _, err := a.parseAuthHeader(authHeader)
 		if err != nil {
 			a.logger.Debug("failed to parse auth header", zap.Error(err))
-			return "", err
+			return "", nil, err
 		}
 		return a.validateAccessKey(accessKey)
 	}
@@ -100,34 +102,72 @@ func (a *Auth) ValidateRequest(r *http.Request) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("invalid authorization format")
+	return "", nil, fmt.Errorf("invalid authorization format")
 }
 
-// validateAccessKey looks up the tenant ID by access key
-func (a *Auth) validateAccessKey(accessKey string) (string, error) {
+// validateAccessKey looks up the tenant ID and key scope by access key.
+// Checks the tenants table first (primary keys, full access), then falls
+// back to api_keys for scoped VLT_ keys.
+func (a *Auth) validateAccessKey(accessKey string) (string, *KeyScope, error) {
 	if a.db == nil {
-		// Fallback for testing when DB is not available
 		a.logger.Warn("no database connection, using test-tenant")
-		return "test-tenant", nil
+		return "test-tenant", &KeyScope{Permissions: []string{"*"}}, nil
 	}
 
+	// Try primary tenant key first (full access).
 	var tenantID string
-	query := `SELECT id FROM tenants WHERE access_key = $1`
-	err := a.db.QueryRow(query, accessKey).Scan(&tenantID)
+	err := a.db.QueryRow(`SELECT id FROM tenants WHERE access_key = $1`, accessKey).Scan(&tenantID)
+	if err == nil {
+		a.logger.Debug("authenticated tenant (primary key)",
+			zap.String("tenant_id", tenantID),
+			zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."))
+		return tenantID, &KeyScope{Permissions: []string{"*"}}, nil
+	}
+	if err != sql.ErrNoRows {
+		a.logger.Error("database error during auth", zap.Error(err))
+		return "", nil, fmt.Errorf("auth lookup failed: %w", err)
+	}
+
+	// Try scoped API key (VLT_ prefix keys from api_keys table).
+	var permJSON []byte
+	var bucketScope, ipAllowlist pq.StringArray
+	var expiresAt sql.NullTime
+	err = a.db.QueryRow(`
+		SELECT t.id,
+		       COALESCE(ak.permissions, '["*"]'::jsonb),
+		       COALESCE(ak.bucket_scope, '{}'),
+		       COALESCE(ak.ip_allowlist, '{}'),
+		       ak.expires_at
+		FROM api_keys ak
+		JOIN users u ON u.id = ak.user_id
+		JOIN tenants t ON t.email = u.email
+		WHERE ak.key_id = $1
+	`, accessKey).Scan(&tenantID, &permJSON, &bucketScope, &ipAllowlist, &expiresAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			a.logger.Debug("invalid access key", zap.String("access_key", accessKey))
-			return "", fmt.Errorf("invalid access key")
+			return "", nil, fmt.Errorf("invalid access key")
 		}
-		a.logger.Error("database error during auth", zap.Error(err))
-		return "", fmt.Errorf("auth lookup failed: %w", err)
+		a.logger.Error("database error during scoped key auth", zap.Error(err))
+		return "", nil, fmt.Errorf("auth lookup failed: %w", err)
 	}
 
-	a.logger.Debug("authenticated tenant",
-		zap.String("tenant_id", tenantID),
-		zap.String("access_key", accessKey[:6]+"...")) // Log only first 6 chars for security
+	scope := &KeyScope{
+		BucketScope: []string(bucketScope),
+		IPAllowlist: []string(ipAllowlist),
+	}
+	if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
+		scope.Permissions = []string{"*"}
+	}
+	if expiresAt.Valid {
+		scope.ExpiresAt = &expiresAt.Time
+	}
 
-	return tenantID, nil
+	a.logger.Debug("authenticated tenant (scoped key)",
+		zap.String("tenant_id", tenantID),
+		zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."),
+		zap.Int("permissions", len(scope.Permissions)))
+	return tenantID, scope, nil
 }
 
 // parseAuthHeader parses AWS Signature v4 authorization header

--- a/internal/auth/scoped_keys.go
+++ b/internal/auth/scoped_keys.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// KeyScope carries the permission constraints for a single API key.
+// Returned alongside the tenant ID from auth lookups so that callers
+// can enforce scope without a second query.
+type KeyScope struct {
+	Permissions []string
+	BucketScope []string
+	IPAllowlist []string
+	ExpiresAt   *time.Time
+}
+
+// KeyCreateOptions specifies optional scope constraints when creating
+// a new API key. Nil means full access (["*"]).
+type KeyCreateOptions struct {
+	Permissions []string
+	BucketScope []string
+	IPAllowlist []string
+	ExpiresAt   *time.Time
+}
+
+// ValidPermissions is the set of operation names that may appear in
+// an API key's permissions list. These match the operation strings
+// produced by determineOperation in s3.go.
+var ValidPermissions = map[string]bool{
+	"*":                          true,
+	"GetObject":                  true,
+	"PutObject":                  true,
+	"DeleteObject":               true,
+	"HeadObject":                 true,
+	"ListObjects":                true,
+	"ListBuckets":                true,
+	"CreateBucket":               true,
+	"DeleteBucket":               true,
+	"HeadBucket":                 true,
+	"DeleteObjects":              true,
+	"InitiateMultipartUpload":    true,
+	"UploadPart":                 true,
+	"CompleteMultipartUpload":    true,
+	"AbortMultipartUpload":       true,
+	"ListMultipartUploads":       true,
+	"ListParts":                  true,
+	"GetBucketVersioning":        true,
+	"PutBucketVersioning":        true,
+	"GetBucketNotification":      true,
+	"PutBucketNotification":      true,
+	"GetObjectLockConfiguration": true,
+	"PutObjectLockConfiguration": true,
+	"PutObjectRetention":         true,
+	"GetObjectRetention":         true,
+	"PutObjectLegalHold":         true,
+	"GetObjectLegalHold":         true,
+	"PostObject":                 true,
+}
+
+// CheckPermission returns true if keyPerms authorizes the given operation.
+func CheckPermission(keyPerms []string, operation string) bool {
+	for _, p := range keyPerms {
+		if p == "*" || p == operation {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckBucketScope returns true if the bucket is allowed by the scope.
+// An empty scope list means unrestricted (all buckets allowed).
+func CheckBucketScope(scopes []string, bucket string) bool {
+	if len(scopes) == 0 {
+		return true
+	}
+	for _, s := range scopes {
+		if s == bucket {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckIPAllowlist returns true if clientIP is permitted.
+// An empty allowlist means unrestricted (all IPs allowed).
+func CheckIPAllowlist(allowlist []string, clientIP string) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	parsed := net.ParseIP(clientIP)
+	for _, entry := range allowlist {
+		if strings.Contains(entry, "/") {
+			_, cidr, err := net.ParseCIDR(entry)
+			if err != nil {
+				continue
+			}
+			if parsed != nil && cidr.Contains(parsed) {
+				return true
+			}
+		} else {
+			if entry == clientIP {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsKeyExpired returns true if the key has passed its expiration time.
+func IsKeyExpired(expiresAt *time.Time) bool {
+	if expiresAt == nil {
+		return false
+	}
+	return time.Now().After(*expiresAt)
+}
+
+// ValidatePermissions checks that every entry in perms is a known
+// operation name. Returns an error naming the first invalid entry.
+func ValidatePermissions(perms []string) error {
+	for _, p := range perms {
+		if !ValidPermissions[p] {
+			return fmt.Errorf("unknown permission: %q", p)
+		}
+	}
+	return nil
+}

--- a/internal/auth/scoped_keys_test.go
+++ b/internal/auth/scoped_keys_test.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckPermission_Wildcard(t *testing.T) {
+	assert.True(t, CheckPermission([]string{"*"}, "GetObject"))
+	assert.True(t, CheckPermission([]string{"*"}, "DeleteBucket"))
+	assert.True(t, CheckPermission([]string{"*"}, "PutObject"))
+}
+
+func TestCheckPermission_Specific(t *testing.T) {
+	perms := []string{"GetObject", "PutObject"}
+	assert.True(t, CheckPermission(perms, "GetObject"))
+	assert.True(t, CheckPermission(perms, "PutObject"))
+	assert.False(t, CheckPermission(perms, "DeleteObject"))
+	assert.False(t, CheckPermission(perms, "ListBuckets"))
+}
+
+func TestCheckPermission_Empty(t *testing.T) {
+	assert.False(t, CheckPermission([]string{}, "GetObject"))
+	assert.False(t, CheckPermission(nil, "PutObject"))
+}
+
+func TestCheckBucketScope_Unrestricted(t *testing.T) {
+	assert.True(t, CheckBucketScope([]string{}, "anything"))
+	assert.True(t, CheckBucketScope(nil, "any-bucket"))
+}
+
+func TestCheckBucketScope_Restricted(t *testing.T) {
+	scopes := []string{"uploads"}
+	assert.True(t, CheckBucketScope(scopes, "uploads"))
+	assert.False(t, CheckBucketScope(scopes, "private"))
+	assert.False(t, CheckBucketScope(scopes, "uploads2"))
+}
+
+func TestCheckIPAllowlist_Unrestricted(t *testing.T) {
+	assert.True(t, CheckIPAllowlist([]string{}, "1.2.3.4"))
+	assert.True(t, CheckIPAllowlist(nil, "10.0.0.1"))
+}
+
+func TestCheckIPAllowlist_CIDR(t *testing.T) {
+	allowlist := []string{"10.0.0.0/8"}
+	assert.True(t, CheckIPAllowlist(allowlist, "10.1.2.3"))
+	assert.True(t, CheckIPAllowlist(allowlist, "10.255.255.255"))
+	assert.False(t, CheckIPAllowlist(allowlist, "192.168.1.1"))
+	assert.False(t, CheckIPAllowlist(allowlist, "11.0.0.1"))
+}
+
+func TestCheckIPAllowlist_ExactIP(t *testing.T) {
+	allowlist := []string{"1.2.3.4"}
+	assert.True(t, CheckIPAllowlist(allowlist, "1.2.3.4"))
+	assert.False(t, CheckIPAllowlist(allowlist, "1.2.3.5"))
+	assert.False(t, CheckIPAllowlist(allowlist, "5.6.7.8"))
+}
+
+func TestCheckIPAllowlist_Mixed(t *testing.T) {
+	allowlist := []string{"10.0.0.0/8", "192.168.1.100", "172.16.0.0/12"}
+	assert.True(t, CheckIPAllowlist(allowlist, "10.50.0.1"))
+	assert.True(t, CheckIPAllowlist(allowlist, "192.168.1.100"))
+	assert.True(t, CheckIPAllowlist(allowlist, "172.20.0.5"))
+	assert.False(t, CheckIPAllowlist(allowlist, "192.168.1.101"))
+	assert.False(t, CheckIPAllowlist(allowlist, "8.8.8.8"))
+}
+
+func TestIsKeyExpired_Valid(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour)
+	assert.False(t, IsKeyExpired(&future))
+}
+
+func TestIsKeyExpired_Expired(t *testing.T) {
+	past := time.Now().Add(-1 * time.Hour)
+	assert.True(t, IsKeyExpired(&past))
+}
+
+func TestIsKeyExpired_Nil(t *testing.T) {
+	assert.False(t, IsKeyExpired(nil))
+}
+
+func TestValidatePermissions_Valid(t *testing.T) {
+	require.NoError(t, ValidatePermissions([]string{"*"}))
+	require.NoError(t, ValidatePermissions([]string{"GetObject", "PutObject"}))
+	require.NoError(t, ValidatePermissions([]string{"ListBuckets", "HeadObject", "DeleteObjects"}))
+}
+
+func TestValidatePermissions_Invalid(t *testing.T) {
+	err := ValidatePermissions([]string{"GetObject", "InvalidOp"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidOp")
+}
+
+func TestValidatePermissions_Empty(t *testing.T) {
+	require.NoError(t, ValidatePermissions([]string{}))
+	require.NoError(t, ValidatePermissions(nil))
+}

--- a/internal/dashboard/handlers/apikeys.go
+++ b/internal/dashboard/handlers/apikeys.go
@@ -15,13 +15,14 @@ import (
 
 // KeyRow is a single API key for the template.
 type KeyRow struct {
-	ID          string
-	Name        string
-	KeyID       string
-	Status      string
-	StatusClass string
-	CreatedFmt  string
-	LastUsedFmt string
+	ID           string
+	Name         string
+	KeyID        string
+	ScopeSummary string
+	Status       string
+	StatusClass  string
+	CreatedFmt   string
+	LastUsedFmt  string
 }
 
 // NewKeyData holds the just-generated key credentials (shown once).
@@ -70,7 +71,37 @@ func HandleGenerateKey(tmpl *template.Template, authSvc *auth.AuthService, logge
 			name = "default"
 		}
 
-		key, err := authSvc.GenerateAPIKey(r.Context(), sd.UserID, name)
+		var opts *auth.KeyCreateOptions
+		perms := r.Form["permissions"]
+		bucketScope := parseCSV(r.FormValue("bucket_scope"))
+		ipAllowlist := parseCSV(r.FormValue("ip_allowlist"))
+		expiresStr := r.FormValue("expires_at")
+
+		hasScope := len(perms) > 0 || len(bucketScope) > 0 || len(ipAllowlist) > 0 || expiresStr != ""
+		if hasScope {
+			opts = &auth.KeyCreateOptions{
+				Permissions: perms,
+				BucketScope: bucketScope,
+				IPAllowlist: ipAllowlist,
+			}
+			if expiresStr != "" {
+				if t, parseErr := time.Parse("2006-01-02", expiresStr); parseErr == nil {
+					eod := t.Add(24*time.Hour - time.Second)
+					opts.ExpiresAt = &eod
+				}
+			}
+			if len(opts.Permissions) > 0 {
+				if err := auth.ValidatePermissions(opts.Permissions); err != nil {
+					data["GenerateError"] = "Invalid permission: " + err.Error()
+					data["Keys"] = listKeys(r, authSvc, sd.UserID)
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_ = tmpl.ExecuteTemplate(w, "base", data)
+					return
+				}
+			}
+		}
+
+		key, err := authSvc.GenerateAPIKey(r.Context(), sd.UserID, name, opts)
 		if err != nil {
 			logger.Error("generate API key", zap.Error(err))
 			data["GenerateError"] = "Failed to generate key. Please try again."
@@ -145,14 +176,50 @@ func listKeys(r *http.Request, authSvc *auth.AuthService, userID string) []KeyRo
 		}
 
 		rows = append(rows, KeyRow{
-			ID:          k.ID,
-			Name:        k.Name,
-			KeyID:       k.Key,
-			Status:      status,
-			StatusClass: statusClass,
-			CreatedFmt:  relativeTime(k.CreatedAt),
-			LastUsedFmt: lastUsed,
+			ID:           k.ID,
+			Name:         k.Name,
+			KeyID:        k.Key,
+			ScopeSummary: scopeSummary(k),
+			Status:       status,
+			StatusClass:  statusClass,
+			CreatedFmt:   relativeTime(k.CreatedAt),
+			LastUsedFmt:  lastUsed,
 		})
 	}
 	return rows
+}
+
+func scopeSummary(k *auth.APIKey) string {
+	if len(k.Permissions) == 1 && k.Permissions[0] == "*" && len(k.BucketScope) == 0 && len(k.IPAllowlist) == 0 {
+		return "Full access"
+	}
+	var parts []string
+	if len(k.Permissions) > 0 && (len(k.Permissions) != 1 || k.Permissions[0] != "*") {
+		parts = append(parts, strings.Join(k.Permissions, ", "))
+	}
+	if len(k.BucketScope) > 0 {
+		parts = append(parts, "buckets: "+strings.Join(k.BucketScope, ", "))
+	}
+	if len(k.IPAllowlist) > 0 {
+		parts = append(parts, "IPs: "+strings.Join(k.IPAllowlist, ", "))
+	}
+	if len(parts) == 0 {
+		return "Full access"
+	}
+	return strings.Join(parts, " | ")
+}
+
+func parseCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var result []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
 }

--- a/internal/dashboard/handlers/apikeys_test.go
+++ b/internal/dashboard/handlers/apikeys_test.go
@@ -69,7 +69,7 @@ func TestHandleAPIKeys_ListWithKeys(t *testing.T) {
 	tmpl := testAPIKeysTemplate(t)
 	authSvc, sd := setupAuthWithUser(t)
 
-	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "test-key")
+	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "test-key", nil)
 	require.NoError(t, err)
 
 	handler := HandleAPIKeys(tmpl, authSvc, zap.NewNop())
@@ -143,7 +143,7 @@ func TestHandleGenerateKey_DefaultName(t *testing.T) {
 func TestHandleRevokeKey(t *testing.T) {
 	authSvc, sd := setupAuthWithUser(t)
 
-	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "revoke-me")
+	key, err := authSvc.GenerateAPIKey(context.Background(), sd.UserID, "revoke-me", nil)
 	require.NoError(t, err)
 
 	handler := HandleRevokeKey(authSvc, zap.NewNop())

--- a/internal/dashboard/templates/customer/apikeys.html
+++ b/internal/dashboard/templates/customer/apikeys.html
@@ -18,8 +18,60 @@
                 <label>Key Name</label>
                 <input type="text" name="name" required placeholder="e.g. rclone-backup, ci-deploy">
             </div>
-            <button type="submit" class="btn btn-primary">Generate</button>
         </div>
+
+        <div class="form-group">
+            <label>Permissions</label>
+            <div class="checkbox-grid">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="permissions" value="*" checked onchange="togglePermGroups(this)"> Full Access (*)
+                </label>
+            </div>
+            <div id="perm-groups" class="checkbox-grid" style="display:none; margin-top: 0.5rem;">
+                <div>
+                    <strong class="text-muted">Read</strong>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="GetObject"> GetObject</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="HeadObject"> HeadObject</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="HeadBucket"> HeadBucket</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="ListObjects"> ListObjects</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="ListBuckets"> ListBuckets</label>
+                </div>
+                <div>
+                    <strong class="text-muted">Write</strong>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="PutObject"> PutObject</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="DeleteObject"> DeleteObject</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="DeleteObjects"> DeleteObjects</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="CreateBucket"> CreateBucket</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="DeleteBucket"> DeleteBucket</label>
+                </div>
+                <div>
+                    <strong class="text-muted">Multipart</strong>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="InitiateMultipartUpload"> Initiate</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="UploadPart"> UploadPart</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="CompleteMultipartUpload"> Complete</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="AbortMultipartUpload"> Abort</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="ListMultipartUploads"> ListUploads</label>
+                    <label class="checkbox-label"><input type="checkbox" name="permissions" value="ListParts"> ListParts</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group form-group-inline">
+                <label>Bucket Scope <span class="text-muted">(optional)</span></label>
+                <input type="text" name="bucket_scope" placeholder="bucket1, bucket2 (empty = all buckets)">
+            </div>
+            <div class="form-group form-group-inline">
+                <label>IP Allowlist <span class="text-muted">(optional)</span></label>
+                <input type="text" name="ip_allowlist" placeholder="10.0.0.0/8, 1.2.3.4 (empty = all IPs)">
+            </div>
+            <div class="form-group form-group-inline">
+                <label>Expires <span class="text-muted">(optional)</span></label>
+                <input type="date" name="expires_at">
+            </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Generate</button>
     </form>
 </div>
 
@@ -57,6 +109,7 @@ aws s3 ls --endpoint-url https://stored.ge</div>
             <tr>
                 <th>Name</th>
                 <th>Access Key</th>
+                <th>Scope</th>
                 <th>Created</th>
                 <th>Last Used</th>
                 <th>Status</th>
@@ -68,6 +121,7 @@ aws s3 ls --endpoint-url https://stored.ge</div>
             <tr>
                 <td>{{.Name}}</td>
                 <td class="mono">{{.KeyID}}</td>
+                <td>{{.ScopeSummary}}</td>
                 <td>{{.CreatedFmt}}</td>
                 <td>{{.LastUsedFmt}}</td>
                 <td><span class="badge badge-{{.StatusClass}}">{{.Status}}</span></td>
@@ -94,4 +148,16 @@ aws s3 ls --endpoint-url https://stored.ge</div>
 <div class="dashboard-actions">
     <a href="/dashboard/" class="btn">Back to Dashboard</a>
 </div>
+
+<script>
+function togglePermGroups(fullAccessCheckbox) {
+    var groups = document.getElementById('perm-groups');
+    if (fullAccessCheckbox.checked) {
+        groups.style.display = 'none';
+        groups.querySelectorAll('input[type=checkbox]').forEach(function(cb) { cb.checked = false; });
+    } else {
+        groups.style.display = 'block';
+    }
+}
+</script>
 {{end}}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -22,12 +22,13 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 028 | Object Lock: `object_lock_enabled`, `default_retention_mode`, `default_retention_days` on `buckets`; `object_locks` table |
 | 029 | Idempotency cache: `idempotency_cache` table for management API request deduplication (24h TTL) |
 | 030 | Metadata: `metadata JSONB` column on `buckets` and `object_head_cache` |
+| 031 | Scoped API keys: `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at` (TIMESTAMPTZ), `secret_key` (TEXT) on `api_keys` |
 
 ## Key Tables
 
 - **users** — `id (UUID)`, `email`, `password_hash`, `company`, `status`, `role`, `stripe_customer_id`
 - **tenants** — `id`, `name`, `email`, `access_key`, `secret_key`, `slug`, `slug_locked`, `stripe_customer_id`, `stripe_subscription_id`, `subscription_status`, `plan`, `suspended_at`
-- **api_keys** — `id (UUID)`, `user_id → users`, `name`, `key_id`, `secret_hash`
+- **api_keys** — `id (UUID)`, `user_id → users`, `name`, `key_id`, `secret_hash`, `secret_key`, `permissions` (JSONB, default `["*"]`), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at`
 - **tenant_quotas** — `tenant_id (PK)`, `storage_limit_bytes`, `storage_used_bytes`, `tier`
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking

--- a/internal/database/migrations/031_scoped_keys.sql
+++ b/internal/database/migrations/031_scoped_keys.sql
@@ -1,0 +1,9 @@
+-- Phase 5.11.4: Scoped API Keys
+-- Adds permission scoping, bucket restrictions, IP allowlists, and expiration to API keys.
+-- Defaults preserve backward compatibility: existing keys get full ["*"] access.
+
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS permissions JSONB NOT NULL DEFAULT '["*"]';
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS bucket_scope TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS ip_allowlist TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS secret_key TEXT;


### PR DESCRIPTION
## Summary

- **Migration 031**: Adds `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at`, and `secret_key` columns to `api_keys`. Defaults preserve backward compatibility — existing keys get `["*"]` (full access).
- **Scope check functions** (`scoped_keys.go`): `CheckPermission`, `CheckBucketScope`, `CheckIPAllowlist`, `IsKeyExpired`, `ValidatePermissions` — all reusable for Phase 5.11.5 (STS).
- **S3 enforcement** (`handleS3Request`): After auth, checks key expiry → IP allowlist → operation permission → bucket scope. Each denial returns 403 with a helpful suggestion message. `extractClientIP` checks CF-Connecting-IP > X-Forwarded-For > RemoteAddr.
- **Presigned URL enforcement** (`verifyPresignedURL`): Extended to look up scoped VLT_ keys with their stored `secret_key` for signature verification. Returns and enforces scope.
- **Auth path extended**: `ValidateRequest` and `validateAccessKey` now return `(tenantID, *KeyScope, error)`. Queries `tenants` first (primary key, full access), falls back to `api_keys` JOIN for scoped keys.
- **LoadFromDB**: Loads `api_keys` table with scope columns on startup, populates both `apiKeys` and `keyIndex` maps so scoped keys authenticate S3 requests in-memory.
- **GenerateAPIKey**: Accepts `*KeyCreateOptions`, persists scope to DB, adds to `keyIndex`.
- **Management API**: `POST /api/v1/manage/keys` accepts `permissions`, `bucket_scope`, `ip_allowlist`, `expires_at` with validation. List and create responses include all scope fields.
- **Dashboard**: Permission checkboxes grouped by Read/Write/Multipart with Full Access toggle, bucket scope input, IP allowlist input, expiration date picker. Key list shows scope summary column.
- **14 unit tests** covering all check functions (wildcard/specific/empty permissions, restricted/unrestricted bucket scope, CIDR/exact IP allowlist, expired/valid/nil expiration, valid/invalid permission names).

## Test plan

- [ ] `make build` passes
- [ ] `make test-unit` passes (all 14 new scoped key tests + existing tests)
- [ ] `make lint` passes (0 issues)
- [ ] CI `build-and-test` passes
- [ ] Create scoped key via management API: `POST /api/v1/manage/keys` with `{"name": "readonly", "permissions": ["GetObject", "HeadObject", "ListObjects"]}`
- [ ] Use scoped key for allowed operation (GetObject → succeeds)
- [ ] Use scoped key for denied operation (PutObject → 403 with "does not have PutObject access")
- [ ] Create bucket-scoped key, verify cross-bucket access denied
- [ ] Create IP-restricted key, verify denied from wrong IP
- [ ] Create key with expiration, verify expired key returns 403
- [ ] Dashboard: generate scoped key with checkboxes, verify scope summary in key list
- [ ] Existing unscoped keys continue to work with full access (backward compatibility)