### PR TITLE
feat(email): email service with Resend, SMTP, and dev logger [Phase 5.13]

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/dashboard"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/docs"
+	"github.com/FairForge/vaultaire/internal/email"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/rbac"
 	"github.com/go-chi/chi/v5"
@@ -68,6 +69,8 @@ type Server struct {
 	mfaService       *auth.MFAService
 	mfaPendingStore  *dashboard.MFAPendingStore
 	cdnRateLimiter   *RateLimiter
+	emailSender      email.Sender
+	baseURL          string
 	startTime        time.Time
 }
 
@@ -178,11 +181,13 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		logger.Info("stripe billing service initialized")
 	}
 
-	// OAuth providers. Only active when client ID+secret are set.
+	// Base URL for OAuth callbacks and email links.
 	baseURL := os.Getenv("VAULTAIRE_BASE_URL")
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("http://localhost:%d", cfg.Server.Port)
 	}
+	s.baseURL = baseURL
+	s.emailSender = email.NewSender(logger)
 	if googleID := os.Getenv("GOOGLE_CLIENT_ID"); googleID != "" {
 		s.googleOAuth = &oauth2.Config{
 			ClientID:     googleID,
@@ -434,6 +439,8 @@ func (s *Server) setupRoutes() {
 		Google:      s.googleOAuth,
 		GitHub:      s.githubOAuth,
 		StorageMode: storageMode,
+		Email:       s.emailSender,
+		BaseURL:     s.baseURL,
 	})
 
 	s.logger.Info("Registering management API routes")
@@ -637,15 +644,18 @@ func (s *Server) handlePasswordReset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	token, err := s.auth.RequestPasswordReset(r.Context(), req.Email)
-	if err != nil {
-		http.Error(w, "Email not found", http.StatusNotFound)
-		return
+	if err == nil {
+		htmlBody, textBody, renderErr := email.RenderPasswordReset(s.baseURL, token, req.Email)
+		if renderErr != nil {
+			s.logger.Error("render password reset email", zap.Error(renderErr))
+		} else if sendErr := s.emailSender.Send(r.Context(), req.Email, "Reset your password — stored.ge", htmlBody, textBody); sendErr != nil {
+			s.logger.Error("send password reset email", zap.String("to", req.Email), zap.Error(sendErr))
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]string{
-		"message": "Reset token generated",
-		"token":   token,
+		"message": "If that email is registered, a reset link has been sent.",
 	}); err != nil {
 		s.logger.Error("failed to encode password reset response", zap.Error(err))
 	}

--- a/internal/dashboard/handlers/email_verify.go
+++ b/internal/dashboard/handlers/email_verify.go
@@ -6,13 +6,13 @@ import (
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/FairForge/vaultaire/internal/email"
 	"go.uber.org/zap"
 )
 
 // HandleResendVerification handles POST /dashboard/settings/resend-verify.
-// Generates a new verification token (the actual email sending is deferred
-// to when an email service is configured — for now the token is logged).
-func HandleResendVerification(authSvc *auth.AuthService, logger *zap.Logger) http.HandlerFunc {
+// Generates a new verification token and sends the verification email.
+func HandleResendVerification(authSvc *auth.AuthService, logger *zap.Logger, sender email.Sender, baseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sd := dashauth.GetSession(r.Context())
 		if sd == nil {
@@ -34,11 +34,17 @@ func HandleResendVerification(authSvc *auth.AuthService, logger *zap.Logger) htt
 			return
 		}
 
-		// TODO: Send email with verification link when email service is configured.
-		// For now, log the verification URL.
-		logger.Info("email verification token generated",
-			zap.String("user", sd.Email),
-			zap.String("verify_url", "/verify?token="+token))
+		htmlBody, textBody, err := email.RenderVerification(baseURL, token, sd.Email)
+		if err != nil {
+			logger.Error("render verification email", zap.Error(err))
+			middleware.SetFlash(w, "error", "Could not send verification email.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		if err := sender.Send(r.Context(), sd.Email, "Verify your email — stored.ge", htmlBody, textBody); err != nil {
+			logger.Error("send verification email", zap.String("to", sd.Email), zap.Error(err))
+		}
 
 		middleware.SetFlash(w, "success", "Verification email sent. Check your inbox.")
 		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -13,6 +13,7 @@ import (
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
 	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/FairForge/vaultaire/internal/email"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -33,6 +34,8 @@ type Deps struct {
 	Google      *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
 	GitHub      *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
 	StorageMode string                 // e.g. "local", "s3", "quotaless", "geyser", "idrive"
+	Email       email.Sender           // Email sender (LogSender if unconfigured).
+	BaseURL     string                 // Base URL for email links (e.g. "https://stored.ge").
 }
 
 // RegisterRoutes mounts the dashboard, auth, admin, and static-asset
@@ -160,7 +163,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Post("/settings/mfa/disable", handlers.HandleMFADisable(settingsTmpl, deps.Auth, deps.Logger))
 
 		// Email verification resend.
-		dr.Post("/settings/resend-verify", handlers.HandleResendVerification(deps.Auth, deps.Logger))
+		dr.Post("/settings/resend-verify", handlers.HandleResendVerification(deps.Auth, deps.Logger, deps.Email, deps.BaseURL))
 
 		// Onboarding dismiss.
 		dr.Post("/onboarding/dismiss", handlers.HandleDismissOnboarding(deps.Logger))
@@ -505,30 +508,28 @@ func handleLogout(store dashauth.SessionStore) http.HandlerFunc {
 
 // handleForgotPassword handles POST /forgot-password. It always returns the
 // same success message regardless of whether the email exists, to prevent
-// user enumeration. When the email matches a real user, a reset link is
-// generated and (eventually) emailed; for now the link is logged.
+// user enumeration.
 func handleForgotPassword(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 	tmpl := template.Must(baseTmpl.Clone())
 	template.Must(tmpl.Parse(pageContent("forgot-password")))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		email := r.FormValue("email")
+		addr := r.FormValue("email")
 
-		// Always show the same success message — never reveal whether the
-		// email is registered.
 		const successMsg = "If that email is registered, you'll receive a reset link shortly."
 
-		token, err := deps.Auth.RequestPasswordReset(r.Context(), email)
+		token, err := deps.Auth.RequestPasswordReset(r.Context(), addr)
 		if err == nil {
-			deps.Logger.Info("password reset token generated",
-				zap.String("email", email),
-				zap.String("reset_url", "/reset-password?token="+token))
+			htmlBody, textBody, renderErr := email.RenderPasswordReset(deps.BaseURL, token, addr)
+			if renderErr != nil {
+				deps.Logger.Error("render password reset email", zap.Error(renderErr))
+			} else if sendErr := deps.Email.Send(r.Context(), addr, "Reset your password — stored.ge", htmlBody, textBody); sendErr != nil {
+				deps.Logger.Error("send password reset email", zap.String("to", addr), zap.Error(sendErr))
+			}
 		} else if !errors.Is(err, auth.ErrResetRateLimited) {
-			// "user not found" — log at debug, do NOT reveal to client.
 			deps.Logger.Debug("password reset requested for unknown email",
-				zap.String("email", email), zap.Error(err))
+				zap.String("email", addr), zap.Error(err))
 		}
-		// Rate-limited requests fall through silently — same success message.
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_ = tmpl.ExecuteTemplate(w, "base", map[string]any{

--- a/internal/dashboard/router_test.go
+++ b/internal/dashboard/router_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/email"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,13 +20,16 @@ import (
 
 func setupTestRouter(t *testing.T) (chi.Router, *auth.AuthService, dashauth.SessionStore) {
 	t.Helper()
+	logger := zap.NewNop()
 	authSvc := auth.NewAuthService(nil, nil)
 	sessions := dashauth.NewMemoryStore()
 	r := chi.NewRouter()
 	RegisterRoutes(r, Deps{
 		Auth:     authSvc,
 		Sessions: sessions,
-		Logger:   zap.NewNop(),
+		Logger:   logger,
+		Email:    email.NewSender(logger),
+		BaseURL:  "http://localhost:8000",
 	})
 	return r, authSvc, sessions
 }

--- a/internal/email/CLAUDE.md
+++ b/internal/email/CLAUDE.md
@@ -1,0 +1,44 @@
+# internal/email
+
+Email service abstraction for Vaultaire. Provides a `Sender` interface with three implementations: Resend API, SMTP, and dev-mode log sender.
+
+## Architecture
+
+- **email.go** — `Sender` interface, `NewSender` factory (reads `EMAIL_PROVIDER` env var), `LogSender`, per-recipient rate limiter (10/min sliding window)
+- **resend.go** — `ResendSender`: raw `net/http` POST to Resend API (no SDK dependency)
+- **smtp.go** — `SMTPSender`: stdlib `net/smtp` with STARTTLS (port 587) and implicit TLS (port 465), multipart/alternative MIME
+- **templates.go** — `//go:embed` HTML templates, `RenderVerification`, `RenderPasswordReset`, `RenderWelcome`
+- **templates/*.html** — Branded email templates with inline CSS (no external resources)
+
+## Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `EMAIL_PROVIDER` | No | `resend`, `smtp`, or unset (log sender) |
+| `EMAIL_FROM` | No | Sender address (default `noreply@stored.ge`) |
+| `RESEND_API_KEY` | When `resend` | Resend API key |
+| `SMTP_HOST` | When `smtp` | SMTP server hostname |
+| `SMTP_PORT` | When `smtp` | SMTP port (587 for STARTTLS, 465 for implicit TLS) |
+| `SMTP_USER` | No | SMTP auth username |
+| `SMTP_PASSWORD` | No | SMTP auth password |
+
+## Integration
+
+`Sender` is injected via `dashboard.Deps.Email` and constructed in `server.go`. Handlers that send email:
+- `HandleResendVerification` (dashboard) — email verification
+- `handleForgotPassword` (dashboard) — password reset
+- `handlePasswordReset` (API) — password reset via JSON API
+
+The `LogSender` fallback is always non-nil and zero-config — dev mode logs full emails at Info level so developers can grab verification/reset links from logs.
+
+## Rate Limiting
+
+Per-recipient, 10 emails per minute sliding window. Shared across all email types. Returns `ErrRateLimited` when exceeded.
+
+## Testing
+
+```bash
+go test ./internal/email/... -v -race
+```
+
+9 tests covering: log sender, rate limiting, Resend API mock, SMTP MIME building, template rendering, factory env routing.

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -1,0 +1,115 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// ErrRateLimited is returned when a recipient exceeds the per-recipient
+// rate limit of 10 emails per minute.
+var ErrRateLimited = errors.New("email rate limit exceeded")
+
+// Sender sends emails. Implementations must be safe for concurrent use.
+type Sender interface {
+	Send(ctx context.Context, to, subject, htmlBody, textBody string) error
+}
+
+// NewSender returns a Sender based on environment configuration.
+// EMAIL_PROVIDER selects the backend: "resend", "smtp", or anything else
+// falls back to LogSender (logs the full email, zero config).
+func NewSender(logger *zap.Logger) Sender {
+	from := os.Getenv("EMAIL_FROM")
+	if from == "" {
+		from = "noreply@stored.ge"
+	}
+
+	rl := &rateLimiter{
+		window:   make(map[string][]time.Time),
+		limit:    10,
+		interval: time.Minute,
+	}
+
+	switch os.Getenv("EMAIL_PROVIDER") {
+	case "resend":
+		apiKey := os.Getenv("RESEND_API_KEY")
+		if apiKey == "" {
+			logger.Warn("EMAIL_PROVIDER=resend but RESEND_API_KEY is empty, falling back to log sender")
+			return &LogSender{logger: logger, rl: rl}
+		}
+		return &ResendSender{apiKey: apiKey, from: from, rl: rl}
+	case "smtp":
+		host := os.Getenv("SMTP_HOST")
+		port := os.Getenv("SMTP_PORT")
+		if host == "" || port == "" {
+			logger.Warn("EMAIL_PROVIDER=smtp but SMTP_HOST/SMTP_PORT missing, falling back to log sender")
+			return &LogSender{logger: logger, rl: rl}
+		}
+		return &SMTPSender{
+			host:     host,
+			port:     port,
+			user:     os.Getenv("SMTP_USER"),
+			password: os.Getenv("SMTP_PASSWORD"),
+			from:     from,
+			rl:       rl,
+		}
+	default:
+		return &LogSender{logger: logger, rl: rl}
+	}
+}
+
+// LogSender logs emails at Info level instead of sending them.
+// Used in development and as the zero-config fallback.
+type LogSender struct {
+	logger *zap.Logger
+	rl     *rateLimiter
+}
+
+func (s *LogSender) Send(_ context.Context, to, subject, htmlBody, textBody string) error {
+	if err := s.rl.check(to); err != nil {
+		return err
+	}
+	s.logger.Info("email (dev mode — not sent)",
+		zap.String("to", to),
+		zap.String("subject", subject),
+		zap.String("html", htmlBody),
+		zap.String("text", textBody))
+	return nil
+}
+
+// rateLimiter enforces a per-recipient sliding window rate limit.
+type rateLimiter struct {
+	mu       sync.Mutex
+	window   map[string][]time.Time
+	limit    int
+	interval time.Duration
+}
+
+func (rl *rateLimiter) check(recipient string) error {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rl.interval)
+
+	entries := rl.window[recipient]
+	kept := entries[:0]
+	for _, t := range entries {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+
+	if len(kept) >= rl.limit {
+		rl.window[recipient] = kept
+		return fmt.Errorf("%w: %s (max %d per %s)", ErrRateLimited, recipient, rl.limit, rl.interval)
+	}
+
+	rl.window[recipient] = append(kept, now)
+	return nil
+}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -1,0 +1,227 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestLogSender_Send(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	sender := &LogSender{logger: logger, rl: newTestRateLimiter()}
+	err := sender.Send(context.Background(), "user@example.com", "Test Subject", "<h1>Hi</h1>", "Hi")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, logs.Len())
+
+	entry := logs.All()[0]
+	assert.Equal(t, "email (dev mode — not sent)", entry.Message)
+
+	fields := make(map[string]string)
+	for _, f := range entry.Context {
+		fields[f.Key] = f.String
+	}
+	assert.Equal(t, "user@example.com", fields["to"])
+	assert.Equal(t, "Test Subject", fields["subject"])
+	assert.Equal(t, "<h1>Hi</h1>", fields["html"])
+	assert.Equal(t, "Hi", fields["text"])
+}
+
+func TestLogSender_RateLimit(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	sender := &LogSender{logger: logger, rl: newTestRateLimiter()}
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		err := sender.Send(ctx, "flood@example.com", "msg", "<p>x</p>", "x")
+		require.NoError(t, err, "send %d should succeed", i)
+	}
+
+	err := sender.Send(ctx, "flood@example.com", "msg", "<p>x</p>", "x")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRateLimited))
+
+	err = sender.Send(ctx, "other@example.com", "msg", "<p>x</p>", "x")
+	require.NoError(t, err, "different recipient should not be rate limited")
+}
+
+func TestResendSender_Send(t *testing.T) {
+	var gotBody resendRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_123"}`))
+	}))
+	defer server.Close()
+
+	sender := &ResendSender{apiKey: "test-api-key", from: "noreply@stored.ge", rl: newTestRateLimiter()}
+	origSend := sender.Send
+
+	// Patch the URL by wrapping Send — instead, use httptest.NewServer and
+	// override the Resend URL for testing. Since we can't easily override a
+	// const URL, we'll test the request building via the mock server.
+	_ = origSend
+
+	// For the actual test, use a custom HTTP client approach. Since ResendSender
+	// uses http.DefaultClient, we swap the transport.
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &rewriteTransport{base: origTransport, target: server.URL}
+	defer func() { http.DefaultTransport = origTransport }()
+
+	err := sender.Send(context.Background(), "user@example.com", "Hello", "<h1>Hi</h1>", "Hi")
+	require.NoError(t, err)
+
+	assert.Equal(t, "noreply@stored.ge", gotBody.From)
+	assert.Equal(t, []string{"user@example.com"}, gotBody.To)
+	assert.Equal(t, "Hello", gotBody.Subject)
+	assert.Equal(t, "<h1>Hi</h1>", gotBody.HTML)
+	assert.Equal(t, "Hi", gotBody.Text)
+}
+
+func TestResendSender_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"invalid from address"}`))
+	}))
+	defer server.Close()
+
+	sender := &ResendSender{apiKey: "test-key", from: "bad@x", rl: newTestRateLimiter()}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &rewriteTransport{base: origTransport, target: server.URL}
+	defer func() { http.DefaultTransport = origTransport }()
+
+	err := sender.Send(context.Background(), "user@example.com", "Subj", "<p>x</p>", "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "422")
+	assert.Contains(t, err.Error(), "invalid from address")
+}
+
+func TestSMTPSender_BuildMessage(t *testing.T) {
+	msg := buildMIMEMessage("noreply@stored.ge", "user@example.com", "Test Subject", "<h1>Hi</h1>", "Hi")
+	s := string(msg)
+
+	assert.Contains(t, s, "From: noreply@stored.ge")
+	assert.Contains(t, s, "To: user@example.com")
+	assert.Contains(t, s, "Subject: Test Subject")
+	assert.Contains(t, s, "MIME-Version: 1.0")
+	assert.Contains(t, s, "multipart/alternative")
+	assert.Contains(t, s, "text/plain")
+	assert.Contains(t, s, "text/html")
+	assert.Contains(t, s, "<h1>Hi</h1>")
+	assert.Contains(t, s, "Hi")
+}
+
+func TestRenderVerification(t *testing.T) {
+	html, text, err := RenderVerification("https://stored.ge", "abc123", "user@example.com")
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "https://stored.ge/verify?token=abc123")
+	assert.Contains(t, html, "user@example.com")
+	assert.Contains(t, html, "Verify")
+
+	assert.Contains(t, text, "https://stored.ge/verify?token=abc123")
+	assert.NotContains(t, text, "<")
+}
+
+func TestRenderPasswordReset(t *testing.T) {
+	html, text, err := RenderPasswordReset("https://stored.ge", "reset-tok", "user@example.com")
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "https://stored.ge/reset-password?token=reset-tok")
+	assert.Contains(t, html, "user@example.com")
+	assert.Contains(t, html, "Reset")
+
+	assert.Contains(t, text, "https://stored.ge/reset-password?token=reset-tok")
+	assert.NotContains(t, text, "<")
+}
+
+func TestRenderWelcome(t *testing.T) {
+	html, text, err := RenderWelcome("user@example.com", "AKID12345")
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "AKID12345")
+	assert.Contains(t, html, "Welcome")
+	assert.Contains(t, html, "stored.ge")
+
+	assert.Contains(t, text, "AKID12345")
+	assert.NotContains(t, text, "<")
+}
+
+func TestNewSender_EnvRouting(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Default: LogSender.
+	s := NewSender(logger)
+	assert.IsType(t, &LogSender{}, s)
+
+	// Resend with key.
+	t.Setenv("EMAIL_PROVIDER", "resend")
+	t.Setenv("RESEND_API_KEY", "re_test123")
+	s = NewSender(logger)
+	assert.IsType(t, &ResendSender{}, s)
+
+	// Resend without key falls back.
+	t.Setenv("RESEND_API_KEY", "")
+	s = NewSender(logger)
+	assert.IsType(t, &LogSender{}, s)
+
+	// SMTP with config.
+	t.Setenv("EMAIL_PROVIDER", "smtp")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_PORT", "587")
+	s = NewSender(logger)
+	assert.IsType(t, &SMTPSender{}, s)
+
+	// SMTP without config falls back.
+	t.Setenv("SMTP_HOST", "")
+	s = NewSender(logger)
+	assert.IsType(t, &LogSender{}, s)
+
+	// Unknown provider.
+	t.Setenv("EMAIL_PROVIDER", "mailgun")
+	s = NewSender(logger)
+	assert.IsType(t, &LogSender{}, s)
+}
+
+// rewriteTransport redirects HTTPS requests to the test server.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "resend.com") {
+		u, _ := http.NewRequest(req.Method, t.target+req.URL.Path, req.Body)
+		u.Header = req.Header
+		return t.base.RoundTrip(u)
+	}
+	return t.base.RoundTrip(req)
+}
+
+func newTestRateLimiter() *rateLimiter {
+	return &rateLimiter{
+		window:   make(map[string][]time.Time),
+		limit:    10,
+		interval: time.Minute,
+	}
+}

--- a/internal/email/resend.go
+++ b/internal/email/resend.go
@@ -1,0 +1,63 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ResendSender sends emails via the Resend API (https://resend.com).
+// Uses raw net/http — no external SDK dependency.
+type ResendSender struct {
+	apiKey string
+	from   string
+	rl     *rateLimiter
+}
+
+type resendRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html"`
+	Text    string   `json:"text"`
+}
+
+func (s *ResendSender) Send(ctx context.Context, to, subject, htmlBody, textBody string) error {
+	if err := s.rl.check(to); err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(resendRequest{
+		From:    s.from,
+		To:      []string{to},
+		Subject: subject,
+		HTML:    htmlBody,
+		Text:    textBody,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal resend request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend API request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("resend API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -1,0 +1,109 @@
+package email
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+)
+
+// SMTPSender sends emails via a generic SMTP server.
+// Supports STARTTLS (port 587) and implicit TLS (port 465).
+type SMTPSender struct {
+	host     string
+	port     string
+	user     string
+	password string
+	from     string
+	rl       *rateLimiter
+}
+
+func (s *SMTPSender) Send(_ context.Context, to, subject, htmlBody, textBody string) error {
+	if err := s.rl.check(to); err != nil {
+		return err
+	}
+
+	msg := buildMIMEMessage(s.from, to, subject, htmlBody, textBody)
+	addr := net.JoinHostPort(s.host, s.port)
+
+	if s.port == "465" {
+		return s.sendImplicitTLS(addr, to, msg)
+	}
+	return s.sendSTARTTLS(addr, to, msg)
+}
+
+func (s *SMTPSender) sendSTARTTLS(addr, to string, msg []byte) error {
+	var a smtp.Auth
+	if s.user != "" {
+		a = smtp.PlainAuth("", s.user, s.password, s.host)
+	}
+	return smtp.SendMail(addr, a, s.from, []string{to}, msg)
+}
+
+func (s *SMTPSender) sendImplicitTLS(addr, to string, msg []byte) error {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: s.host})
+	if err != nil {
+		return fmt.Errorf("tls dial %s: %w", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	c, err := smtp.NewClient(conn, s.host)
+	if err != nil {
+		return fmt.Errorf("smtp client: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if s.user != "" {
+		if err := c.Auth(smtp.PlainAuth("", s.user, s.password, s.host)); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+	if err := c.Mail(s.from); err != nil {
+		return fmt.Errorf("smtp mail: %w", err)
+	}
+	if err := c.Rcpt(to); err != nil {
+		return fmt.Errorf("smtp rcpt: %w", err)
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("smtp write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp close data: %w", err)
+	}
+	return c.Quit()
+}
+
+const boundary = "----vaultaire-email-boundary"
+
+func buildMIMEMessage(from, to, subject, htmlBody, textBody string) []byte {
+	var b strings.Builder
+	b.WriteString("From: " + from + "\r\n")
+	b.WriteString("To: " + to + "\r\n")
+	b.WriteString("Subject: " + subject + "\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: multipart/alternative; boundary=\"" + boundary + "\"\r\n")
+	b.WriteString("\r\n")
+
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
+	b.WriteString("Content-Transfer-Encoding: 7bit\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(textBody)
+	b.WriteString("\r\n")
+
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n")
+	b.WriteString("Content-Transfer-Encoding: 7bit\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(htmlBody)
+	b.WriteString("\r\n")
+
+	b.WriteString("--" + boundary + "--\r\n")
+	return []byte(b.String())
+}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -1,0 +1,81 @@
+package email
+
+import (
+	"bytes"
+	"embed"
+	"html/template"
+	"regexp"
+	"strings"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+var templates = template.Must(template.ParseFS(templateFS, "templates/*.html"))
+
+var tagRe = regexp.MustCompile(`<[^>]*>`)
+
+func stripTags(html string) string {
+	text := tagRe.ReplaceAllString(html, "")
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func render(name string, data any) (htmlBody, textBody string, err error) {
+	var buf bytes.Buffer
+	if err := templates.ExecuteTemplate(&buf, name, data); err != nil {
+		return "", "", err
+	}
+	htmlBody = buf.String()
+	textBody = stripTags(htmlBody)
+	return htmlBody, textBody, nil
+}
+
+type verificationData struct {
+	BaseURL string
+	Token   string
+	Email   string
+}
+
+// RenderVerification renders the email verification template.
+func RenderVerification(baseURL, token, email string) (string, string, error) {
+	return render("verification.html", verificationData{
+		BaseURL: baseURL,
+		Token:   token,
+		Email:   email,
+	})
+}
+
+type passwordResetData struct {
+	BaseURL string
+	Token   string
+	Email   string
+}
+
+// RenderPasswordReset renders the password reset template.
+func RenderPasswordReset(baseURL, token, email string) (string, string, error) {
+	return render("password_reset.html", passwordResetData{
+		BaseURL: baseURL,
+		Token:   token,
+		Email:   email,
+	})
+}
+
+type welcomeData struct {
+	Email     string
+	AccessKey string
+}
+
+// RenderWelcome renders the welcome email template.
+func RenderWelcome(email, accessKey string) (string, string, error) {
+	return render("welcome.html", welcomeData{
+		Email:     email,
+		AccessKey: accessKey,
+	})
+}

--- a/internal/email/templates/password_reset.html
+++ b/internal/email/templates/password_reset.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;">
+  <tr><td style="background-color:#18181b;padding:24px 32px;">
+    <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.5px;">stored.ge</span>
+  </td></tr>
+  <tr><td style="padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:22px;color:#18181b;">Reset your password</h1>
+    <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#3f3f46;">
+      We received a password reset request for <strong>{{.Email}}</strong>.
+      Click the button below to choose a new password. This link expires in 1 hour.
+    </p>
+    <table cellpadding="0" cellspacing="0"><tr><td style="background-color:#2563eb;border-radius:6px;">
+      <a href="{{.BaseURL}}/reset-password?token={{.Token}}"
+         style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">
+        Reset Password
+      </a>
+    </td></tr></table>
+    <p style="margin:24px 0 0;font-size:13px;line-height:1.5;color:#71717a;">
+      If the button doesn't work, copy and paste this link into your browser:<br>
+      {{.BaseURL}}/reset-password?token={{.Token}}
+    </p>
+  </td></tr>
+  <tr><td style="padding:16px 32px;background-color:#fafafa;border-top:1px solid #e4e4e7;">
+    <p style="margin:0;font-size:12px;color:#a1a1aa;">
+      If you didn't request a password reset, you can safely ignore this email.
+      Your password will remain unchanged.
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/internal/email/templates/verification.html
+++ b/internal/email/templates/verification.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;">
+  <tr><td style="background-color:#18181b;padding:24px 32px;">
+    <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.5px;">stored.ge</span>
+  </td></tr>
+  <tr><td style="padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:22px;color:#18181b;">Verify your email</h1>
+    <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#3f3f46;">
+      Click the button below to verify <strong>{{.Email}}</strong> on stored.ge.
+      This link expires in 24 hours.
+    </p>
+    <table cellpadding="0" cellspacing="0"><tr><td style="background-color:#2563eb;border-radius:6px;">
+      <a href="{{.BaseURL}}/verify?token={{.Token}}"
+         style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">
+        Verify Email
+      </a>
+    </td></tr></table>
+    <p style="margin:24px 0 0;font-size:13px;line-height:1.5;color:#71717a;">
+      If the button doesn't work, copy and paste this link into your browser:<br>
+      {{.BaseURL}}/verify?token={{.Token}}
+    </p>
+  </td></tr>
+  <tr><td style="padding:16px 32px;background-color:#fafafa;border-top:1px solid #e4e4e7;">
+    <p style="margin:0;font-size:12px;color:#a1a1aa;">
+      If you didn't create an account on stored.ge, you can safely ignore this email.
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/internal/email/templates/welcome.html
+++ b/internal/email/templates/welcome.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;">
+  <tr><td style="background-color:#18181b;padding:24px 32px;">
+    <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.5px;">stored.ge</span>
+  </td></tr>
+  <tr><td style="padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:22px;color:#18181b;">Welcome to stored.ge</h1>
+    <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#3f3f46;">
+      Your account is ready. Here's your S3-compatible access key to get started:
+    </p>
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;border-radius:6px;margin-bottom:24px;">
+      <tr><td style="padding:16px;">
+        <p style="margin:0 0 4px;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.5px;">Access Key</p>
+        <p style="margin:0;font-size:15px;font-family:monospace;color:#18181b;">{{.AccessKey}}</p>
+      </td></tr>
+    </table>
+    <h2 style="margin:0 0 12px;font-size:16px;color:#18181b;">Quick start</h2>
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <tr><td style="padding:8px 0;">
+        <a href="https://stored.ge/dashboard" style="color:#2563eb;font-size:14px;text-decoration:none;font-weight:500;">Dashboard</a>
+        <span style="color:#a1a1aa;font-size:14px;"> — manage buckets, keys, and usage</span>
+      </td></tr>
+      <tr><td style="padding:8px 0;">
+        <a href="https://stored.ge/llms.txt" style="color:#2563eb;font-size:14px;text-decoration:none;font-weight:500;">API Docs</a>
+        <span style="color:#a1a1aa;font-size:14px;"> — S3-compatible REST API reference</span>
+      </td></tr>
+    </table>
+  </td></tr>
+  <tr><td style="padding:16px 32px;background-color:#fafafa;border-top:1px solid #e4e4e7;">
+    <p style="margin:0;font-size:12px;color:#a1a1aa;">
+      $3.99/TB S3-compatible storage — stored.ge
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `internal/email` package with `Sender` interface and three implementations: Resend API (raw net/http), generic SMTP (STARTTLS + implicit TLS), and zero-config dev LogSender
- Per-recipient rate limiting (10/min sliding window) shared across all email types
- Branded HTML email templates for verification, password reset, and welcome emails
- Wired into all three existing handler stubs: dashboard resend-verify, dashboard forgot-password, and API password reset
- API password reset endpoint no longer leaks the reset token in the response body (anti-enumeration fix)
- 9 tests covering all senders, rate limiting, template rendering, and env-based factory routing

## Test plan
- [x] `go test ./internal/email/... -v -race` — 9/9 pass
- [x] `go test ./internal/dashboard/... -short -race` — all pass (including existing password reset tests)
- [x] `go test ./internal/api/... -short -race` — passes
- [x] `golangci-lint run ./internal/email/... ./internal/dashboard/... ./internal/api/...` — 0 issues
- [x] Pre-commit hooks (fmt, test, lint) all pass
- [ ] Set `EMAIL_PROVIDER=resend` + `RESEND_API_KEY` in staging to verify real email delivery
- [ ] Phase 5.13.2 (DNS: SPF/DKIM/DMARC records) is manual ops — not part of this PR