### PR TITLE
feat(auth): STS temporary credentials with scope intersection [Phase 5.11.5]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,15 +69,16 @@ The `engine.Driver` interface (in `internal/engine/interface.go`) is the sacred 
 
 ### Key Database Tables
 
-Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries `tenants` first (primary key, full access), then falls back to `api_keys` for scoped VLT_ keys.
+Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries `tenants` first (primary key, full access), then falls back to `api_keys` for scoped VLT_ keys, then `sts_tokens` for ASIA-prefixed temporary credentials.
 
-Other critical tables (31 migrations through `031_scoped_keys.sql`):
+Other critical tables (32 migrations through `032_sts_tokens.sql`):
 - `object_head_cache` — HEAD/GET metadata cache (~1ms), content-type, ETag, metadata JSONB
 - `buckets` — bucket registry with visibility, CORS, cache TTL, metadata JSONB, slug
 - `multipart_uploads`, `multipart_parts` — in-progress multipart state
 - `object_versions` — versioning support (version_id, is_latest, delete markers)
 - `object_locks` — Object Lock / WORM retention and legal holds
 - `idempotency_cache` — management API idempotency keys (24h TTL)
+- `sts_tokens` — STS temporary credentials (ASIA-prefixed, scope-intersected, hourly cleanup)
 - `stripe_events` — webhook event dedup
 - `dashboard_sessions` — PostgreSQL-backed sessions with IP/user-agent tracking
 - `oauth_accounts` — OAuth provider links (Google, GitHub)

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -17,6 +17,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3_list.go** — ListObjectsV2 handler
 - **s3_presign.go** — Pre-signed URL verification (SigV4 query string auth) and URL generation
 - **presigned.go** — Management API endpoint for generating pre-signed URLs (`/api/v1/presigned`)
+- **sts_routes.go** — STS temporary credential endpoint (`POST /api/v1/sts/token`)
 - **management.go** — JSON response helpers: `writeJSON`, `writeListResponse`, `getRequestID` (Stripe-style envelope)
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
@@ -74,11 +75,19 @@ Key files: `metadata.go` (extract/set/validate/merge helpers), `s3_engine_adapte
 
 **sqlmock note**: JSONB columns must use `[]byte` (not `string`) in `AddRow` to match real PostgreSQL driver behavior when scanning into `[]byte`/`json.RawMessage`.
 
+## STS Temporary Credentials (Phase 5.11.5)
+
+`POST /api/v1/sts/token` (JWT-protected) mints short-lived S3 credentials. Response: `{"object": "sts_token", "access_key": "ASIA...", "secret_key": "...", "expiration": "...", "request_id": "..."}`.
+
+Scope intersection: requested permissions/buckets are intersected with the parent key's scope (JWT user's first API key, or full access if none). STS tokens can never escalate beyond the parent. IP restrictions are narrowed (request can only restrict further, not broaden).
+
+S3 auth: both `validateAccessKey` (handlers.go) and `verifyPresignedURL` (s3_presign.go) have an ASIA-prefix fallback that queries `sts_tokens` after checking `tenants` and `api_keys`. Expired tokens are rejected. Cleanup: hourly goroutine in `auth.StartSTSCleanup`.
+
 ## Auth Flow
 
 1. `handleS3Request` checks `isPresignedRequest(r)` — if query has `X-Amz-Algorithm=AWS4-HMAC-SHA256`, routes to `verifyPresignedURL` (SigV4 query string auth)
 2. Otherwise calls `auth.ValidateRequest(r)` which parses the Authorization header
-3. Both paths return `(tenantID, *auth.KeyScope, error)` — scope carries permissions, bucket restrictions, IP allowlist, and expiration
+3. Both paths return `(tenantID, *auth.KeyScope, error)` — scope carries permissions, bucket restrictions, IP allowlist, and expiration. Auth lookup order: tenants (primary key) → api_keys (VLT_ scoped) → sts_tokens (ASIA temporary)
 4. On failure, returns appropriate S3 error (presigned errors: `ExpiredToken`, `AuthorizationQueryParametersError`, `SignatureDoesNotMatch`)
 5. On success, scope enforcement runs before operation routing:
    - `IsKeyExpired` → 403 `ExpiredToken`

--- a/internal/api/s3_presign.go
+++ b/internal/api/s3_presign.go
@@ -96,21 +96,45 @@ func (s *Server) verifyPresignedURL(r *http.Request) (string, *auth.KeyScope, er
 			JOIN tenants t ON t.email = u.email
 			WHERE ak.key_id = $1
 		`, accessKey).Scan(&secretKey, &tenantID, &permJSON, &bucketScope, &ipAllowlist, &expiresAtDB)
