### PR TITLE
feat(dashboard): CDN previews and copy URLs in object browser [Phase 5.11.11]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -11,7 +11,7 @@ Web dashboard for stored.ge customers and admins. Uses htmx + Go templates, embe
 - **templates/layouts/** — shared HTML layouts (`base.html`, `admin.html`)
 - **templates/customer/** — customer page templates (`dashboard.html` = overview)
 - **static/css/** — `style.css`
-- **static/js/** — `htmx.min.js` (v2.0.4, vendored)
+- **static/js/** — `htmx.min.js` (v2.0.4, vendored), `dashboard.js` (shared tab switching + copy-to-clipboard)
 - **middleware/** — 4 middleware files:
   - `csrf.go` — double-submit cookie CSRF on all POST forms
   - `flash.go` — cookie-based flash messages ("Settings saved", "Key revoked", etc.)

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -18,7 +18,9 @@ Helper functions are in `context.go`: `formatBytes` (human-readable sizes), `rel
 Three handlers:
 - `HandleBuckets(tmpl, db, dataPath, logger)` — lists buckets from `buckets` table LEFT JOIN `object_head_cache` (includes empty buckets with count=0)
 - `HandleCreateBucket(tmpl, db, dataPath, logger)` — validates S3-compatible name, creates directory at `{dataPath}/{name}`, persists to `buckets` table
-- `HandleBucketObjects(tmpl, db, logger)` — lists objects in a bucket with prefix-based "folder" navigation (uses chi URL param `{name}`)
+- `HandleBucketObjects(tmpl, db, logger)` — lists objects in a bucket with prefix-based "folder" navigation (uses chi URL param `{name}`). Queries bucket visibility and tenant slug; for public-read buckets with a slug, sets `CDNBaseURL` and populates `ObjectRow.CDNURL` and `ObjectRow.PreviewType` fields for inline media previews and CDN copy buttons.
+
+`previewTypeFromContentType(ct)` maps content types to preview categories: `image/*` → "image", `video/*` → "video", `audio/*` → "audio", `text/*`/json/xml/js → "text", everything else → "".
 
 Bucket name validation: `^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$` + path traversal check.
 

--- a/internal/dashboard/handlers/buckets.go
+++ b/internal/dashboard/handlers/buckets.go
@@ -38,6 +38,8 @@ type ObjectRow struct {
 	LastModified    time.Time
 	SizeFmt         string
 	LastModifiedFmt string
+	PreviewType     string
+	CDNURL          string
 }
 
 // PrefixRow is a common-prefix "folder" in the bucket browser.
@@ -190,7 +192,20 @@ func HandleBucketObjects(tmpl *template.Template, db *sql.DB, logger *zap.Logger
 		}
 
 		if db != nil {
-			populateBucketObjects(r.Context(), db, sd.TenantID, bucketName, prefix, data)
+			var vis, slug string
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT visibility FROM buckets WHERE tenant_id = $1 AND name = $2`,
+				sd.TenantID, bucketName).Scan(&vis)
+			_ = db.QueryRowContext(r.Context(),
+				`SELECT COALESCE(slug, '') FROM tenants WHERE id = $1`,
+				sd.TenantID).Scan(&slug)
+			data["Visibility"] = vis
+			cdnBase := ""
+			if vis == "public-read" && slug != "" {
+				cdnBase = cdnBaseHost + slug + "/" + bucketName
+				data["CDNBaseURL"] = cdnBase
+			}
+			populateBucketObjects(r.Context(), db, sd.TenantID, bucketName, prefix, cdnBase, data)
 		} else {
 			data["ObjectCount"] = 0
 			data["TotalSizeFmt"] = "0 B"
@@ -261,7 +276,23 @@ func listBuckets(ctx context.Context, db *sql.DB, tenantID string) []BucketRow {
 	return buckets
 }
 
-func populateBucketObjects(ctx context.Context, db *sql.DB, tenantID, bucket, prefix string, data map[string]any) {
+func previewTypeFromContentType(ct string) string {
+	if strings.HasPrefix(ct, "image/") {
+		return "image"
+	}
+	if strings.HasPrefix(ct, "video/") {
+		return "video"
+	}
+	if strings.HasPrefix(ct, "audio/") {
+		return "audio"
+	}
+	if strings.HasPrefix(ct, "text/") || ct == "application/json" || ct == "application/xml" || ct == "application/javascript" {
+		return "text"
+	}
+	return ""
+}
+
+func populateBucketObjects(ctx context.Context, db *sql.DB, tenantID, bucket, prefix, cdnBase string, data map[string]any) {
 	// Query all objects matching the prefix.
 	query := `SELECT object_key, size_bytes, content_type, updated_at
 		 FROM object_head_cache
@@ -310,7 +341,7 @@ func populateBucketObjects(ctx context.Context, db *sql.DB, tenantID, bucket, pr
 			continue
 		}
 
-		objects = append(objects, ObjectRow{
+		obj := ObjectRow{
 			Key:             key,
 			Display:         rel,
 			Size:            size,
@@ -318,7 +349,12 @@ func populateBucketObjects(ctx context.Context, db *sql.DB, tenantID, bucket, pr
 			LastModified:    lastMod,
 			SizeFmt:         formatBytes(size),
 			LastModifiedFmt: relativeTime(lastMod),
-		})
+			PreviewType:     previewTypeFromContentType(contentType),
+		}
+		if cdnBase != "" {
+			obj.CDNURL = cdnBase + "/" + key
+		}
+		objects = append(objects, obj)
 	}
 
 	// Build sorted prefix list.

--- a/internal/dashboard/handlers/buckets_test.go
+++ b/internal/dashboard/handlers/buckets_test.go
@@ -286,6 +286,135 @@ func TestHandleCreateBucket_InvalidName_NoDB(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Invalid bucket name")
 }
 
+func TestObjectRow_PreviewType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        string
+	}{
+		{"image/png", "image"},
+		{"image/jpeg", "image"},
+		{"image/svg+xml", "image"},
+		{"video/mp4", "video"},
+		{"video/webm", "video"},
+		{"audio/mpeg", "audio"},
+		{"audio/ogg", "audio"},
+		{"text/plain", "text"},
+		{"text/html", "text"},
+		{"application/json", "text"},
+		{"application/xml", "text"},
+		{"application/javascript", "text"},
+		{"application/octet-stream", ""},
+		{"application/pdf", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := previewTypeFromContentType(tt.contentType)
+		assert.Equal(t, tt.want, got, "contentType=%q", tt.contentType)
+	}
+}
+
+func TestHandleBucketObjects_CDNData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	tenantID := "test-dash-cdn-1"
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ($1, 'CDN Co', 'cdn@test.com', 'VK-cdn1', 'SK-cdn1', 'cdnco')
+		ON CONFLICT DO NOTHING`, tenantID)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, 'pub-bucket', 'public-read')
+		ON CONFLICT DO NOTHING`, tenantID)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, content_type, etag)
+		VALUES ($1, 'pub-bucket', 'photo.jpg', 1024, 'image/jpeg', 'abc123')
+		ON CONFLICT DO NOTHING`, tenantID)
+	require.NoError(t, err)
+
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Objects{{end}}` +
+			`{{define "content"}}` +
+			`vis={{.Visibility}} cdn={{.CDNBaseURL}}` +
+			`{{range .Objects}}preview={{.PreviewType}} url={{.CDNURL}}{{end}}` +
+			`{{end}}`))
+
+	handler := HandleBucketObjects(tmpl, db, zap.NewNop())
+	req := injectSessionWithTenant(httptest.NewRequest("GET", "/dashboard/buckets/pub-bucket", nil), tenantID)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "pub-bucket")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "vis=public-read")
+	assert.Contains(t, body, "cdn=https://cdn.stored.ge/cdnco/pub-bucket")
+	assert.Contains(t, body, "preview=image")
+	assert.Contains(t, body, "url=https://cdn.stored.ge/cdnco/pub-bucket/photo.jpg")
+}
+
+func TestHandleBucketObjects_NoCDNForPrivate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	tenantID := "test-dash-cdn-2"
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ($1, 'Private Co', 'priv@test.com', 'VK-cdn2', 'SK-cdn2', 'privco')
+		ON CONFLICT DO NOTHING`, tenantID)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, 'priv-bucket', 'private')
+		ON CONFLICT DO NOTHING`, tenantID)
+	require.NoError(t, err)
+
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Objects{{end}}` +
+			`{{define "content"}}` +
+			`vis={{.Visibility}} cdn={{.CDNBaseURL}}` +
+			`{{end}}`))
+
+	handler := HandleBucketObjects(tmpl, db, zap.NewNop())
+	req := injectSessionWithTenant(httptest.NewRequest("GET", "/dashboard/buckets/priv-bucket", nil), tenantID)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "priv-bucket")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "vis=private")
+	assert.NotContains(t, body, "cdn=https://cdn.stored.ge")
+}
+
+func TestDashboardJS_Exists(t *testing.T) {
+	data, err := os.ReadFile("../static/js/dashboard.js")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "showTab")
+	assert.Contains(t, string(data), "btn-copy")
+}
+
 func TestListBuckets_Dashboard_IncludesEmptyBuckets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires database")

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -485,6 +485,11 @@ th {
 .tab-visible { display: block; }
 .tab-panel .code-block { margin: 0; border-radius: 0; }
 
+/* Object browser previews */
+.preview-cell img, .preview-cell video { display: block; }
+.preview-cell audio { display: block; height: 32px; }
+.btn-copy { font-size: 0.75rem; padding: 0.15rem 0.5rem; white-space: nowrap; }
+
 /* Responsive */
 @media (max-width: 768px) {
     .admin-layout { flex-direction: column; }

--- a/internal/dashboard/static/js/dashboard.js
+++ b/internal/dashboard/static/js/dashboard.js
@@ -1,0 +1,18 @@
+function showTab(btn, id) {
+    btn.closest('.code-tabs').querySelectorAll('.tab-panel').forEach(function(p) { p.classList.remove('tab-visible'); });
+    btn.closest('.tab-bar').querySelectorAll('.tab-btn').forEach(function(b) { b.classList.remove('tab-active'); });
+    document.getElementById(id).classList.add('tab-visible');
+    btn.classList.add('tab-active');
+}
+
+document.addEventListener('click', function(e) {
+    var btn = e.target.closest('.btn-copy');
+    if (!btn) return;
+    var url = btn.getAttribute('data-url');
+    if (url) {
+        navigator.clipboard.writeText(url).then(function() {
+            btn.textContent = 'Copied!';
+            setTimeout(function() { btn.textContent = 'Copy URL'; }, 1500);
+        });
+    }
+});

--- a/internal/dashboard/templates/customer/bucket_objects.html
+++ b/internal/dashboard/templates/customer/bucket_objects.html
@@ -31,6 +31,8 @@
                 <th>Size</th>
                 <th>Type</th>
                 <th>Last Modified</th>
+                {{if .CDNBaseURL}}<th>Preview</th>
+                <th>CDN URL</th>{{end}}
             </tr>
         </thead>
         <tbody>
@@ -39,9 +41,11 @@
                 <td>
                     <a href="/dashboard/buckets/{{$.BucketName}}?prefix={{.FullPrefix}}" class="bucket-link">{{.Display}}/</a>
                 </td>
-                <td class="text-muted">—</td>
+                <td class="text-muted">&mdash;</td>
                 <td class="text-muted">prefix</td>
-                <td class="text-muted">—</td>
+                <td class="text-muted">&mdash;</td>
+                {{if $.CDNBaseURL}}<td class="text-muted">&mdash;</td>
+                <td class="text-muted">&mdash;</td>{{end}}
             </tr>
             {{end}}
             {{range .Objects}}
@@ -50,6 +54,8 @@
                 <td>{{.SizeFmt}}</td>
                 <td>{{.ContentType}}</td>
                 <td>{{.LastModifiedFmt}}</td>
+                {{if $.CDNBaseURL}}<td class="preview-cell">{{if eq .PreviewType "image"}}<img src="{{.CDNURL}}" loading="lazy" style="max-width:80px;max-height:60px;border-radius:4px;">{{else if eq .PreviewType "video"}}<video src="{{.CDNURL}}" controls preload="none" style="max-width:120px;max-height:80px;"></video>{{else if eq .PreviewType "audio"}}<audio src="{{.CDNURL}}" controls preload="none" style="max-width:160px;"></audio>{{else if eq .PreviewType "text"}}<span class="text-muted">text</span>{{else}}<span class="text-muted">&mdash;</span>{{end}}</td>
+                <td><button type="button" class="btn btn-sm btn-copy" data-url="{{.CDNURL}}">Copy URL</button></td>{{end}}
             </tr>
             {{end}}
         </tbody>

--- a/internal/dashboard/templates/customer/bucket_settings.html
+++ b/internal/dashboard/templates/customer/bucket_settings.html
@@ -90,6 +90,15 @@ with open("file.jpg", "wb") as f:
 &lt;video src="{{.CDNBaseURL}}/video.mp4" controls&gt;&lt;/video&gt;</pre>
             </div>
         </div>
+
+        <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border);">
+            <div style="font-weight:600;font-size:0.9rem;margin-bottom:0.5rem;">Quick Upload</div>
+            <pre class="code-block">aws s3 cp ./myfile.jpg s3://{{.BucketName}}/ \
+  --endpoint-url https://stored.ge
+
+# After uploading, your file is available at:
+# {{.CDNBaseURL}}/myfile.jpg</pre>
+        </div>
     </div>
     {{end}}
 
