### PR TITLE
fix(drivers): rewrite Quotaless driver with raw HTTP + SigV4 [Phase 5.12.1]

### DIFF
--- a/internal/drivers/CLAUDE.md
+++ b/internal/drivers/CLAUDE.md
@@ -27,14 +27,14 @@ type Driver interface {
 | `LocalDriver` | `local.go` | `NewLocalDriver(basePath, logger)` | Local filesystem | `DATA_PATH` env var; reader/file pools; transactions; buffered writes; multipart uploads; file locking; sparse files; xattrs; directory indexing |
 | `S3CompatDriver` | `s3compat.go` | `NewS3CompatDriver(accessKey, secretKey, logger)` | S3-compatible (maps to Quotaless endpoint) | Hardcoded `us.s3compat.cloud:8000`; optional `S3COMPAT_INSECURE_TLS` for self-signed certs |
 | `LyveDriver` | `lyve.go` | `NewLyveDriver(accessKey, secretKey, tenantID, region, logger)` | Seagate Lyve Cloud | Auto-builds `s3.{region}.global.lyve.seagate.com` endpoint; tenant isolation via context key |
-| `QuotalessDriver` | `quotaless.go` | `NewQuotalessDriver(accessKey, secretKey, endpoint, logger)` | Quotaless | Embeds `*S3Driver`; 50 MB chunks; 100 MB multipart cutoff; static vs dynamic endpoint detection |
+| `QuotalessDriver` | `quotaless.go` | `NewQuotalessDriver(accessKey, secretKey, endpoint, logger)` | Quotaless | Raw HTTP + SigV4 (UNSIGNED-PAYLOAD); fixed bucket `data`; `personal-files/` prefix; TCP dial health check; default srv1 endpoint |
 | `GeyserDriver` | `geyser.go` | `NewGeyserDriver(accessKey, secretKey, bucket, tenantID, logger, ...GeyserOption)` | Spectra Logic Vail (LTO-9 tape) | Default LA endpoint; `WithGeyserEndpoint` for London; 64 MB spill threshold (RAM vs temp file); generous HTTP timeouts for tape ops |
 
 ### Not wired in main.go (scaffolds / future)
 
 | Driver | File | Constructor | Backend | Status |
 |--------|------|-------------|---------|--------|
-| `S3Driver` | `s3.go` | `NewS3Driver(endpoint, accessKey, secretKey, region, logger)` | Generic AWS S3 | Used as base for `QuotalessDriver` (embedded); not directly wired |
+| `S3Driver` | `s3.go` | `NewS3Driver(endpoint, accessKey, secretKey, region, logger)` | Generic AWS S3 | Not directly wired; legacy |
 | `IDriveDriver` | `idrive.go` | `NewIDriveDriver(accessKey, secretKey, endpoint, region, logger)` | iDrive E2 | Standalone S3-compatible driver with built-in `EgressTracker`; not yet wired |
 | `OneDriveDriver` | `onedrive.go` | `NewOneDriveDriver(clientID, clientSecret, refreshToken, tenantID, logger)` | Microsoft OneDrive (Graph API) | Scaffold only; Put/Get return "not implemented" |
 

--- a/internal/drivers/quotaless.go
+++ b/internal/drivers/quotaless.go
@@ -3,133 +3,196 @@ package drivers
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/xml"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 
 	"github.com/FairForge/vaultaire/internal/engine"
 	"go.uber.org/zap"
 )
 