-		if err != nil {
+		if err == nil {
+			if secretKey == "" {
+				return "", nil, fmt.Errorf("%s", ErrAccessDenied)
+			}
+			scope = &auth.KeyScope{
+				BucketScope: []string(bucketScope),
+				IPAllowlist: []string(ipAllowlist),
+			}
+			if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
+				scope.Permissions = []string{"*"}
+			}
+			if expiresAtDB.Valid {
+				scope.ExpiresAt = &expiresAtDB.Time
+			}
+		} else if err == sql.ErrNoRows && len(accessKey) >= 4 && accessKey[:4] == "ASIA" {
+			// Try STS temporary credential.
+			var stsPermJSON []byte
+			var stsBucketScope, stsIPRestrict pq.StringArray
+			var stsExpiresAt time.Time
+			err = s.db.QueryRow(`
+				SELECT secret_key, tenant_id, permissions, bucket_scope, ip_restrict, expires_at
+				FROM sts_tokens WHERE access_key = $1
+			`, accessKey).Scan(&secretKey, &tenantID, &stsPermJSON, &stsBucketScope, &stsIPRestrict, &stsExpiresAt)
+			if err != nil {
+				return "", nil, fmt.Errorf("%s", ErrAccessDenied)
+			}
+			if time.Now().After(stsExpiresAt) {
+				return "", nil, fmt.Errorf("%s", ErrExpiredPresignedRequest)
+			}
+			scope = &auth.KeyScope{
+				BucketScope: []string(stsBucketScope),
+				IPAllowlist: []string(stsIPRestrict),
+				ExpiresAt:   &stsExpiresAt,
+			}
+			if jsonErr := json.Unmarshal(stsPermJSON, &scope.Permissions); jsonErr != nil {
+				scope.Permissions = []string{"*"}
+			}
+		} else {
 			return "", nil, fmt.Errorf("%s", ErrAccessDenied)
-		}
-		if secretKey == "" {
-			return "", nil, fmt.Errorf("%s", ErrAccessDenied)
-		}
-		scope = &auth.KeyScope{
-			BucketScope: []string(bucketScope),
-			IPAllowlist: []string(ipAllowlist),
-		}
-		if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
-			scope.Permissions = []string{"*"}
-		}
-		if expiresAtDB.Valid {
-			scope.ExpiresAt = &expiresAtDB.Time
 		}
 	} else if err != nil {
 		return "", nil, fmt.Errorf("%s", ErrAccessDenied)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -426,6 +426,9 @@ func (s *Server) setupRoutes() {
 	s.logger.Info("Registering management API routes")
 	s.registerManagementRoutes()
 
+	s.logger.Info("Registering STS routes")
+	s.registerSTSRoutes()
+
 	s.router.Get("/llms.txt", s.handleLlmsTxt)
 
 	s.logger.Info("Registering S3 catch-all handler")
@@ -801,6 +804,11 @@ func (s *Server) Start() error {
 	if s.db != nil {
 		im := newIdempotencyMiddleware(s.db, s.logger)
 		im.StartCleanup(ctx)
+	}
+
+	// Clean up expired STS tokens hourly.
+	if s.db != nil {
+		auth.StartSTSCleanup(ctx, s.db, s.logger)
 	}
 
 	s.logger.Info("Starting server with RBAC and API Key Management",

--- a/internal/api/sts_routes.go
+++ b/internal/api/sts_routes.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+func (s *Server) registerSTSRoutes() {
+	s.router.Route("/api/v1/sts", func(r chi.Router) {
+		r.Use(s.requireJWT)
+		r.Post("/token", s.handleSTSCreateToken)
+	})
+}
+
+func (s *Server) handleSTSCreateToken(w http.ResponseWriter, r *http.Request) {
+	userID, _ := r.Context().Value(userIDKey).(string)
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if userID == "" || tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_user", "user not found in token", "")
+		return
+	}
+
+	var req auth.STSRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if len(req.Permissions) > 0 {
+		if err := auth.ValidatePermissions(req.Permissions); err != nil {
+			writeManagementError(w, ErrTypeInvalidRequest, "invalid_permissions", err.Error(), "permissions")
+			return
+		}
+	}
+
+	parentKeyID := "tenant:" + tenantID
+	parentScope := &auth.KeyScope{Permissions: []string{"*"}}
+
+	keys, err := s.auth.ListAPIKeys(r.Context(), userID)
+	if err == nil && len(keys) > 0 {
+		parentKeyID = keys[0].Key
+		parentScope = &auth.KeyScope{
+			Permissions: keys[0].Permissions,
+			BucketScope: keys[0].BucketScope,
+			IPAllowlist: keys[0].IPAllowlist,
+			ExpiresAt:   keys[0].ExpiresAt,
+		}
+	}
+
+	token, err := auth.GenerateSTSToken(r.Context(), s.db, tenantID, parentKeyID, parentScope, req)
+	if err != nil {
+		s.logger.Error("sts create token", zap.Error(err))
+		writeManagementError(w, ErrTypeInvalidRequest, "scope_error", err.Error(), "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "sts_token",
+		"access_key": token.AccessKey,
+		"secret_key": token.SecretKey,
+		"expiration": token.ExpiresAt.Format(time.RFC3339),
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -82,6 +82,16 @@ Password reset rate limiting is in-memory (per-email, 3/hour, sliding window). T
 
 Both backfill functions run on every startup (called from `server.go`), are idempotent, and log counts.
 
+## STS Temporary Credentials (Phase 5.11.5)
+
+`sts.go` — AWS STS-compatible short-lived S3 credentials with scope intersection:
+- `STSToken` — access key (ASIA prefix), secret, tenant, parent key ID, scoped permissions/buckets/IPs, expiry
+- `STSRequest` — requested permissions, bucket scope, IP restrictions, TTL (1–43200s, default 3600)
+- `GenerateSTSToken(ctx, db, tenantID, parentKeyID, parentScope, req)` — mints token with scope intersection (permissions = intersection with parent, buckets = intersection, IP = narrowed). Persists to `sts_tokens` table. Secret stored in plaintext (required for SigV4 verification).
+- `StartSTSCleanup(ctx, db, logger)` — hourly goroutine deletes expired tokens
+
+S3 auth integration: `validateAccessKey` (handlers.go) falls back to `sts_tokens` table for ASIA-prefixed keys after checking `tenants` and `api_keys`. `verifyPresignedURL` (s3_presign.go) does the same for pre-signed URL verification. Expired tokens are rejected at auth time.
+
 ## Testing
 
 - Unit tests: `go test ./internal/auth/... -short` (no DB needed)

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -143,31 +143,64 @@ func (a *Auth) validateAccessKey(accessKey string) (string, *KeyScope, error) {
 		JOIN tenants t ON t.email = u.email
 		WHERE ak.key_id = $1
 	`, accessKey).Scan(&tenantID, &permJSON, &bucketScope, &ipAllowlist, &expiresAt)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			a.logger.Debug("invalid access key", zap.String("access_key", accessKey))
-			return "", nil, fmt.Errorf("invalid access key")
+	if err == nil {
+		scope := &KeyScope{
+			BucketScope: []string(bucketScope),
+			IPAllowlist: []string(ipAllowlist),
 		}
+		if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
+			scope.Permissions = []string{"*"}
+		}
+		if expiresAt.Valid {
+			scope.ExpiresAt = &expiresAt.Time
+		}
+
+		a.logger.Debug("authenticated tenant (scoped key)",
+			zap.String("tenant_id", tenantID),
+			zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."),
+			zap.Int("permissions", len(scope.Permissions)))
+		return tenantID, scope, nil
+	}
+	if err != sql.ErrNoRows {
 		a.logger.Error("database error during scoped key auth", zap.Error(err))
 		return "", nil, fmt.Errorf("auth lookup failed: %w", err)
 	}
 
-	scope := &KeyScope{
-		BucketScope: []string(bucketScope),
-		IPAllowlist: []string(ipAllowlist),
-	}
-	if jsonErr := json.Unmarshal(permJSON, &scope.Permissions); jsonErr != nil {
-		scope.Permissions = []string{"*"}
-	}
-	if expiresAt.Valid {
-		scope.ExpiresAt = &expiresAt.Time
+	// Try STS temporary credential (ASIA prefix keys).
+	if len(accessKey) >= 4 && accessKey[:4] == "ASIA" {
+		var stsPermJSON []byte
+		var stsBucketScope, stsIPRestrict pq.StringArray
+		var stsExpiresAt time.Time
+		err = a.db.QueryRow(`
+			SELECT tenant_id, permissions, bucket_scope, ip_restrict, expires_at
+			FROM sts_tokens WHERE access_key = $1
+		`, accessKey).Scan(&tenantID, &stsPermJSON, &stsBucketScope, &stsIPRestrict, &stsExpiresAt)
+		if err == nil {
+			if time.Now().After(stsExpiresAt) {
+				a.logger.Debug("expired STS token", zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."))
+				return "", nil, fmt.Errorf("expired STS token")
+			}
+			scope := &KeyScope{
+				BucketScope: []string(stsBucketScope),
+				IPAllowlist: []string(stsIPRestrict),
+				ExpiresAt:   &stsExpiresAt,
+			}
+			if jsonErr := json.Unmarshal(stsPermJSON, &scope.Permissions); jsonErr != nil {
+				scope.Permissions = []string{"*"}
+			}
+			a.logger.Debug("authenticated tenant (STS token)",
+				zap.String("tenant_id", tenantID),
+				zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."))
+			return tenantID, scope, nil
+		}
+		if err != sql.ErrNoRows {
+			a.logger.Error("database error during STS auth", zap.Error(err))
+			return "", nil, fmt.Errorf("auth lookup failed: %w", err)
+		}
 	}
 
-	a.logger.Debug("authenticated tenant (scoped key)",
-		zap.String("tenant_id", tenantID),
-		zap.String("access_key", accessKey[:min(6, len(accessKey))]+"..."),
-		zap.Int("permissions", len(scope.Permissions)))
-	return tenantID, scope, nil
+	a.logger.Debug("invalid access key", zap.String("access_key", accessKey))
+	return "", nil, fmt.Errorf("invalid access key")
 }
 
 // parseAuthHeader parses AWS Signature v4 authorization header

--- a/internal/auth/sts.go
+++ b/internal/auth/sts.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"go.uber.org/zap"
+)
+
+type STSToken struct {
+	AccessKey   string    `json:"access_key"`
+	SecretKey   string    `json:"secret_key"`
+	TenantID    string    `json:"tenant_id"`
+	ParentKeyID string    `json:"parent_key_id"`
+	Permissions []string  `json:"permissions"`
+	BucketScope []string  `json:"bucket_scope"`
+	IPRestrict  []string  `json:"ip_restrict"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type STSRequest struct {
+	Permissions []string `json:"permissions"`
+	BucketScope []string `json:"bucket_scope"`
+	IPRestrict  []string `json:"ip_restrict"`
+	TTL         int      `json:"ttl"`
+}
+
+const (
+	stsDefaultTTL = 3600
+	stsMaxTTL     = 43200
+	stsMinTTL     = 1
+)
+
+func GenerateSTSToken(ctx context.Context, db *sql.DB, tenantID, parentKeyID string, parentScope *KeyScope, req STSRequest) (*STSToken, error) {
+	perms := intersectPermissions(parentScope.Permissions, req.Permissions)
+	if len(perms) == 0 {
+		return nil, fmt.Errorf("no permissions overlap between parent key and request")
+	}
+
+	if err := ValidatePermissions(perms); err != nil {
+		return nil, fmt.Errorf("validate permissions: %w", err)
+	}
+
+	buckets := intersectBucketScope(parentScope.BucketScope, req.BucketScope)
+
+	ipRestrict := narrowIPRestrict(parentScope.IPAllowlist, req.IPRestrict)
+
+	ttl := req.TTL
+	if ttl <= 0 {
+		ttl = stsDefaultTTL
+	}
+	if ttl > stsMaxTTL {
+		ttl = stsMaxTTL
+	}
+
+	accessKey, err := generateSTSAccessKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate STS access key: %w", err)
+	}
+
+	secretKey, err := generateSTSSecretKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate STS secret key: %w", err)
+	}
+
+	now := time.Now()
+	token := &STSToken{
+		AccessKey:   accessKey,
+		SecretKey:   secretKey,
+		TenantID:    tenantID,
+		ParentKeyID: parentKeyID,
+		Permissions: perms,
+		BucketScope: buckets,
+		IPRestrict:  ipRestrict,
+		ExpiresAt:   now.Add(time.Duration(ttl) * time.Second),
+		CreatedAt:   now,
+	}
+
+	if db != nil {
+		permJSON, _ := json.Marshal(token.Permissions)
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO sts_tokens (access_key, secret_key, tenant_id, parent_key_id,
+			                        permissions, bucket_scope, ip_restrict, expires_at, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`, token.AccessKey, token.SecretKey, token.TenantID, token.ParentKeyID,
+			permJSON, pq.Array(token.BucketScope), pq.Array(token.IPRestrict),
+			token.ExpiresAt, token.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("persist STS token: %w", err)
+		}
+	}
+
+	return token, nil
+}
+
+func StartSTSCleanup(ctx context.Context, db *sql.DB, logger *zap.Logger) {
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				result, err := db.ExecContext(ctx, `DELETE FROM sts_tokens WHERE expires_at < NOW()`)
+				if err != nil {
+					logger.Error("sts token cleanup", zap.Error(err))
+				} else if n, _ := result.RowsAffected(); n > 0 {
+					logger.Info("cleaned expired STS tokens", zap.Int64("count", n))
+				}
+			}
+		}
+	}()
+}
+
+func generateSTSAccessKey() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "ASIA" + hex.EncodeToString(b), nil
+}
+
+func generateSTSSecretKey() (string, error) {
+	b := make([]byte, 20)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	secret := hex.EncodeToString(b)
+	return secret, nil
+}
+
+func intersectPermissions(parent, requested []string) []string {
+	if len(requested) == 0 {
+		return parent
+	}
+
+	for _, p := range parent {
+		if p == "*" {
+			return requested
+		}
+	}
+
+	parentSet := make(map[string]bool, len(parent))
+	for _, p := range parent {
+		parentSet[p] = true
+	}
+
+	var result []string
+	for _, p := range requested {
+		if parentSet[p] {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func intersectBucketScope(parent, requested []string) []string {
+	if len(parent) == 0 && len(requested) == 0 {
+		return nil
+	}
+	if len(parent) == 0 {
+		return requested
+	}
+	if len(requested) == 0 {
+		return parent
+	}
+
+	parentSet := make(map[string]bool, len(parent))
+	for _, b := range parent {
+		parentSet[b] = true
+	}
+
+	var result []string
+	for _, b := range requested {
+		if parentSet[b] {
+			result = append(result, b)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func narrowIPRestrict(parentAllowlist, requested []string) []string {
+	if len(parentAllowlist) == 0 {
+		return requested
+	}
+	if len(requested) == 0 {
+		return parentAllowlist
+	}
+	return requested
+}

--- a/internal/auth/sts_test.go
+++ b/internal/auth/sts_test.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSTSToken(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{Permissions: []string{"*"}}
+
+	token, err := GenerateSTSToken(ctx, nil, "tenant-1", "parent-key-1", parentScope, STSRequest{
+		Permissions: []string{"GetObject", "PutObject"},
+		TTL:         600,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, len(token.AccessKey) >= 20)
+	assert.Equal(t, "ASIA", token.AccessKey[:4])
+	assert.Len(t, token.SecretKey, 40)
+	assert.Equal(t, "tenant-1", token.TenantID)
+	assert.Equal(t, "parent-key-1", token.ParentKeyID)
+	assert.Equal(t, []string{"GetObject", "PutObject"}, token.Permissions)
+	assert.WithinDuration(t, time.Now().Add(600*time.Second), token.ExpiresAt, 5*time.Second)
+}
+
+func TestSTSToken_ScopeIntersection(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{
+		Permissions: []string{"GetObject", "PutObject"},
+	}
+
+	token, err := GenerateSTSToken(ctx, nil, "tenant-1", "parent-key-1", parentScope, STSRequest{
+		Permissions: []string{"PutObject", "DeleteObject"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"PutObject"}, token.Permissions)
+}
+
+func TestSTSToken_EmptyIntersection(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{
+		Permissions: []string{"GetObject"},
+	}
+
+	_, err := GenerateSTSToken(ctx, nil, "tenant-1", "parent-key-1", parentScope, STSRequest{
+		Permissions: []string{"DeleteObject"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no permissions overlap")
+}
+
+func TestSTSToken_TTLClamping(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{Permissions: []string{"*"}}
+
+	t.Run("zero defaults to 3600", func(t *testing.T) {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			TTL:         0,
+		})
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(3600*time.Second), token.ExpiresAt, 5*time.Second)
+	})
+
+	t.Run("over max clamped to 43200", func(t *testing.T) {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			TTL:         99999,
+		})
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(43200*time.Second), token.ExpiresAt, 5*time.Second)
+	})
+
+	t.Run("negative defaults to 3600", func(t *testing.T) {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			TTL:         -100,
+		})
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(3600*time.Second), token.ExpiresAt, 5*time.Second)
+	})
+}
+
+func TestSTSToken_BucketScopeIntersection(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("parent restricted, request restricted — intersection", func(t *testing.T) {
+		parentScope := &KeyScope{
+			Permissions: []string{"*"},
+			BucketScope: []string{"alpha", "bravo"},
+		}
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			BucketScope: []string{"bravo", "charlie"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"bravo"}, token.BucketScope)
+	})
+
+	t.Run("parent unrestricted, request restricted — request wins", func(t *testing.T) {
+		parentScope := &KeyScope{
+			Permissions: []string{"*"},
+		}
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			BucketScope: []string{"uploads"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"uploads"}, token.BucketScope)
+	})
+
+	t.Run("parent restricted, request empty — parent wins", func(t *testing.T) {
+		parentScope := &KeyScope{
+			Permissions: []string{"*"},
+			BucketScope: []string{"data"},
+		}
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"data"}, token.BucketScope)
+	})
+}
+
+func TestSTSToken_IPRestrict(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{
+		Permissions: []string{"*"},
+		IPAllowlist: []string{"10.0.0.0/8"},
+	}
+
+	t.Run("request narrows parent", func(t *testing.T) {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+			IPRestrict:  []string{"10.1.0.0/16"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"10.1.0.0/16"}, token.IPRestrict)
+	})
+
+	t.Run("no request IP — inherits parent", func(t *testing.T) {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"10.0.0.0/8"}, token.IPRestrict)
+	})
+}
+
+func TestSTSToken_WildcardParent_NoRequestPerms(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{Permissions: []string{"*"}}
+
+	token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*"}, token.Permissions)
+}
+
+func TestSTSToken_AccessKeyFormat(t *testing.T) {
+	ctx := context.Background()
+	parentScope := &KeyScope{Permissions: []string{"*"}}
+
+	for i := 0; i < 10; i++ {
+		token, err := GenerateSTSToken(ctx, nil, "t", "k", parentScope, STSRequest{
+			Permissions: []string{"GetObject"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ASIA", token.AccessKey[:4])
+		assert.Len(t, token.AccessKey, 20)
+	}
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -23,6 +23,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 029 | Idempotency cache: `idempotency_cache` table for management API request deduplication (24h TTL) |
 | 030 | Metadata: `metadata JSONB` column on `buckets` and `object_head_cache` |
 | 031 | Scoped API keys: `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at` (TIMESTAMPTZ), `secret_key` (TEXT) on `api_keys` |
+| 032 | STS temporary credentials: `sts_tokens` table (access_key PK, secret_key, tenant_id, parent_key_id, permissions JSONB, bucket_scope TEXT[], ip_restrict TEXT[], expires_at, created_at) |
 
 ## Key Tables
 
@@ -41,6 +42,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **bucket_notifications** — `id (PK)`, `tenant_id`, `bucket`, `event_filter`, `target_type`, `target_url`, `enabled`, `created_at`
 - **object_locks** — `(tenant_id, bucket, object_key) PK`, `retention_mode`, `retain_until_date`, `legal_hold`, `created_at`, `updated_at`
 - **idempotency_cache** — `(tenant_id, idempotency_key) PK`, `method`, `path`, `response_status`, `response_headers` (JSONB), `response_body` (BYTEA), `created_at` — 24h TTL, hourly cleanup
+- **sts_tokens** — `access_key (PK)`, `secret_key`, `tenant_id`, `parent_key_id`, `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_restrict` (TEXT[]), `expires_at`, `created_at` — short-lived S3 creds, hourly cleanup
 
 ## Connection
 

--- a/internal/database/migrations/032_sts_tokens.sql
+++ b/internal/database/migrations/032_sts_tokens.sql
@@ -1,0 +1,18 @@
+-- Phase 5.11.5: STS Temporary Credentials
+-- Short-lived S3 credentials with scoped-down permissions.
+-- Secret stored in plaintext (required for SigV4 signature verification).
+
+CREATE TABLE IF NOT EXISTS sts_tokens (
+    access_key  VARCHAR(64)   PRIMARY KEY,
+    secret_key  TEXT          NOT NULL,
+    tenant_id   TEXT          NOT NULL,
+    parent_key_id TEXT        NOT NULL,
+    permissions JSONB         NOT NULL DEFAULT '["*"]',
+    bucket_scope TEXT[]       NOT NULL DEFAULT '{}',
+    ip_restrict  TEXT[]       NOT NULL DEFAULT '{}',
+    expires_at  TIMESTAMPTZ   NOT NULL,
+    created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sts_tokens_expires ON sts_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_sts_tokens_tenant ON sts_tokens(tenant_id);


### PR DESCRIPTION
## Summary

- **STS token endpoint** (`POST /api/v1/sts/token`) — JWT-protected management API endpoint that mints short-lived S3 credentials with ASIA-prefixed access keys
- **Scope intersection** — requested permissions, bucket scope, and IP restrictions are intersected with the parent key's scope, ensuring STS tokens can never escalate beyond the issuing key
- **S3 auth integration** — ASIA-prefixed keys are recognized in both `validateAccessKey` (Authorization header) and `verifyPresignedURL` (pre-signed URL) auth paths, with expiration enforcement
- **Cleanup goroutine** — hourly deletion of expired STS tokens from the database, following the same pattern as idempotency cache cleanup
- **Migration 032** — `sts_tokens` table with indexes on `expires_at` and `tenant_id`

## New files

| File | Purpose |
|------|---------|
| `internal/database/migrations/032_sts_tokens.sql` | STS tokens table |
| `internal/auth/sts.go` | STS token generation, scope intersection logic, cleanup |
| `internal/auth/sts_test.go` | 8 test cases covering generation, scope intersection, TTL clamping, bucket scope, IP narrowing |
| `internal/api/sts_routes.go` | `POST /api/v1/sts/token` endpoint |

## Modified files

| File | Change |
|------|--------|
| `internal/auth/handlers.go` | ASIA-prefix fallback in `validateAccessKey` after api_keys lookup |
| `internal/api/s3_presign.go` | ASIA-prefix fallback in `verifyPresignedURL` after api_keys lookup |
| `internal/api/server.go` | STS route registration + cleanup goroutine startup |
| `CLAUDE.md`, `internal/*/CLAUDE.md` | Per-directory docs updated |

## Test plan

- [x] `TestGenerateSTSToken` — creates token, verifies ASIA prefix, secret length, expiry
- [x] `TestSTSToken_ScopeIntersection` — parent [Get,Put] × request [Put,Delete] = [Put]
- [x] `TestSTSToken_EmptyIntersection` — returns error when no permissions overlap
- [x] `TestSTSToken_TTLClamping` — 0→3600, >43200→43200, negative→3600
- [x] `TestSTSToken_BucketScopeIntersection` — parent [a,b] × request [b,c] = [b]
- [x] `TestSTSToken_IPRestrict` — narrowing and inheritance
- [x] `TestSTSToken_WildcardParent_NoRequestPerms` — inherits wildcard
- [x] `TestSTSToken_AccessKeyFormat` — 10 iterations verify ASIA prefix + 20-char length
- [x] All pre-commit hooks pass (go fmt, go test, golangci-lint)