@@ -123,12 +132,4 @@ with open("file.jpg", "wb") as f:
     </div>
 </form>
 
-<script>
-function showTab(btn, id) {
-    btn.closest('.code-tabs').querySelectorAll('.tab-panel').forEach(p => p.classList.remove('tab-visible'));
-    btn.closest('.tab-bar').querySelectorAll('.tab-btn').forEach(b => b.classList.remove('tab-active'));
-    document.getElementById(id).classList.add('tab-visible');
-    btn.classList.add('tab-active');
-}
-</script>
 {{end}}

--- a/internal/dashboard/templates/layouts/base.html
+++ b/internal/dashboard/templates/layouts/base.html
@@ -7,6 +7,7 @@
     <title>{{block "title" .}}stored.ge{{end}}</title>
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/dashboard.js"></script>
     {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
     {{block "head" .}}{{end}}
 </head>


### PR DESCRIPTION
## Summary

- **Object browser CDN columns**: Public-read buckets now show Preview and CDN URL columns with inline image/video/audio previews and one-click copy buttons
- **Shared dashboard.js**: Extracted `showTab` and clipboard logic from inline `<script>` into `static/js/dashboard.js`, loaded globally via base layout
- **Quick Upload section**: Bucket settings CDN card now includes a pre-filled `aws s3 cp` command with the resulting CDN URL
- **Preview type mapping**: `previewTypeFromContentType()` categorizes content types (image/video/audio/text) for conditional rendering; private buckets show the original 4-column table unchanged

## Test plan

- [x] `TestObjectRow_PreviewType` — verifies content type → preview category mapping (15 cases)
- [x] `TestHandleBucketObjects_CDNData` — public-read bucket with slug produces CDNBaseURL, object CDNURL, and preview type
- [x] `TestHandleBucketObjects_NoCDNForPrivate` — private bucket never exposes CDN URLs
- [x] `TestDashboardJS_Exists` — embedded JS file exists and contains expected functions
- [x] Full test suite passes (`go test ./... -short`)
- [x] `golangci-lint run` — 0 issues
- [ ] Visual check: browse a public bucket in dashboard, verify preview thumbnails render and Copy URL copies correct URL
- [ ] Visual check: bucket settings page for public bucket shows Quick Upload section and tab switching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)