-// QuotalessDriver wraps S3Driver with Quotaless-specific optimizations
-type QuotalessDriver struct {
-	*S3Driver
-	rootPath     string
-	endpoint     string
-	useMultipart bool
-	maxRetries   int
-	chunkSize    int64
-	uploadCutoff int64
-	logger       *zap.Logger
+type listResult struct {
+	XMLName  xml.Name `xml:"ListBucketResult"`
+	Contents []struct {
+		Key string `xml:"Key"`
+	} `xml:"Contents"`
 }
 
-// NewQuotalessDriver creates a Quotaless-optimized driver
+// QuotalessDriver uses raw HTTP + SigV4 signing with UNSIGNED-PAYLOAD.
+// The AWS SDK v2 S3 client is incompatible with Quotaless's Minio gateway
+// (flexible checksums corrupt downloads, streaming payload signing resets connections).
+type QuotalessDriver struct {
+	httpClient *http.Client
+	signer     *v4.Signer
+	creds      aws.CredentialsProvider
+	endpoint   string
+	bucket     string
+	rootPath   string
+	region     string
+	maxRetries int
+	logger     *zap.Logger
+}
+
 func NewQuotalessDriver(accessKey, secretKey, endpoint string, logger *zap.Logger) (*QuotalessDriver, error) {
-	// Default to US endpoint if not specified
 	if endpoint == "" {
-		endpoint = "https://us.quotaless.cloud:8000"
+		endpoint = "https://srv1.quotaless.cloud:8000"
 	}
 
-	// Determine if this is a static (single-server) or dynamic (multi-server) endpoint
 	isStaticEndpoint := strings.Contains(endpoint, "srv") ||
 		strings.Contains(endpoint, "nl.") ||
 		strings.Contains(endpoint, "us.") ||
 		strings.Contains(endpoint, "sg.")
 
-	// Create base S3 driver with Quotaless-specific settings
-	s3Driver, err := NewS3Driver(
-		endpoint,
-		accessKey,
-		secretKey,
-		"us-east-1", // Quotaless doesn't use regions
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create S3 driver: %w", err)
+	transport := &http.Transport{
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 200,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		ReadBufferSize:      256 * 1024,
+		WriteBufferSize:     256 * 1024,
+		DisableCompression:  true,
+		ForceAttemptHTTP2:   true,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: tls.NewLRUClientSessionCache(128),
+		},
 	}
-
-	// Configure based on endpoint type (per Quotaless documentation)
-	driver := &QuotalessDriver{
-		S3Driver:     s3Driver,
-		rootPath:     "personal-files",
-		endpoint:     endpoint,
-		maxRetries:   3,
-		chunkSize:    50 * 1024 * 1024,  // 50MB chunks as recommended
-		uploadCutoff: 100 * 1024 * 1024, // 100MB cutoff as recommended
-		logger:       logger,
-	}
-
-	// Static endpoints support multipart, dynamic endpoints don't
-	driver.useMultipart = isStaticEndpoint
 
 	if isStaticEndpoint {
-		logger.Info("Quotaless using static endpoint with multipart",
+		logger.Info("Quotaless using static endpoint",
 			zap.String("endpoint", endpoint))
 	} else {
-		logger.Info("Quotaless using dynamic endpoint without multipart",
+		logger.Info("Quotaless using dynamic endpoint",
 			zap.String("endpoint", endpoint))
 	}
 
-	return driver, nil
+	return &QuotalessDriver{
+		httpClient: &http.Client{Transport: transport},
+		signer:     v4.NewSigner(),
+		creds:      credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+		endpoint:   strings.TrimRight(endpoint, "/"),
+		bucket:     "data",
+		rootPath:   "personal-files",
+		region:     "us-east-1",
+		maxRetries: 3,
+		logger:     logger,
+	}, nil
 }
 
-// Put implements optimized upload for Quotaless with retry logic
-func (d *QuotalessDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error {
-	fullPath := fmt.Sprintf("%s/%s/%s", d.rootPath, container, artifact)
+func (d *QuotalessDriver) signAndDo(ctx context.Context, req *http.Request) (*http.Response, error) {
+	creds, err := d.creds.Retrieve(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve credentials: %w", err)
+	}
+	req.Header.Set("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+	if err := d.signer.SignHTTP(ctx, creds, req, "UNSIGNED-PAYLOAD", "s3", d.region, time.Now()); err != nil {
+		return nil, fmt.Errorf("sign request: %w", err)
+	}
+	return d.httpClient.Do(req)
+}
 
-	// Buffer the data for retries if it's not already seekable
-	var buffer *bytes.Buffer
-	if _, ok := data.(io.Seeker); !ok {
-		// Read into buffer for retry capability
-		buf, err := io.ReadAll(data)
+func (d *QuotalessDriver) objectURL(container, artifact string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s", d.endpoint, d.bucket, d.rootPath, container, artifact)
+}
+
+func (d *QuotalessDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error {
+	var (
+		buf    []byte
+		seeker io.ReadSeeker
+		size   int64
+	)
+
+	if rs, ok := data.(io.ReadSeeker); ok {
+		seeker = rs
+		cur, err := rs.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return fmt.Errorf("seek current: %w", err)
+		}
+		end, err := rs.Seek(0, io.SeekEnd)
+		if err != nil {
+			return fmt.Errorf("seek end: %w", err)
+		}
+		size = end - cur
+		if _, err := rs.Seek(cur, io.SeekStart); err != nil {
+			return fmt.Errorf("seek start: %w", err)
+		}
+	} else {
+		var err error
+		buf, err = io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("buffer data: %w", err)
 		}
-		buffer = bytes.NewBuffer(buf)
-		data = buffer
+		size = int64(len(buf))
 	}
 
-	// Retry logic for resilience
+	objURL := d.objectURL(container, artifact)
 	var lastErr error
 	for attempt := 0; attempt < d.maxRetries; attempt++ {
 		if attempt > 0 {
-			// Exponential backoff
 			backoff := time.Duration(attempt*attempt) * time.Second
 			d.logger.Warn("retrying upload",
 				zap.Int("attempt", attempt+1),
-				zap.String("path", fullPath),
+				zap.String("path", container+"/"+artifact),
 				zap.Duration("backoff", backoff),
 				zap.Error(lastErr))
 			time.Sleep(backoff)
+		}
 
-			// Reset reader if we buffered it
-			if buffer != nil {
-				data = bytes.NewReader(buffer.Bytes())
-			} else if seeker, ok := data.(io.Seeker); ok {
-				_, _ = seeker.Seek(0, io.SeekStart)
+		var reqBody io.Reader
+		if buf != nil {
+			reqBody = bytes.NewReader(buf)
+		} else {
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return fmt.Errorf("reset reader: %w", err)
 			}
+			reqBody = seeker
 		}
 
-		// Use the S3Driver's Put method directly
-		// Note: S3Driver.Put doesn't take variadic options, just the reader
-		lastErr = d.S3Driver.Put(ctx, "data", fullPath, data)
-
-		if lastErr == nil {
-			d.logger.Debug("upload successful",
-				zap.String("container", container),
-				zap.String("artifact", artifact),
-				zap.Int("attempts", attempt+1))
-			return nil
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, objURL, reqBody)
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
 		}
+		req.ContentLength = size
+
+		resp, err := d.signAndDo(ctx, req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("PUT %d", resp.StatusCode)
+			continue
+		}
+
+		d.logger.Debug("upload successful",
+			zap.String("container", container),
+			zap.String("artifact", artifact),
+			zap.Int("attempts", attempt+1))
+		return nil
 	}
 
 	return fmt.Errorf("upload failed after %d attempts: %w", d.maxRetries, lastErr)
 }
 
-// Get retrieves data with retry logic
 func (d *QuotalessDriver) Get(ctx context.Context, container, artifact string) (io.ReadCloser, error) {
-	fullPath := fmt.Sprintf("%s/%s/%s", d.rootPath, container, artifact)
+	objURL := d.objectURL(container, artifact)
 
 	var lastErr error
 	for attempt := 0; attempt < d.maxRetries; attempt++ {
@@ -137,25 +200,42 @@ func (d *QuotalessDriver) Get(ctx context.Context, container, artifact string) (
 			backoff := time.Duration(attempt*attempt) * time.Second
 			d.logger.Warn("retrying get",
 				zap.Int("attempt", attempt+1),
-				zap.String("path", fullPath),
+				zap.String("path", container+"/"+artifact),
 				zap.Duration("backoff", backoff),
 				zap.Error(lastErr))
 			time.Sleep(backoff)
 		}
 
-		reader, err := d.S3Driver.Get(ctx, "data", fullPath)
-		if err == nil {
-			return reader, nil
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, objURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
 		}
-		lastErr = err
+
+		resp, err := d.signAndDo(ctx, req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("object not found: %s/%s", container, artifact)
+		}
+
+		if resp.StatusCode >= 300 {
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("GET %d", resp.StatusCode)
+			continue
+		}
+
+		return resp.Body, nil
 	}
 
 	return nil, fmt.Errorf("get failed after %d attempts: %w", d.maxRetries, lastErr)
 }
 
-// Delete with retry logic
 func (d *QuotalessDriver) Delete(ctx context.Context, container, artifact string) error {
-	fullPath := fmt.Sprintf("%s/%s/%s", d.rootPath, container, artifact)
+	objURL := d.objectURL(container, artifact)
 
 	var lastErr error
 	for attempt := 0; attempt < d.maxRetries; attempt++ {
@@ -163,32 +243,53 @@ func (d *QuotalessDriver) Delete(ctx context.Context, container, artifact string
 			backoff := time.Duration(attempt*attempt) * time.Second
 			d.logger.Warn("retrying delete",
 				zap.Int("attempt", attempt+1),
-				zap.String("path", fullPath),
+				zap.String("path", container+"/"+artifact),
 				zap.Duration("backoff", backoff),
 				zap.Error(lastErr))
 			time.Sleep(backoff)
 		}
 
-		err := d.S3Driver.Delete(ctx, "data", fullPath)
-		if err == nil {
-			return nil
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, objURL, nil)
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
 		}
-		lastErr = err
+
+		resp, err := d.signAndDo(ctx, req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode >= 300 && resp.StatusCode != http.StatusNotFound {
+			lastErr = fmt.Errorf("DELETE %d", resp.StatusCode)
+			continue
+		}
+
+		return nil
 	}
 
 	return fmt.Errorf("delete failed after %d attempts: %w", d.maxRetries, lastErr)
 }
 
-// List with proper prefix handling for Quotaless structure
 func (d *QuotalessDriver) List(ctx context.Context, container string, prefix string) ([]string, error) {
 	fullPrefix := fmt.Sprintf("%s/%s/", d.rootPath, container)
 	if prefix != "" {
-		fullPrefix = fmt.Sprintf("%s%s", fullPrefix, prefix)
+		fullPrefix += prefix
 	}
 
-	var results []string
-	var lastErr error
+	u, err := url.Parse(fmt.Sprintf("%s/%s", d.endpoint, d.bucket))
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	q := u.Query()
+	q.Set("list-type", "2")
+	q.Set("prefix", fullPrefix)
+	q.Set("max-keys", "1000")
+	u.RawQuery = q.Encode()
 
+	var lastErr error
 	for attempt := 0; attempt < d.maxRetries; attempt++ {
 		if attempt > 0 {
 			backoff := time.Duration(attempt*attempt) * time.Second
@@ -200,82 +301,114 @@ func (d *QuotalessDriver) List(ctx context.Context, container string, prefix str
 			time.Sleep(backoff)
 		}
 
-		results, lastErr = d.S3Driver.List(ctx, "data", fullPrefix)
-		if lastErr == nil {
-			break
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
 		}
-	}
 
-	if lastErr != nil {
-		return nil, fmt.Errorf("list failed after %d attempts: %w", d.maxRetries, lastErr)
-	}
-
-	// Strip the prefix to return relative paths
-	prefixLen := len(fullPrefix)
-	cleaned := make([]string, 0, len(results))
-	for _, result := range results {
-		if len(result) > prefixLen {
-			cleaned = append(cleaned, result[prefixLen:])
+		resp, err := d.signAndDo(ctx, req)
+		if err != nil {
+			lastErr = err
+			continue
 		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("LIST %d", resp.StatusCode)
+			continue
+		}
+
+		var result listResult
+		if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("parse list response: %w", err)
+			continue
+		}
+		_ = resp.Body.Close()
+
+		cleaned := make([]string, 0, len(result.Contents))
+		for _, entry := range result.Contents {
+			rel := strings.TrimPrefix(entry.Key, fullPrefix)
+			if rel != "" {
+				cleaned = append(cleaned, rel)
+			}
+		}
+
+		return cleaned, nil
 	}
 
-	return cleaned, nil
+	return nil, fmt.Errorf("list failed after %d attempts: %w", d.maxRetries, lastErr)
 }
 
-// Exists checks if an object exists with retry logic
 func (d *QuotalessDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
-	fullPath := fmt.Sprintf("%s/%s/%s", d.rootPath, container, artifact)
+	objURL := d.objectURL(container, artifact)
 
 	var lastErr error
 	for attempt := 0; attempt < d.maxRetries; attempt++ {
 		if attempt > 0 {
 			backoff := time.Duration(attempt*attempt) * time.Second
-			d.logger.Warn("retrying exists",
+			d.logger.Warn("retrying exists check",
 				zap.Int("attempt", attempt+1),
-				zap.String("path", fullPath),
+				zap.String("path", container+"/"+artifact),
 				zap.Duration("backoff", backoff),
 				zap.Error(lastErr))
 			time.Sleep(backoff)
 		}
 
-		exists, err := d.S3Driver.Exists(ctx, "data", fullPath)
-		if err == nil {
-			return exists, nil
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, objURL, nil)
+		if err != nil {
+			return false, fmt.Errorf("create request: %w", err)
 		}
-		lastErr = err
+
+		resp, err := d.signAndDo(ctx, req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			return true, nil
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+
+		lastErr = fmt.Errorf("HEAD %d", resp.StatusCode)
 	}
 
-	return false, fmt.Errorf("exists failed after %d attempts: %w", d.maxRetries, lastErr)
+	return false, fmt.Errorf("exists check failed after %d attempts: %w", d.maxRetries, lastErr)
 }
 
-// HealthCheck with timeout and retry
 func (d *QuotalessDriver) HealthCheck(ctx context.Context) error {
-	// Create a timeout context for health check
-	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	// Try a simple list operation with minimal results
-	_, err := d.S3Driver.List(checkCtx, "data", d.rootPath+"/")
+	u, err := url.Parse(d.endpoint)
 	if err != nil {
-		return fmt.Errorf("health check failed: %w", err)
+		return fmt.Errorf("parse endpoint: %w", err)
 	}
-
-	return nil
+	host := u.Host
+	if !strings.Contains(host, ":") {
+		if u.Scheme == "https" {
+			host += ":443"
+		} else {
+			host += ":80"
+		}
+	}
+	conn, err := net.DialTimeout("tcp", host, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("quotaless health check: %w", err)
+	}
+	return conn.Close()
 }
 
-// GetMetrics returns performance metrics
 func (d *QuotalessDriver) GetMetrics() map[string]interface{} {
 	return map[string]interface{}{
-		"endpoint":         d.endpoint,
-		"multipart":        d.useMultipart,
-		"chunk_size_mb":    d.chunkSize / (1024 * 1024),
-		"upload_cutoff_mb": d.uploadCutoff / (1024 * 1024),
-		"max_retries":      d.maxRetries,
-		"root_path":        d.rootPath,
+		"endpoint":    d.endpoint,
+		"bucket":      d.bucket,
+		"max_retries": d.maxRetries,
+		"root_path":   d.rootPath,
 	}
 }
 
-// Name returns the driver name
 func (d *QuotalessDriver) Name() string {
 	return "quotaless"
 }

--- a/internal/drivers/quotaless_test.go
+++ b/internal/drivers/quotaless_test.go
@@ -20,10 +20,12 @@ import (
 
 // s3Mock is a minimal S3-compatible HTTP handler for unit tests.
 type s3Mock struct {
-	mu       sync.RWMutex
-	objects  map[string][]byte // bucket/key -> data
-	requests atomic.Int32
-	failN    int // fail the first N requests
+	mu          sync.RWMutex
+	objects     map[string][]byte // bucket/key -> data
+	requests    atomic.Int32
+	failN       int // fail the first N requests
+	headerMu    sync.Mutex
+	lastHeaders http.Header
 }
 
 type listBucketResult struct {
@@ -48,6 +50,10 @@ func newS3Mock() *s3Mock {
 }
 
 func (m *s3Mock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.headerMu.Lock()
+	m.lastHeaders = r.Header.Clone()
+	m.headerMu.Unlock()
+
 	n := int(m.requests.Add(1))
 	if n <= m.failN {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -161,27 +167,22 @@ func newTestQuotalessDriver(t *testing.T, mock *s3Mock) (*QuotalessDriver, *http
 
 func TestQuotaless_EndpointDiscrimination(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	mock := newS3Mock()
-	srv := httptest.NewServer(mock)
-	defer srv.Close()
 
 	cases := []struct {
-		endpoint  string
-		wantMulti bool
+		endpoint string
 	}{
-		{"https://srv1.quotaless.cloud:8000", true},
-		{"https://us.quotaless.cloud:8000", true},
-		{"https://nl.quotaless.cloud:8000", true},
-		{"https://sg.quotaless.cloud:8000", true},
-		{"https://quotaless.cloud:8000", false},
+		{"https://srv1.quotaless.cloud:8000"},
+		{"https://us.quotaless.cloud:8000"},
+		{"https://nl.quotaless.cloud:8000"},
+		{"https://sg.quotaless.cloud:8000"},
+		{"https://quotaless.cloud:8000"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.endpoint, func(t *testing.T) {
 			driver, err := NewQuotalessDriver("k", "s", tc.endpoint, logger)
 			require.NoError(t, err)
-			assert.Equal(t, tc.wantMulti, driver.useMultipart,
-				"endpoint %s: useMultipart", tc.endpoint)
+			assert.Equal(t, tc.endpoint, driver.endpoint)
 		})
 	}
 }
@@ -201,7 +202,33 @@ func TestQuotaless_RootPathPrefix(t *testing.T) {
 	assert.True(t, ok, "expected key with personal-files prefix in mock store")
 }
 
-// ── Retry on failure ─────────────────────────────────────────────────────────
+// ── Path construction ────────────────────────────────────────────────────────
+
+func TestQuotaless_PathConstruction(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	cases := []struct {
+		container, artifact, wantKey string
+	}{
+		{"mybucket", "myfile.txt", "data/personal-files/mybucket/myfile.txt"},
+		{"tenant1", "docs/report.pdf", "data/personal-files/tenant1/docs/report.pdf"},
+		{"bucket", "a/b/c/deep.bin", "data/personal-files/bucket/a/b/c/deep.bin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.wantKey, func(t *testing.T) {
+			require.NoError(t, driver.Put(ctx, tc.container, tc.artifact, strings.NewReader("x")))
+			mock.mu.RLock()
+			_, ok := mock.objects[tc.wantKey]
+			mock.mu.RUnlock()
+			assert.True(t, ok, "expected key %s in mock store", tc.wantKey)
+		})
+	}
+}
+
+// ── Retry on failure ────────────────────────────────────────────────────────
 
 func TestQuotaless_RetryOnFailure(t *testing.T) {
 	mock := newS3Mock()
@@ -214,7 +241,7 @@ func TestQuotaless_RetryOnFailure(t *testing.T) {
 	assert.GreaterOrEqual(t, int(mock.requests.Load()), 3)
 }
 
-// ── Exhausted retries ────────────────────────────────────────────────────────
+// ── Exhausted retries ───────────────────────────────────────────────────────
 
 func TestQuotaless_ExhaustedRetries(t *testing.T) {
 	mock := newS3Mock()
@@ -227,27 +254,22 @@ func TestQuotaless_ExhaustedRetries(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed after 3 attempts")
 }
 
-// ── Chunk size defaults ──────────────────────────────────────────────────────
+// ── Health check (TCP dial) ─────────────────────────────────────────────────
 
-func TestQuotaless_ChunkSizeDefaults(t *testing.T) {
+func TestQuotaless_HealthCheck_TCPDial(t *testing.T) {
 	mock := newS3Mock()
-	driver, _ := newTestQuotalessDriver(t, mock)
-
-	assert.Equal(t, int64(50*1024*1024), driver.chunkSize)
-	assert.Equal(t, int64(100*1024*1024), driver.uploadCutoff)
-}
-
-// ── Health check ─────────────────────────────────────────────────────────────
-
-func TestQuotaless_HealthCheck(t *testing.T) {
-	mock := newS3Mock()
-	driver, _ := newTestQuotalessDriver(t, mock)
+	driver, srv := newTestQuotalessDriver(t, mock)
 
 	err := driver.HealthCheck(context.Background())
 	require.NoError(t, err)
+
+	srv.Close()
+	err = driver.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "health check")
 }
 
-// ── List strips prefix ───────────────────────────────────────────────────────
+// ── List strips prefix ──────────────────────────────────────────────────────
 
 func TestQuotaless_ListStripsPrefix(t *testing.T) {
 	mock := newS3Mock()
@@ -262,7 +284,7 @@ func TestQuotaless_ListStripsPrefix(t *testing.T) {
 	assert.ElementsMatch(t, []string{"a.txt", "b.txt"}, results)
 }
 
-// ── Get round-trip ───────────────────────────────────────────────────────────
+// ── Get round-trip ──────────────────────────────────────────────────────────
 
 func TestQuotaless_GetRoundtrip(t *testing.T) {
 	mock := newS3Mock()
@@ -280,7 +302,7 @@ func TestQuotaless_GetRoundtrip(t *testing.T) {
 	assert.Equal(t, "world", string(data))
 }
 
-// ── Delete ───────────────────────────────────────────────────────────────────
+// ── Delete ──────────────────────────────────────────────────────────────────
 
 func TestQuotaless_Delete(t *testing.T) {
 	mock := newS3Mock()
@@ -296,7 +318,7 @@ func TestQuotaless_Delete(t *testing.T) {
 	assert.False(t, ok, "object should be deleted")
 }
 
-// ── Exists ───────────────────────────────────────────────────────────────────
+// ── Exists ──────────────────────────────────────────────────────────────────
 
 func TestQuotaless_Exists(t *testing.T) {
 	mock := newS3Mock()
@@ -314,7 +336,7 @@ func TestQuotaless_Exists(t *testing.T) {
 	assert.False(t, exists)
 }
 
-// ── Name ─────────────────────────────────────────────────────────────────────
+// ── Name ────────────────────────────────────────────────────────────────────
 
 func TestQuotaless_Name(t *testing.T) {
 	mock := newS3Mock()
@@ -322,7 +344,7 @@ func TestQuotaless_Name(t *testing.T) {
 	assert.Equal(t, "quotaless", driver.Name())
 }
 
-// ── Get retry ────────────────────────────────────────────────────────────────
+// ── Get retry ───────────────────────────────────────────────────────────────
 
 func TestQuotaless_GetRetryOnFailure(t *testing.T) {
 	mock := newS3Mock()
@@ -340,4 +362,20 @@ func TestQuotaless_GetRetryOnFailure(t *testing.T) {
 
 	data, _ := io.ReadAll(rc)
 	assert.Equal(t, "retried", string(data))
+}
+
+// ── UNSIGNED-PAYLOAD header ─────────────────────────────────────────────────
+
+func TestQuotaless_UnsignedPayloadHeader(t *testing.T) {
+	mock := newS3Mock()
+	driver, _ := newTestQuotalessDriver(t, mock)
+	ctx := context.Background()
+
+	require.NoError(t, driver.Put(ctx, "bucket", "file.txt", strings.NewReader("data")))
+
+	mock.headerMu.Lock()
+	h := mock.lastHeaders.Get("X-Amz-Content-Sha256")
+	mock.headerMu.Unlock()
+
+	assert.Equal(t, "UNSIGNED-PAYLOAD", h)
 }


### PR DESCRIPTION
## Summary

- **Rewrote QuotalessDriver** from AWS SDK v2 S3 client embedding to raw HTTP + SigV4 signing with `UNSIGNED-PAYLOAD`. The SDK's flexible checksum middleware corrupts downloads and streaming payload signing causes connection resets against Quotaless's Minio gateway.
- **Tuned HTTP transport**: 200 idle connections, HTTP/2, TLS 1.2+, 256KB read/write buffers — matches the proven `cmd/quotaless-bench-v2` pattern that achieves 393 MB/s download.
- **TCP dial health check** per architecture decision (HTTP health checks against S3 backends are unreliable). Default endpoint changed from `us.` to `srv1.` (2x faster, no LB overhead).

## Changes

| File | What changed |
|------|-------------|
| `internal/drivers/quotaless.go` | Full rewrite: removed `*S3Driver` embedding, added `signAndDo()` with v4 signer, raw HTTP for PUT/GET/DELETE/HEAD/LIST, `encoding/xml` for ListObjectsV2, `net.DialTimeout` health check |
| `internal/drivers/quotaless_test.go` | 13 tests: roundtrip, delete, list, exists, retry, exhausted retries, TCP health check, path construction, UNSIGNED-PAYLOAD header verification. Mock upgraded with header capture. |
| `internal/drivers/CLAUDE.md` | Updated driver table entries |

## Test plan

- [x] `go test ./internal/drivers/... -run TestQuotaless -v` — 13/13 pass
- [x] `go build ./...` — compiles clean
- [x] `make lint` — 0 issues
- [x] Pre-commit hooks (fmt, test, lint) — all pass
- [ ] CI `build-and-test` workflow