### PR TITLE
feat(api): event log and webhook management API [Phase 5.11.6]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -24,6 +24,8 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **management_ratelimit.go** — Per-tenant rate limiter middleware (100 req/min, token bucket, X-RateLimit-* headers)
 - **idempotency.go** — `Idempotency-Key` header middleware for management API (24h cache, replay with `Idempotency-Replayed: true`)
 - **metadata.go** — S3 user metadata extraction/validation, Stripe-style merge for management API PATCH
+- **events.go** — Event emitter (`emitEvent`), webhook dispatch, HMAC signing, `GET /api/v1/events` list endpoint
+- **webhooks_routes.go** — Webhook CRUD API (`/api/v1/webhooks`): create, list, update, delete, delivery history, test fire
 - **llms_txt.go** — Static `/llms.txt` endpoint (plain-text API summary for LLMs)
 
 ## Error Response Pattern
@@ -82,6 +84,25 @@ Key files: `metadata.go` (extract/set/validate/merge helpers), `s3_engine_adapte
 Scope intersection: requested permissions/buckets are intersected with the parent key's scope (JWT user's first API key, or full access if none). STS tokens can never escalate beyond the parent. IP restrictions are narrowed (request can only restrict further, not broaden).
 
 S3 auth: both `validateAccessKey` (handlers.go) and `verifyPresignedURL` (s3_presign.go) have an ASIA-prefix fallback that queries `sts_tokens` after checking `tenants` and `api_keys`. Expired tokens are rejected. Cleanup: hourly goroutine in `auth.StartSTSCleanup`.
+
+## Event Log + Webhook Management API (Phase 5.11.6)
+
+Persistent event log + webhook CRUD API for SaaS developer integrations. Three new tables: `events`, `webhook_endpoints`, `webhook_deliveries` (migration 033).
+
+**Event types**: `object.created`, `object.deleted`, `object.downloaded`, `bucket.created`, `bucket.deleted`, `key.created`, `key.revoked`, `sts.token_created`, `webhook.test`.
+
+**`emitEvent(ctx, db, logger, eventType, tenantID, data)`** — inserts event row synchronously, dispatches webhooks asynchronously in a goroutine. Nil-safe on db. Wired into S3 handlers (PUT/GET/DELETE), bucket create/delete, key create/revoke, and STS token creation.
+
+**Webhook dispatch**: queries `webhook_endpoints` for tenant, filters by `event_filter` (exact match, `object.*` wildcards, `*` catch-all). Delivers via HTTP POST with `X-Webhook-Signature: sha256=<hmac-hex>` header. Records delivery in `webhook_deliveries` (status, response_code, latency_ms). No retry loop in this phase — `next_retry_at` column reserved for future use.
+
+**Endpoints** (JWT-protected, rate-limited):
+- `GET /api/v1/events` — cursor pagination (created_at), type filter, tenant-scoped
+- `POST /api/v1/webhooks` — create (returns `whsec_` secret, only time it's exposed)
+- `GET /api/v1/webhooks` — list (secret omitted)
+- `PATCH /api/v1/webhooks/{id}` — partial update (url, events, enabled)
+- `DELETE /api/v1/webhooks/{id}` — cascade deletes deliveries
+- `GET /api/v1/webhooks/{id}/deliveries` — delivery history with cursor pagination
+- `POST /api/v1/webhooks/{id}/test` — fires synthetic `webhook.test` event
 
 ## Auth Flow
 

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,0 +1,333 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"go.uber.org/zap"
+)
+
+var validEventTypes = []string{
+	"object.created",
+	"object.deleted",
+	"object.downloaded",
+	"bucket.created",
+	"bucket.deleted",
+	"key.created",
+	"key.revoked",
+	"sts.token_created",
+	"webhook.test",
+}
+
+func isValidEventType(t string) bool {
+	for _, v := range validEventTypes {
+		if t == v {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesWebhookFilter(filter []string, eventType string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, f := range filter {
+		if f == "*" || f == eventType {
+			return true
+		}
+		if strings.HasSuffix(f, ".*") {
+			prefix := strings.TrimSuffix(f, ".*")
+			if strings.HasPrefix(eventType, prefix+".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func emitEvent(ctx context.Context, db *sql.DB, logger *zap.Logger, eventType, tenantID string, data map[string]interface{}) {
+	if db == nil {
+		return
+	}
+
+	eventID := uuid.New().String()
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		logger.Error("marshal event data", zap.Error(err))
+		return
+	}
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO events (id, type, tenant_id, data)
+		VALUES ($1, $2, $3, $4)`,
+		eventID, eventType, tenantID, dataJSON)
+	if err != nil {
+		logger.Error("insert event",
+			zap.Error(err),
+			zap.String("type", eventType),
+			zap.String("tenant_id", tenantID))
+		return
+	}
+
+	go dispatchWebhooks(db, logger, eventID, eventType, tenantID, dataJSON)
+}
+
+func dispatchWebhooks(db *sql.DB, logger *zap.Logger, eventID, eventType, tenantID string, payload []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, url, event_filter, secret
+		FROM webhook_endpoints
+		WHERE tenant_id = $1 AND enabled = TRUE`,
+		tenantID)
+	if err != nil {
+		logger.Error("query webhook endpoints for dispatch",
+			zap.Error(err),
+			zap.String("tenant_id", tenantID))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type endpoint struct {
+		id     string
+		url    string
+		filter []string
+		secret string
+	}
+	var endpoints []endpoint
+	for rows.Next() {
+		var ep endpoint
+		if err := rows.Scan(&ep.id, &ep.url, pq.Array(&ep.filter), &ep.secret); err != nil {
+			logger.Error("scan webhook endpoint", zap.Error(err))
+			continue
+		}
+		endpoints = append(endpoints, ep)
+	}
+
+	eventPayload := map[string]interface{}{
+		"id":         eventID,
+		"type":       eventType,
+		"tenant_id":  tenantID,
+		"data":       json.RawMessage(payload),
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	body, err := json.Marshal(eventPayload)
+	if err != nil {
+		logger.Error("marshal webhook payload", zap.Error(err))
+		return
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	for _, ep := range endpoints {
+		if !matchesWebhookFilter(ep.filter, eventType) {
+			continue
+		}
+		deliverWebhook(ctx, db, logger, client, ep.id, ep.url, ep.secret, eventID, body)
+	}
+}
+
+func deliverWebhook(ctx context.Context, db *sql.DB, logger *zap.Logger, client *http.Client, webhookID, url, secret, eventID string, body []byte) {
+	deliveryID := uuid.New().String()
+	start := time.Now()
+
+	sig := generateWebhookSignature(body, secret)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		logger.Error("create webhook request", zap.Error(err), zap.String("url", url))
+		recordDelivery(ctx, db, logger, deliveryID, webhookID, eventID, "failed", 0, err.Error(), 0)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Vaultaire-Webhooks/1.0")
+	req.Header.Set("X-Webhook-Signature", sig)
+	req.Header.Set("X-Event-ID", eventID)
+
+	resp, err := client.Do(req)
+	latencyMs := int(time.Since(start).Milliseconds())
+	if err != nil {
+		logger.Warn("webhook delivery failed",
+			zap.Error(err),
+			zap.String("webhook_id", webhookID),
+			zap.String("url", url))
+		recordDelivery(ctx, db, logger, deliveryID, webhookID, eventID, "failed", 0, err.Error(), latencyMs)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var respBody strings.Builder
+	respBody.Grow(1024)
+	buf := make([]byte, 1024)
+	n, _ := resp.Body.Read(buf)
+	respBody.Write(buf[:n])
+
+	status := "delivered"
+	if resp.StatusCode >= 400 {
+		status = "failed"
+	}
+
+	recordDelivery(ctx, db, logger, deliveryID, webhookID, eventID, status, resp.StatusCode, respBody.String(), latencyMs)
+}
+
+func recordDelivery(ctx context.Context, db *sql.DB, logger *zap.Logger, deliveryID, webhookID, eventID, status string, responseCode int, responseBody string, latencyMs int) {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO webhook_deliveries (id, webhook_id, event_id, status, response_code, response_body, latency_ms)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		deliveryID, webhookID, eventID, status, responseCode, responseBody, latencyMs)
+	if err != nil {
+		logger.Error("record webhook delivery",
+			zap.Error(err),
+			zap.String("delivery_id", deliveryID))
+	}
+}
+
+func generateWebhookSignature(payload []byte, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(payload)
+	return "sha256=" + hex.EncodeToString(h.Sum(nil))
+}
+
+func generateWebhookSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate webhook secret: %w", err)
+	}
+	return "whsec_" + hex.EncodeToString(b), nil
+}
+
+func isValidEventFilter(events []string) bool {
+	for _, e := range events {
+		if e == "*" {
+			continue
+		}
+		if strings.HasSuffix(e, ".*") {
+			prefix := strings.TrimSuffix(e, ".*")
+			validPrefix := false
+			for _, v := range validEventTypes {
+				if strings.HasPrefix(v, prefix+".") {
+					validPrefix = true
+					break
+				}
+			}
+			if !validPrefix {
+				return false
+			}
+			continue
+		}
+		if !isValidEventType(e) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	if s.db == nil {
+		writeListResponse(w, nil, false, "", 0)
+		return
+	}
+
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	cursor := r.URL.Query().Get("cursor")
+	typeFilter := r.URL.Query().Get("type")
+
+	var rows *sql.Rows
+	var err error
+
+	if typeFilter != "" && cursor != "" {
+		rows, err = s.db.QueryContext(r.Context(), `
+			SELECT id, type, data, created_at FROM events
+			WHERE tenant_id = $1 AND type = $2 AND created_at < $3
+			ORDER BY created_at DESC LIMIT $4`,
+			tenantID, typeFilter, cursor, limit+1)
+	} else if typeFilter != "" {
+		rows, err = s.db.QueryContext(r.Context(), `
+			SELECT id, type, data, created_at FROM events
+			WHERE tenant_id = $1 AND type = $2
+			ORDER BY created_at DESC LIMIT $3`,
+			tenantID, typeFilter, limit+1)
+	} else if cursor != "" {
+		rows, err = s.db.QueryContext(r.Context(), `
+			SELECT id, type, data, created_at FROM events
+			WHERE tenant_id = $1 AND created_at < $2
+			ORDER BY created_at DESC LIMIT $3`,
+			tenantID, cursor, limit+1)
+	} else {
+		rows, err = s.db.QueryContext(r.Context(), `
+			SELECT id, type, data, created_at FROM events
+			WHERE tenant_id = $1
+			ORDER BY created_at DESC LIMIT $2`,
+			tenantID, limit+1)
+	}
+	if err != nil {
+		s.logger.Error("list events", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to list events", "")
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []interface{}
+	for rows.Next() {
+		var id, eventType string
+		var data []byte
+		var createdAt time.Time
+		if err := rows.Scan(&id, &eventType, &data, &createdAt); err != nil {
+			s.logger.Error("scan event row", zap.Error(err))
+			continue
+		}
+		items = append(items, map[string]interface{}{
+			"object":     "event",
+			"id":         id,
+			"type":       eventType,
+			"data":       json.RawMessage(data),
+			"created_at": createdAt.Format(time.RFC3339),
+		})
+	}
+
+	hasMore := len(items) > limit
+	nextCursor := ""
+	if hasMore {
+		items = items[:limit]
+		last := items[limit-1].(map[string]interface{})
+		nextCursor = last["created_at"].(string)
+	}
+
+	var total int
+	if typeFilter != "" {
+		_ = s.db.QueryRowContext(r.Context(),
+			`SELECT COUNT(*) FROM events WHERE tenant_id = $1 AND type = $2`,
+			tenantID, typeFilter).Scan(&total)
+	} else {
+		_ = s.db.QueryRowContext(r.Context(),
+			`SELECT COUNT(*) FROM events WHERE tenant_id = $1`,
+			tenantID).Scan(&total)
+	}
+
+	writeListResponse(w, items, hasMore, nextCursor, total)
+}

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -1,0 +1,446 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/FairForge/vaultaire/internal/config"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newWebhookTestServer(t *testing.T) (*Server, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	logger, _ := zap.NewDevelopment()
+
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		db:     db,
+		config: &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	s.router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Request-Id", uuid.New().String())
+			ctx := context.WithValue(r.Context(), tenantIDKey, "test-tenant")
+			ctx = context.WithValue(ctx, userIDKey, "test-user")
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+
+	s.router.Route("/api/v1/webhooks", func(r chi.Router) {
+		r.Post("/", s.handleCreateWebhook)
+		r.Get("/", s.handleListWebhooks)
+		r.Patch("/{id}", s.handleUpdateWebhook)
+		r.Delete("/{id}", s.handleDeleteWebhook)
+		r.Get("/{id}/deliveries", s.handleListDeliveries)
+		r.Post("/{id}/test", s.handleTestWebhook)
+	})
+	s.router.Get("/api/v1/events", s.handleListEvents)
+
+	return s, mock, func() { _ = db.Close() }
+}
+
+func TestEmitEvent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger, _ := zap.NewDevelopment()
+
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(sqlmock.AnyArg(), "object.created", "tenant-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+
+	emitEvent(context.Background(), db, logger, "object.created", "tenant-1", map[string]interface{}{
+		"bucket": "my-bucket", "key": "file.txt", "size": 1024,
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEmitEvent_NilDB(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	emitEvent(context.Background(), nil, logger, "object.created", "tenant-1", nil)
+}
+
+func TestListEvents(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	earlier := now.Add(-1 * time.Hour)
+
+	mock.ExpectQuery(`SELECT id, type, data, created_at FROM events`).
+		WithArgs("test-tenant", 21).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "data", "created_at"}).
+			AddRow("evt-1", "object.created", []byte(`{"bucket":"b1"}`), now).
+			AddRow("evt-2", "object.deleted", []byte(`{"bucket":"b1"}`), earlier))
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WithArgs("test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	req := httptest.NewRequest("GET", "/api/v1/events", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "list", resp["object"])
+
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 2)
+
+	first := data[0].(map[string]interface{})
+	assert.Equal(t, "event", first["object"])
+	assert.Equal(t, "evt-1", first["id"])
+	assert.Equal(t, "object.created", first["type"])
+}
+
+func TestListEvents_TypeFilter(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`SELECT id, type, data, created_at FROM events.*type = \$2`).
+		WithArgs("test-tenant", "object.created", 21).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "data", "created_at"}).
+			AddRow("evt-1", "object.created", []byte(`{}`), now))
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WithArgs("test-tenant", "object.created").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	req := httptest.NewRequest("GET", "/api/v1/events?type=object.created", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 1)
+}
+
+func TestListEvents_TenantIsolation(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT id, type, data, created_at FROM events.*WHERE tenant_id = \$1`).
+		WithArgs("test-tenant", 21).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "data", "created_at"}))
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WithArgs("test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	req := httptest.NewRequest("GET", "/api/v1/events", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Empty(t, data)
+	assert.Equal(t, float64(0), resp["total_count"])
+}
+
+func TestCreateWebhook(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`INSERT INTO webhook_endpoints`).
+		WithArgs(sqlmock.AnyArg(), "test-tenant", "https://example.com/hook", pq.Array([]string{"object.created"}), sqlmock.AnyArg(), true, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"url":"https://example.com/hook","events":["object.created"]}`
+	req := httptest.NewRequest("POST", "/api/v1/webhooks", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "webhook", resp["object"])
+	assert.NotEmpty(t, resp["id"])
+	assert.Equal(t, "https://example.com/hook", resp["url"])
+	assert.True(t, resp["enabled"].(bool))
+
+	secret := resp["secret"].(string)
+	assert.True(t, len(secret) > 6)
+	assert.Equal(t, "whsec_", secret[:6])
+}
+
+func TestCreateWebhook_ValidationErrors(t *testing.T) {
+	s, _, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		body string
+		code string
+	}{
+		{"missing url", `{"events":["object.created"]}`, "missing_url"},
+		{"missing events", `{"url":"https://example.com/hook"}`, "missing_events"},
+		{"invalid events", `{"url":"https://example.com/hook","events":["invalid.type"]}`, "invalid_events"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/v1/webhooks", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			s.router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			var resp map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			errBody := resp["error"].(map[string]interface{})
+			assert.Equal(t, tt.code, errBody["code"])
+		})
+	}
+}
+
+func TestListWebhooks(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`SELECT id, url, event_filter, enabled, created_at, updated_at FROM webhook_endpoints`).
+		WithArgs("test-tenant", 21).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "enabled", "created_at", "updated_at"}).
+			AddRow("wh-1", "https://example.com/a", pq.Array([]string{"object.*"}), true, now, now).
+			AddRow("wh-2", "https://example.com/b", pq.Array([]string{"bucket.created"}), false, now, now))
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WithArgs("test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 2)
+
+	first := data[0].(map[string]interface{})
+	assert.Equal(t, "webhook", first["object"])
+	assert.Nil(t, first["secret"], "secret must not be exposed in list")
+}
+
+func TestUpdateWebhook(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`SELECT url, event_filter, enabled, created_at FROM webhook_endpoints`).
+		WithArgs("wh-123", "test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"url", "event_filter", "enabled", "created_at"}).
+			AddRow("https://old.com/hook", pq.Array([]string{"object.*"}), true, now))
+
+	mock.ExpectExec(`UPDATE webhook_endpoints`).
+		WithArgs("https://new.com/hook", pq.Array([]string{"object.*"}), true, sqlmock.AnyArg(), "wh-123", "test-tenant").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"url":"https://new.com/hook"}`
+	req := httptest.NewRequest("PATCH", "/api/v1/webhooks/wh-123", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://new.com/hook", resp["url"])
+}
+
+func TestDeleteWebhook(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM webhook_endpoints`).
+		WithArgs("wh-123", "test-tenant").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/webhooks/wh-123", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp["deleted"].(bool))
+}
+
+func TestDeleteWebhook_NotFound(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM webhook_endpoints`).
+		WithArgs("wh-missing", "test-tenant").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/webhooks/wh-missing", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestWebhookTestFire(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT EXISTS`).
+		WithArgs("wh-123", "test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(sqlmock.AnyArg(), "webhook.test", "test-tenant", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WithArgs("test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+
+	req := httptest.NewRequest("POST", "/api/v1/webhooks/wh-123/test", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "webhook_test", resp["object"])
+	assert.NotEmpty(t, resp["event_id"])
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestDeliveryHistory(t *testing.T) {
+	s, mock, cleanup := newWebhookTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`SELECT EXISTS`).
+		WithArgs("wh-123", "test-tenant").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	mock.ExpectQuery(`SELECT id, event_id, status, response_code, latency_ms, retry_count, created_at FROM webhook_deliveries`).
+		WithArgs("wh-123", 21).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "event_id", "status", "response_code", "latency_ms", "retry_count", "created_at"}).
+			AddRow("del-1", "evt-1", "delivered", 200, 42, 0, now).
+			AddRow("del-2", "evt-2", "failed", 500, 150, 1, now.Add(-time.Minute)))
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WithArgs("wh-123").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks/wh-123/deliveries", nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 2)
+
+	first := data[0].(map[string]interface{})
+	assert.Equal(t, "webhook_delivery", first["object"])
+	assert.Equal(t, "delivered", first["status"])
+	assert.Equal(t, float64(200), first["response_code"])
+}
+
+func TestMatchesEventFilter(t *testing.T) {
+	tests := []struct {
+		filter    []string
+		eventType string
+		expected  bool
+	}{
+		{nil, "object.created", true},
+		{[]string{}, "object.created", true},
+		{[]string{"*"}, "object.created", true},
+		{[]string{"object.created"}, "object.created", true},
+		{[]string{"object.deleted"}, "object.created", false},
+		{[]string{"object.*"}, "object.created", true},
+		{[]string{"object.*"}, "bucket.created", false},
+		{[]string{"object.created", "bucket.*"}, "bucket.deleted", true},
+	}
+
+	for _, tt := range tests {
+		result := matchesWebhookFilter(tt.filter, tt.eventType)
+		assert.Equal(t, tt.expected, result, "filter=%v event=%s", tt.filter, tt.eventType)
+	}
+}
+
+func TestIsValidEventFilter(t *testing.T) {
+	assert.True(t, isValidEventFilter([]string{"object.created"}))
+	assert.True(t, isValidEventFilter([]string{"object.*"}))
+	assert.True(t, isValidEventFilter([]string{"*"}))
+	assert.True(t, isValidEventFilter([]string{"object.created", "bucket.deleted"}))
+	assert.False(t, isValidEventFilter([]string{"invalid.type"}))
+	assert.False(t, isValidEventFilter([]string{"foo.*"}))
+}
+
+func TestGenerateWebhookSecret(t *testing.T) {
+	secret, err := generateWebhookSecret()
+	require.NoError(t, err)
+	assert.True(t, len(secret) > 6)
+	assert.Equal(t, "whsec_", secret[:6])
+
+	secret2, err := generateWebhookSecret()
+	require.NoError(t, err)
+	assert.NotEqual(t, secret, secret2)
+}
+
+func TestGenerateWebhookSignature(t *testing.T) {
+	payload := []byte(`{"type":"object.created"}`)
+	sig := generateWebhookSignature(payload, "test-secret")
+	assert.True(t, len(sig) > 7)
+	assert.Equal(t, "sha256=", sig[:7])
+
+	sig2 := generateWebhookSignature(payload, "test-secret")
+	assert.Equal(t, sig, sig2, "same input must produce same signature")
+
+	sig3 := generateWebhookSignature(payload, "different-secret")
+	assert.NotEqual(t, sig, sig3, "different secret must produce different signature")
+}

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -504,6 +504,11 @@ func (s *Server) handleMgmtCreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	emitEvent(r.Context(), s.db, s.logger, "key.created", tenantID, map[string]interface{}{
+		"key_id": key.ID, "name": key.Name,
+	})
+
 	resp := map[string]interface{}{
 		"object":       "api_key",
 		"id":           key.ID,
@@ -534,6 +539,11 @@ func (s *Server) handleMgmtDeleteKey(w http.ResponseWriter, r *http.Request) {
 		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to revoke API key", "")
 		return
 	}
+
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	emitEvent(r.Context(), s.db, s.logger, "key.revoked", tenantID, map[string]interface{}{
+		"key_id": keyID,
+	})
 
 	resp := map[string]interface{}{
 		"object":     "api_key",

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -139,6 +139,9 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		auth.EnsureTenantSlug(ctx, s.db, tenantID, s.logger)
 	}
 
+	emitEvent(ctx, s.db, s.logger, "bucket.created", tenantID, map[string]interface{}{
+		"bucket": bucket,
+	})
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -214,5 +217,8 @@ func (s *Server) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 		`, tenantID, bucket)
 	}
 
+	emitEvent(ctx, s.db, s.logger, "bucket.deleted", tenantID, map[string]interface{}{
+		"bucket": bucket,
+	})
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -308,6 +308,10 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.String("engine.container", container),
 		zap.String("engine.artifact", artifact),
 		zap.Int64("bytes", written))
+
+	emitEvent(r.Context(), a.db, a.logger, "object.downloaded", t.ID, map[string]interface{}{
+		"bucket": bucket, "key": object, "size": written,
+	})
 }
 
 // detectContentType determines MIME type from extension
@@ -503,6 +507,9 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.Int64("size", size))
 
 	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:Put", object, size, etag)
+	emitEvent(r.Context(), a.db, a.logger, "object.created", t.ID, map[string]interface{}{
+		"bucket": bucket, "key": object, "size": size, "etag": etag,
+	})
 }
 
 // HandleDelete processes S3 DELETE requests
@@ -553,6 +560,9 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 		w.Header().Set("x-amz-version-id", reqVersionID)
 		w.WriteHeader(http.StatusNoContent)
 		a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
+		emitEvent(r.Context(), a.db, a.logger, "object.deleted", t.ID, map[string]interface{}{
+			"bucket": bucket, "key": object,
+		})
 		return
 	}
 
@@ -579,6 +589,9 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 		w.Header().Set("x-amz-delete-marker", "true")
 		w.WriteHeader(http.StatusNoContent)
 		a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
+		emitEvent(r.Context(), a.db, a.logger, "object.deleted", t.ID, map[string]interface{}{
+			"bucket": bucket, "key": object,
+		})
 		return
 	}
 
@@ -610,6 +623,9 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 
 	w.WriteHeader(http.StatusNoContent)
 	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectRemoved:Delete", object, 0, "")
+	emitEvent(r.Context(), a.db, a.logger, "object.deleted", t.ID, map[string]interface{}{
+		"bucket": bucket, "key": object,
+	})
 }
 
 // HandleList processes S3 LIST requests

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -429,6 +429,9 @@ func (s *Server) setupRoutes() {
 	s.logger.Info("Registering STS routes")
 	s.registerSTSRoutes()
 
+	s.logger.Info("Registering webhook and event routes")
+	s.registerWebhookRoutes()
+
 	s.router.Get("/llms.txt", s.handleLlmsTxt)
 
 	s.logger.Info("Registering S3 catch-all handler")

--- a/internal/api/sts_routes.go
+++ b/internal/api/sts_routes.go
@@ -59,6 +59,10 @@ func (s *Server) handleSTSCreateToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	emitEvent(r.Context(), s.db, s.logger, "sts.token_created", tenantID, map[string]interface{}{
+		"access_key": token.AccessKey,
+	})
+
 	resp := map[string]interface{}{
 		"object":     "sts_token",
 		"access_key": token.AccessKey,

--- a/internal/api/webhooks_routes.go
+++ b/internal/api/webhooks_routes.go
@@ -1,0 +1,452 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"go.uber.org/zap"
+)
+
+func (s *Server) registerWebhookRoutes() {
+	rl := NewManagementRateLimiter()
+	im := newIdempotencyMiddleware(s.db, s.logger)
+
+	s.router.Route("/api/v1/webhooks", func(r chi.Router) {
+		r.Use(s.requireJWT)
+		r.Use(rl.Middleware)
+		r.Use(im.Middleware)
+
+		r.Post("/", s.handleCreateWebhook)
+		r.Get("/", s.handleListWebhooks)
+		r.Patch("/{id}", s.handleUpdateWebhook)
+		r.Delete("/{id}", s.handleDeleteWebhook)
+		r.Get("/{id}/deliveries", s.handleListDeliveries)
+		r.Post("/{id}/test", s.handleTestWebhook)
+	})
+
+	s.router.Route("/api/v1/events", func(r chi.Router) {
+		r.Use(s.requireJWT)
+		r.Use(rl.Middleware)
+
+		r.Get("/", s.handleListEvents)
+	})
+}
+
+type createWebhookRequest struct {
+	URL     string   `json:"url"`
+	Events  []string `json:"events"`
+	Enabled *bool    `json:"enabled,omitempty"`
+}
+
+func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	var req createWebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if req.URL == "" {
+		writeManagementError(w, ErrTypeInvalidRequest, "missing_url", "url is required", "url")
+		return
+	}
+	if _, err := url.ParseRequestURI(req.URL); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_url", "url must be a valid URL", "url")
+		return
+	}
+	if len(req.Events) == 0 {
+		writeManagementError(w, ErrTypeInvalidRequest, "missing_events", "events is required and must not be empty", "events")
+		return
+	}
+	if !isValidEventFilter(req.Events) {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_events", "events contains invalid event types", "events")
+		return
+	}
+
+	id := uuid.New().String()
+	secret, err := generateWebhookSecret()
+	if err != nil {
+		s.logger.Error("generate webhook secret", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to generate webhook secret", "")
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(r.Context(), `
+		INSERT INTO webhook_endpoints (id, tenant_id, url, event_filter, secret, enabled, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		id, tenantID, req.URL, pq.Array(req.Events), secret, enabled, now, now)
+	if err != nil {
+		s.logger.Error("create webhook endpoint", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to create webhook", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "webhook",
+		"id":         id,
+		"url":        req.URL,
+		"events":     req.Events,
+		"secret":     secret,
+		"enabled":    enabled,
+		"created_at": now.Format(time.RFC3339),
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (s *Server) handleListWebhooks(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	if s.db == nil {
+		writeListResponse(w, nil, false, "", 0)
+		return
+	}
+
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	startingAfter := r.URL.Query().Get("starting_after")
+
+	var rows *sql.Rows
+	var dbErr error
+	if startingAfter != "" {
+		rows, dbErr = s.db.QueryContext(r.Context(), `
+			SELECT id, url, event_filter, enabled, created_at, updated_at
+			FROM webhook_endpoints
+			WHERE tenant_id = $1 AND id > $2
+			ORDER BY id LIMIT $3`,
+			tenantID, startingAfter, limit+1)
+	} else {
+		rows, dbErr = s.db.QueryContext(r.Context(), `
+			SELECT id, url, event_filter, enabled, created_at, updated_at
+			FROM webhook_endpoints
+			WHERE tenant_id = $1
+			ORDER BY id LIMIT $2`,
+			tenantID, limit+1)
+	}
+	if dbErr != nil {
+		s.logger.Error("list webhooks", zap.Error(dbErr))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to list webhooks", "")
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []interface{}
+	for rows.Next() {
+		var id string
+		var whURL string
+		var filter []string
+		var enabled bool
+		var createdAt, updatedAt time.Time
+		if err := rows.Scan(&id, &whURL, pq.Array(&filter), &enabled, &createdAt, &updatedAt); err != nil {
+			s.logger.Error("scan webhook row", zap.Error(err))
+			continue
+		}
+		items = append(items, map[string]interface{}{
+			"object":     "webhook",
+			"id":         id,
+			"url":        whURL,
+			"events":     filter,
+			"enabled":    enabled,
+			"created_at": createdAt.Format(time.RFC3339),
+			"updated_at": updatedAt.Format(time.RFC3339),
+		})
+	}
+
+	hasMore := len(items) > limit
+	nextCursor := ""
+	if hasMore {
+		items = items[:limit]
+		last := items[limit-1].(map[string]interface{})
+		nextCursor = last["id"].(string)
+	}
+
+	var total int
+	_ = s.db.QueryRowContext(r.Context(),
+		`SELECT COUNT(*) FROM webhook_endpoints WHERE tenant_id = $1`,
+		tenantID).Scan(&total)
+
+	writeListResponse(w, items, hasMore, nextCursor, total)
+}
+
+type updateWebhookRequest struct {
+	URL     *string  `json:"url,omitempty"`
+	Events  []string `json:"events,omitempty"`
+	Enabled *bool    `json:"enabled,omitempty"`
+}
+
+func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	webhookID := chi.URLParam(r, "id")
+
+	var req updateWebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if req.URL != nil && *req.URL == "" {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_url", "url must not be empty", "url")
+		return
+	}
+	if req.URL != nil {
+		if _, err := url.ParseRequestURI(*req.URL); err != nil {
+			writeManagementError(w, ErrTypeInvalidRequest, "invalid_url", "url must be a valid URL", "url")
+			return
+		}
+	}
+	if req.Events != nil && len(req.Events) == 0 {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_events", "events must not be empty", "events")
+		return
+	}
+	if req.Events != nil && !isValidEventFilter(req.Events) {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_events", "events contains invalid event types", "events")
+		return
+	}
+
+	var currentURL string
+	var currentFilter []string
+	var currentEnabled bool
+	var createdAt time.Time
+	err := s.db.QueryRowContext(r.Context(), `
+		SELECT url, event_filter, enabled, created_at
+		FROM webhook_endpoints
+		WHERE id = $1 AND tenant_id = $2`,
+		webhookID, tenantID).Scan(&currentURL, pq.Array(&currentFilter), &currentEnabled, &createdAt)
+	if err == sql.ErrNoRows {
+		writeManagementError(w, ErrTypeNotFound, "webhook_not_found", "webhook not found", "")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get webhook for update", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to get webhook", "")
+		return
+	}
+
+	if req.URL != nil {
+		currentURL = *req.URL
+	}
+	if req.Events != nil {
+		currentFilter = req.Events
+	}
+	if req.Enabled != nil {
+		currentEnabled = *req.Enabled
+	}
+
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(r.Context(), `
+		UPDATE webhook_endpoints
+		SET url = $1, event_filter = $2, enabled = $3, updated_at = $4
+		WHERE id = $5 AND tenant_id = $6`,
+		currentURL, pq.Array(currentFilter), currentEnabled, now, webhookID, tenantID)
+	if err != nil {
+		s.logger.Error("update webhook", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to update webhook", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "webhook",
+		"id":         webhookID,
+		"url":        currentURL,
+		"events":     currentFilter,
+		"enabled":    currentEnabled,
+		"created_at": createdAt.Format(time.RFC3339),
+		"updated_at": now.Format(time.RFC3339),
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleDeleteWebhook(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	webhookID := chi.URLParam(r, "id")
+
+	result, err := s.db.ExecContext(r.Context(), `
+		DELETE FROM webhook_endpoints
+		WHERE id = $1 AND tenant_id = $2`,
+		webhookID, tenantID)
+	if err != nil {
+		s.logger.Error("delete webhook", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to delete webhook", "")
+		return
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		writeManagementError(w, ErrTypeNotFound, "webhook_not_found", "webhook not found", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "webhook",
+		"id":         webhookID,
+		"deleted":    true,
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleListDeliveries(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	webhookID := chi.URLParam(r, "id")
+
+	var exists bool
+	err := s.db.QueryRowContext(r.Context(), `
+		SELECT EXISTS(SELECT 1 FROM webhook_endpoints WHERE id = $1 AND tenant_id = $2)`,
+		webhookID, tenantID).Scan(&exists)
+	if err != nil || !exists {
+		writeManagementError(w, ErrTypeNotFound, "webhook_not_found", "webhook not found", "")
+		return
+	}
+
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	cursor := r.URL.Query().Get("cursor")
+
+	var rows *sql.Rows
+	var dbErr error
+	if cursor != "" {
+		rows, dbErr = s.db.QueryContext(r.Context(), `
+			SELECT id, event_id, status, response_code, latency_ms, retry_count, created_at
+			FROM webhook_deliveries
+			WHERE webhook_id = $1 AND created_at < $2
+			ORDER BY created_at DESC LIMIT $3`,
+			webhookID, cursor, limit+1)
+	} else {
+		rows, dbErr = s.db.QueryContext(r.Context(), `
+			SELECT id, event_id, status, response_code, latency_ms, retry_count, created_at
+			FROM webhook_deliveries
+			WHERE webhook_id = $1
+			ORDER BY created_at DESC LIMIT $2`,
+			webhookID, limit+1)
+	}
+	if dbErr != nil {
+		s.logger.Error("list deliveries", zap.Error(dbErr))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to list deliveries", "")
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []interface{}
+	for rows.Next() {
+		var id, eventID, status string
+		var responseCode, latencyMs, retryCount int
+		var createdAt time.Time
+		if err := rows.Scan(&id, &eventID, &status, &responseCode, &latencyMs, &retryCount, &createdAt); err != nil {
+			s.logger.Error("scan delivery row", zap.Error(err))
+			continue
+		}
+		items = append(items, map[string]interface{}{
+			"object":        "webhook_delivery",
+			"id":            id,
+			"event_id":      eventID,
+			"status":        status,
+			"response_code": responseCode,
+			"latency_ms":    latencyMs,
+			"retry_count":   retryCount,
+			"created_at":    createdAt.Format(time.RFC3339),
+		})
+	}
+
+	hasMore := len(items) > limit
+	nextCursor := ""
+	if hasMore {
+		items = items[:limit]
+		last := items[limit-1].(map[string]interface{})
+		nextCursor = last["created_at"].(string)
+	}
+
+	var total int
+	_ = s.db.QueryRowContext(r.Context(),
+		`SELECT COUNT(*) FROM webhook_deliveries WHERE webhook_id = $1`,
+		webhookID).Scan(&total)
+
+	writeListResponse(w, items, hasMore, nextCursor, total)
+}
+
+func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	webhookID := chi.URLParam(r, "id")
+
+	var exists bool
+	err := s.db.QueryRowContext(r.Context(), `
+		SELECT EXISTS(SELECT 1 FROM webhook_endpoints WHERE id = $1 AND tenant_id = $2)`,
+		webhookID, tenantID).Scan(&exists)
+	if err != nil || !exists {
+		writeManagementError(w, ErrTypeNotFound, "webhook_not_found", "webhook not found", "")
+		return
+	}
+
+	eventID := uuid.New().String()
+	data := map[string]interface{}{"webhook_id": webhookID}
+	dataJSON, _ := json.Marshal(data)
+
+	_, err = s.db.ExecContext(r.Context(), `
+		INSERT INTO events (id, type, tenant_id, data)
+		VALUES ($1, $2, $3, $4)`,
+		eventID, "webhook.test", tenantID, dataJSON)
+	if err != nil {
+		s.logger.Error("insert test event", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "internal_error", "failed to create test event", "")
+		return
+	}
+
+	go dispatchWebhooks(s.db, s.logger, eventID, "webhook.test", tenantID, dataJSON)
+
+	resp := map[string]interface{}{
+		"object":     "webhook_test",
+		"event_id":   eventID,
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -24,6 +24,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 030 | Metadata: `metadata JSONB` column on `buckets` and `object_head_cache` |
 | 031 | Scoped API keys: `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at` (TIMESTAMPTZ), `secret_key` (TEXT) on `api_keys` |
 | 032 | STS temporary credentials: `sts_tokens` table (access_key PK, secret_key, tenant_id, parent_key_id, permissions JSONB, bucket_scope TEXT[], ip_restrict TEXT[], expires_at, created_at) |
+| 033 | Event log + webhooks: `events` table, `webhook_endpoints` table (with secret, event_filter TEXT[]), `webhook_deliveries` table (status, response_code, latency_ms, retry support) |
 
 ## Key Tables
 
@@ -43,6 +44,9 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **object_locks** — `(tenant_id, bucket, object_key) PK`, `retention_mode`, `retain_until_date`, `legal_hold`, `created_at`, `updated_at`
 - **idempotency_cache** — `(tenant_id, idempotency_key) PK`, `method`, `path`, `response_status`, `response_headers` (JSONB), `response_body` (BYTEA), `created_at` — 24h TTL, hourly cleanup
 - **sts_tokens** — `access_key (PK)`, `secret_key`, `tenant_id`, `parent_key_id`, `permissions` (JSONB), `bucket_scope` (TEXT[]), `ip_restrict` (TEXT[]), `expires_at`, `created_at` — short-lived S3 creds, hourly cleanup
+- **events** — `id (PK)`, `type`, `tenant_id`, `data` (JSONB), `created_at` — persistent event log
+- **webhook_endpoints** — `id (PK)`, `tenant_id`, `url`, `event_filter` (TEXT[]), `secret`, `enabled`, `created_at`, `updated_at` — webhook subscriptions
+- **webhook_deliveries** — `id (PK)`, `webhook_id → webhook_endpoints`, `event_id → events`, `status`, `response_code`, `response_body`, `latency_ms`, `retry_count`, `next_retry_at`, `created_at` — delivery tracking
 
 ## Connection
 

--- a/internal/database/migrations/033_events_webhooks.sql
+++ b/internal/database/migrations/033_events_webhooks.sql
@@ -1,0 +1,41 @@
+-- Phase 5.11.6: Event Log + Webhook Management API
+-- Persistent event log, webhook endpoint registry, and delivery tracking.
+
+CREATE TABLE IF NOT EXISTS events (
+    id          TEXT PRIMARY KEY,
+    type        TEXT NOT NULL,
+    tenant_id   TEXT NOT NULL,
+    data        JSONB NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_tenant ON events(tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_type   ON events(type);
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+    id            TEXT PRIMARY KEY,
+    tenant_id     TEXT NOT NULL,
+    url           TEXT NOT NULL,
+    event_filter  TEXT[] NOT NULL DEFAULT '{}',
+    secret        TEXT NOT NULL,
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_tenant ON webhook_endpoints(tenant_id);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id             TEXT PRIMARY KEY,
+    webhook_id     TEXT NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+    event_id       TEXT NOT NULL REFERENCES events(id),
+    status         TEXT NOT NULL DEFAULT 'pending',
+    response_code  INT,
+    response_body  TEXT,
+    latency_ms     INT,
+    retry_count    INT NOT NULL DEFAULT 0,
+    next_retry_at  TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook ON webhook_deliveries(webhook_id, created_at DESC);


### PR DESCRIPTION
## Summary

- **Migration 033**: `events`, `webhook_endpoints`, `webhook_deliveries` tables with tenant-scoped indexes
- **Event emitter** (`emitEvent`): inserts event row synchronously, dispatches matching webhooks asynchronously via goroutine — never blocks the S3 hot path. HMAC-SHA256 signed delivery with `X-Webhook-Signature` header. Delivery results recorded in `webhook_deliveries`
- **Event types**: `object.created`, `object.deleted`, `object.downloaded`, `bucket.created`, `bucket.deleted`, `key.created`, `key.revoked`, `sts.token_created`, `webhook.test`
- **Webhook CRUD API** (JWT-protected, rate-limited, idempotent):
  - `GET /api/v1/events` — cursor pagination, type filter, tenant-scoped
  - `POST /api/v1/webhooks` — create (returns `whsec_` secret once)
  - `GET /api/v1/webhooks` — list (secret omitted)
  - `PATCH /api/v1/webhooks/{id}` — partial update
  - `DELETE /api/v1/webhooks/{id}` — cascade deletes deliveries
  - `GET /api/v1/webhooks/{id}/deliveries` — delivery history
  - `POST /api/v1/webhooks/{id}/test` — fires synthetic test event
- **S3 handler wiring**: emitEvent in PUT, GET, DELETE (3 paths), CreateBucket, DeleteBucket, key create/revoke, STS token creation
- **16 tests**: emitEvent (with/without DB), list events (pagination, type filter, tenant isolation), webhook CRUD (create, validation, list, update, delete, not-found), test fire, delivery history, filter matching, secret generation, signature generation

## Test plan

- [x] `go test -short -race ./internal/api/...` — all pass
- [x] `golangci-lint run ./internal/api/...` — 0 issues
- [x] Pre-commit hooks pass (go fmt, go test, golangci-lint)
- [ ] CI `build-and-test` workflow
- [ ] Deploy to dev: verify migration 033 applies cleanly
- [ ] Verify event log populates on object upload/download/delete
- [ ] Verify webhook creation returns `whsec_` secret, list omits it
- [ ] Verify webhook receives HMAC-signed POST on object events