### PR TITLE
feat(cdn): CDN access analytics + bandwidth budgets [Phase 5.11.12]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -18,6 +18,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3_presign.go** — Pre-signed URL verification (SigV4 query string auth) and URL generation
 - **presigned.go** — Management API endpoint for generating pre-signed URLs (`/api/v1/presigned`)
 - **sts_routes.go** — STS temporary credential endpoint (`POST /api/v1/sts/token`)
+- **cdn_analytics.go** — CDNAnalyticsTracker: buffered CDN access event writer (Record/Flush/CheckBudget) + hourly rollup
 - **management.go** — JSON response helpers: `writeJSON`, `writeListResponse`, `getRequestID` (Stripe-style envelope)
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
@@ -148,6 +149,18 @@ JSON REST layer at `/api/v1/manage/` with JWT auth and per-tenant rate limiting.
 **Rate limiting**: `ManagementRateLimiter` — per-tenant token bucket (100 req/min), separate from the CDN per-IP limiter. Evicts if >10K tenants. Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers; returns `Retry-After` on 429.
 
 **Cursor pagination**: queries `LIMIT N+1`; if N+1 results → `has_more=true`, returns first N, `next_cursor` = last item's name/key.
+
+## CDN Access Analytics (Phase 5.11.12)
+
+`CDNAnalyticsTracker` in `cdn_analytics.go` buffers CDN access events in memory and flushes them to `cdn_access_log` every 5 seconds (or at 100 events). Follows the same pattern as `BandwidthTracker`. Initialized in `NewServer()`, nil-safe throughout.
+
+- **Record()** — called from `handleCDNRequest` after successful GET (both full and range). Captures tenant, bucket, key, bytes, country (CF-IPCountry header), referer. Skips HEAD/OPTIONS.
+- **CheckBudget()** — called before object lookup in `handleCDNRequest`. Queries `buckets.bandwidth_budget_bytes` and `cdn_stats_daily` for current month total (plus in-memory buffer). Returns 429 with `Retry-After: 3600` if exceeded. Budget of 0 = unlimited.
+- **StartRollup()** — hourly goroutine aggregates `cdn_access_log` into `cdn_stats_daily` (requests, bytes_sent, unique_objects per tenant/bucket/date).
+
+Dashboard analytics page at `/dashboard/buckets/{name}/analytics` (handler in `internal/dashboard/handlers/bucket_analytics.go`). Shows 24h/7d/30d downloads + bandwidth, top objects, geographic breakdown, budget gauge. Only linked from bucket objects page for public-read buckets.
+
+Tables: `cdn_access_log`, `cdn_stats_daily` (migration 035).
 
 ## Tenant Context
 

--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -57,6 +57,16 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.cdnAnalytics != nil {
+		if _, _, exceeded := s.cdnAnalytics.CheckBudget(ctx, tenantID, bucket); exceeded {
+			w.Header().Set("Retry-After", "3600")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"bandwidth budget exceeded for this bucket"}`))
+			return
+		}
+	}
+
 	var sizeBytes int64
 	var etag, contentType string
 	var updatedAt time.Time
@@ -125,6 +135,10 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 		if s.bandwidthTracker != nil {
 			s.bandwidthTracker.Record(ctx, tenantID, 0, rng.length)
 		}
+		if s.cdnAnalytics != nil {
+			s.cdnAnalytics.Record(ctx, tenantID, bucket, key, rng.length,
+				r.Header.Get("CF-IPCountry"), r.Referer())
+		}
 		return
 	}
 
@@ -138,6 +152,10 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 
 	if s.bandwidthTracker != nil {
 		s.bandwidthTracker.Record(ctx, tenantID, 0, written)
+	}
+	if s.cdnAnalytics != nil {
+		s.cdnAnalytics.Record(ctx, tenantID, bucket, key, written,
+			r.Header.Get("CF-IPCountry"), r.Referer())
 	}
 
 	s.logger.Debug("cdn served",

--- a/internal/api/cdn_analytics.go
+++ b/internal/api/cdn_analytics.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type cdnAccessEvent struct {
+	tenantID  string
+	bucket    string
+	objectKey string
+	bytesSent int64
+	country   string
+	referer   string
+}
+
+// CDNAnalyticsTracker buffers CDN access events and flushes them to the
+// cdn_access_log table periodically. Follows the same pattern as BandwidthTracker.
+type CDNAnalyticsTracker struct {
+	db     *sql.DB
+	mu     sync.Mutex
+	buffer []cdnAccessEvent
+	logger *zap.Logger
+}
+
+func NewCDNAnalyticsTracker(db *sql.DB) *CDNAnalyticsTracker {
+	return &CDNAnalyticsTracker{
+		db:     db,
+		buffer: make([]cdnAccessEvent, 0, 128),
+	}
+}
+
+func (ct *CDNAnalyticsTracker) SetLogger(logger *zap.Logger) {
+	ct.logger = logger
+}
+
+// Record appends a CDN access event to the buffer. Auto-flushes at 100 events.
+func (ct *CDNAnalyticsTracker) Record(_ context.Context, tenantID, bucket, objectKey string, bytesSent int64, country, referer string) {
+	if tenantID == "" || bucket == "" {
+		return
+	}
+
+	ct.mu.Lock()
+	ct.buffer = append(ct.buffer, cdnAccessEvent{
+		tenantID:  tenantID,
+		bucket:    bucket,
+		objectKey: objectKey,
+		bytesSent: bytesSent,
+		country:   country,
+		referer:   referer,
+	})
+	needsFlush := len(ct.buffer) >= 100
+	ct.mu.Unlock()
+
+	if needsFlush {
+		ct.Flush()
+	}
+}
+
+// StartFlusher runs a background goroutine that flushes the buffer every interval.
+func (ct *CDNAnalyticsTracker) StartFlusher(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				ct.Flush()
+				return
+			case <-ticker.C:
+				ct.Flush()
+			}
+		}
+	}()
+}
+
+// Flush writes all buffered events to the cdn_access_log table.
+func (ct *CDNAnalyticsTracker) Flush() {
+	ct.mu.Lock()
+	if len(ct.buffer) == 0 {
+		ct.mu.Unlock()
+		return
+	}
+	events := ct.buffer
+	ct.buffer = make([]cdnAccessEvent, 0, 128)
+	ct.mu.Unlock()
+
+	if ct.db == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, e := range events {
+		_, err := ct.db.ExecContext(ctx, `
+			INSERT INTO cdn_access_log (tenant_id, bucket, object_key, bytes_sent, country, referer)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, e.tenantID, e.bucket, e.objectKey, e.bytesSent, e.country, e.referer)
+		if err != nil && ct.logger != nil {
+			ct.logger.Error("flush cdn access log",
+				zap.String("tenant_id", e.tenantID), zap.Error(err))
+		}
+	}
+}
+
+// StartRollup runs a background goroutine that aggregates cdn_access_log into
+// cdn_stats_daily once per hour.
+func (ct *CDNAnalyticsTracker) StartRollup(ctx context.Context) {
+	if ct.db == nil {
+		return
+	}
+	go func() {
+		ct.runRollup()
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ct.runRollup()
+			}
+		}
+	}()
+}
+
+func (ct *CDNAnalyticsTracker) runRollup() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := ct.db.ExecContext(ctx, `
+		INSERT INTO cdn_stats_daily (tenant_id, bucket, date, requests, bytes_sent, unique_objects)
+		SELECT tenant_id, bucket, DATE(accessed_at), COUNT(*), SUM(bytes_sent), COUNT(DISTINCT object_key)
+		FROM cdn_access_log
+		WHERE accessed_at >= CURRENT_DATE
+		GROUP BY tenant_id, bucket, DATE(accessed_at)
+		ON CONFLICT (tenant_id, bucket, date)
+		DO UPDATE SET requests = EXCLUDED.requests,
+		             bytes_sent = EXCLUDED.bytes_sent,
+		             unique_objects = EXCLUDED.unique_objects
+	`)
+	if err != nil && ct.logger != nil {
+		ct.logger.Error("cdn stats rollup", zap.Error(err))
+	}
+}
+
+// CheckBudget returns the bandwidth used this month, the budget limit, and
+// whether the budget has been exceeded. A budget of 0 means unlimited.
+func (ct *CDNAnalyticsTracker) CheckBudget(ctx context.Context, tenantID, bucket string) (used, limit int64, exceeded bool) {
+	if ct.db == nil {
+		return 0, 0, false
+	}
+
+	var budgetBytes int64
+	err := ct.db.QueryRowContext(ctx,
+		`SELECT bandwidth_budget_bytes FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, bucket).Scan(&budgetBytes)
+	if err != nil || budgetBytes <= 0 {
+		return 0, 0, false
+	}
+
+	var monthBytes int64
+	err = ct.db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(bytes_sent), 0) FROM cdn_stats_daily
+		WHERE tenant_id = $1 AND bucket = $2
+		  AND date >= date_trunc('month', CURRENT_DATE)
+	`, tenantID, bucket).Scan(&monthBytes)
+	if err != nil {
+		return 0, budgetBytes, false
+	}
+
+	// Also sum in-memory buffer for tighter enforcement.
+	ct.mu.Lock()
+	for _, e := range ct.buffer {
+		if e.tenantID == tenantID && e.bucket == bucket {
+			monthBytes += e.bytesSent
+		}
+	}
+	ct.mu.Unlock()
+
+	return monthBytes, budgetBytes, monthBytes >= budgetBytes
+}

--- a/internal/api/cdn_analytics_test.go
+++ b/internal/api/cdn_analytics_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCDNAnalyticsTracker_RecordAndBuffer(t *testing.T) {
+	// Arrange
+	ct := NewCDNAnalyticsTracker(nil)
+
+	// Act
+	ct.Record(context.Background(), "tenant-1", "my-bucket", "photo.jpg", 1024, "US", "https://example.com")
+	ct.Record(context.Background(), "tenant-1", "my-bucket", "video.mp4", 5000, "GB", "")
+	ct.Record(context.Background(), "tenant-2", "other", "file.txt", 256, "", "")
+
+	// Assert
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	require.Len(t, ct.buffer, 3)
+	assert.Equal(t, "tenant-1", ct.buffer[0].tenantID)
+	assert.Equal(t, "my-bucket", ct.buffer[0].bucket)
+	assert.Equal(t, "photo.jpg", ct.buffer[0].objectKey)
+	assert.Equal(t, int64(1024), ct.buffer[0].bytesSent)
+	assert.Equal(t, "US", ct.buffer[0].country)
+	assert.Equal(t, "https://example.com", ct.buffer[0].referer)
+}
+
+func TestCDNAnalyticsTracker_SkipsEmptyTenantOrBucket(t *testing.T) {
+	ct := NewCDNAnalyticsTracker(nil)
+
+	// Act — empty tenant
+	ct.Record(context.Background(), "", "bucket", "key", 100, "", "")
+	// Act — empty bucket
+	ct.Record(context.Background(), "tenant", "", "key", 100, "", "")
+
+	// Assert
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	assert.Empty(t, ct.buffer)
+}
+
+func TestCDNAnalyticsTracker_FlushClearsBuffer(t *testing.T) {
+	// Arrange
+	ct := NewCDNAnalyticsTracker(nil) // nil DB — flush drains buffer silently
+
+	ct.Record(context.Background(), "t1", "b1", "k1", 100, "", "")
+	ct.Record(context.Background(), "t1", "b1", "k2", 200, "", "")
+
+	// Act
+	ct.Flush()
+
+	// Assert
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	assert.Empty(t, ct.buffer)
+}
+
+func TestCDNAnalyticsTracker_FlushNoopWhenEmpty(t *testing.T) {
+	ct := NewCDNAnalyticsTracker(nil)
+
+	// Should not panic or error
+	ct.Flush()
+
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	assert.Empty(t, ct.buffer)
+}
+
+func TestCDNAnalyticsTracker_AutoFlushAt100(t *testing.T) {
+	ct := NewCDNAnalyticsTracker(nil) // nil DB — auto-flush drains silently
+
+	for i := 0; i < 100; i++ {
+		ct.Record(context.Background(), "t1", "b1", "key", 10, "", "")
+	}
+
+	// After 100 records, auto-flush should have cleared the buffer
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	assert.Empty(t, ct.buffer)
+}
+
+func TestCDNAnalyticsTracker_CheckBudget_NilDB(t *testing.T) {
+	ct := NewCDNAnalyticsTracker(nil)
+
+	used, limit, exceeded := ct.CheckBudget(context.Background(), "t1", "b1")
+
+	assert.Equal(t, int64(0), used)
+	assert.Equal(t, int64(0), limit)
+	assert.False(t, exceeded)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -69,6 +69,7 @@ type Server struct {
 	mfaService       *auth.MFAService
 	mfaPendingStore  *dashboard.MFAPendingStore
 	cdnRateLimiter   *RateLimiter
+	cdnAnalytics     *CDNAnalyticsTracker
 	emailSender      email.Sender
 	baseURL          string
 	startTime        time.Time
@@ -167,6 +168,12 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	s.bandwidthTracker = NewBandwidthTracker(s.db)
 	s.bandwidthTracker.SetLogger(logger)
 	s.bandwidthTracker.StartFlusher(context.Background(), 5*time.Second)
+
+	// CDN analytics tracker — buffers CDN access events and flushes to DB.
+	s.cdnAnalytics = NewCDNAnalyticsTracker(s.db)
+	s.cdnAnalytics.SetLogger(logger)
+	s.cdnAnalytics.StartFlusher(context.Background(), 5*time.Second)
+	s.cdnAnalytics.StartRollup(context.Background())
 
 	// Stripe billing service. Only active when STRIPE_SECRET_KEY is set.
 	if stripeKey := os.Getenv("STRIPE_SECRET_KEY"); stripeKey != "" {

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -54,6 +54,7 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/dashboard/buckets/{name}` | GET | session | Object browser with prefix navigation |
 | `/dashboard/buckets/{name}/settings` | GET | session | Bucket settings: visibility, CDN URL, cache, CORS |
 | `/dashboard/buckets/{name}/settings` | POST | session | Update bucket visibility, cache TTL, CORS origins |
+| `/dashboard/buckets/{name}/analytics` | GET | session | CDN analytics: downloads, bandwidth, top objects, geo |
 | `/dashboard/apikeys` | GET | session | List API keys with status |
 | `/dashboard/apikeys` | POST | session | Generate new API key (shows secret once) |
 | `/dashboard/apikeys/{id}/revoke` | POST | session | Revoke an API key |

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -100,6 +100,12 @@ The onboarding card in `dashboard.html` shows a 3-item checklist (bucket, object
 
 **Dashboard upgrade CTA** (`populateStorageUsage` in `overview.go`): sets `ShowUpgradeCTA = true` when tier is "free" and storage usage is >= 80%. The CTA card in `dashboard.html` links to `/dashboard/billing`.
 
+## Bucket Analytics (`bucket_analytics.go`)
+
+`HandleBucketAnalytics(tmpl, db, logger)` renders the CDN analytics page at `/dashboard/buckets/{name}/analytics`. Queries `cdn_stats_daily` for 24h/7d/30d download counts and bandwidth, `cdn_access_log` for top objects and geographic breakdown, and `buckets.bandwidth_budget_bytes` for budget gauge. Degrades to zero-state when DB is nil or tables are empty. Template: `templates/customer/bucket_analytics.html`.
+
+Analytics link only appears in `bucket_objects.html` for public-read buckets (gated on `{{if .CDNBaseURL}}`).
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/bucket_analytics.go
+++ b/internal/dashboard/handlers/bucket_analytics.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"html/template"
+	"net/http"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// TopObject is a single row in the "top objects by downloads" table.
+type TopObject struct {
+	Key       string
+	Downloads int64
+	Bandwidth string
+}
+
+// CountryRow is a single row in the geographic breakdown table.
+type CountryRow struct {
+	Code      string
+	Requests  int64
+	Bandwidth string
+}
+
+// HandleBucketAnalytics renders the CDN analytics page for a bucket.
+func HandleBucketAnalytics(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		bucketName := chi.URLParam(r, "name")
+		if bucketName == "" {
+			http.Redirect(w, r, "/dashboard/buckets", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "buckets")
+		data["BucketName"] = bucketName
+
+		if db != nil {
+			ctx := r.Context()
+			populateAnalyticsStats(ctx, db, sd.TenantID, bucketName, data)
+			populateTopObjects(ctx, db, sd.TenantID, bucketName, data)
+			populateBudget(ctx, db, sd.TenantID, bucketName, data)
+			populateCountries(ctx, db, sd.TenantID, bucketName, data)
+		}
+
+		_, hasDownloads := data["Downloads24h"]
+		if !hasDownloads {
+			setAnalyticsDefaults(data)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render bucket analytics", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func populateAnalyticsStats(ctx context.Context, db *sql.DB, tenantID, bucket string, data map[string]any) {
+	var dl24h, dl7d, dl30d, bw24h, bw7d, bw30d int64
+
+	_ = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(requests), 0), COALESCE(SUM(bytes_sent), 0)
+		FROM cdn_stats_daily
+		WHERE tenant_id = $1 AND bucket = $2 AND date >= CURRENT_DATE - INTERVAL '1 day'`,
+		tenantID, bucket).Scan(&dl24h, &bw24h)
+
+	_ = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(requests), 0), COALESCE(SUM(bytes_sent), 0)
+		FROM cdn_stats_daily
+		WHERE tenant_id = $1 AND bucket = $2 AND date >= CURRENT_DATE - INTERVAL '7 days'`,
+		tenantID, bucket).Scan(&dl7d, &bw7d)
+
+	_ = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(requests), 0), COALESCE(SUM(bytes_sent), 0)
+		FROM cdn_stats_daily
+		WHERE tenant_id = $1 AND bucket = $2 AND date >= CURRENT_DATE - INTERVAL '30 days'`,
+		tenantID, bucket).Scan(&dl30d, &bw30d)
+
+	data["Downloads24h"] = dl24h
+	data["Downloads7d"] = dl7d
+	data["Downloads30d"] = dl30d
+	data["Bandwidth24h"] = formatBytes(bw24h)
+	data["Bandwidth7d"] = formatBytes(bw7d)
+	data["Bandwidth30d"] = formatBytes(bw30d)
+	data["HasData"] = dl30d > 0
+}
+
+func populateTopObjects(ctx context.Context, db *sql.DB, tenantID, bucket string, data map[string]any) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT object_key, COUNT(*) AS downloads, SUM(bytes_sent) AS bandwidth
+		FROM cdn_access_log
+		WHERE tenant_id = $1 AND bucket = $2
+		  AND accessed_at >= NOW() - INTERVAL '30 days'
+		GROUP BY object_key
+		ORDER BY COUNT(*) DESC
+		LIMIT 10`, tenantID, bucket)
+	if err != nil {
+		data["TopObjects"] = nil
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var objects []TopObject
+	for rows.Next() {
+		var o TopObject
+		var bw int64
+		if err := rows.Scan(&o.Key, &o.Downloads, &bw); err != nil {
+			continue
+		}
+		o.Bandwidth = formatBytes(bw)
+		objects = append(objects, o)
+	}
+	data["TopObjects"] = objects
+}
+
+func populateBudget(ctx context.Context, db *sql.DB, tenantID, bucket string, data map[string]any) {
+	var budgetBytes int64
+	err := db.QueryRowContext(ctx,
+		`SELECT bandwidth_budget_bytes FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, bucket).Scan(&budgetBytes)
+	if err != nil || budgetBytes <= 0 {
+		data["HasBudget"] = false
+		data["BudgetUsed"] = "0 B"
+		data["BudgetLimit"] = "0 B"
+		data["BudgetPct"] = 0
+		return
+	}
+
+	var usedBytes int64
+	_ = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(bytes_sent), 0) FROM cdn_stats_daily
+		WHERE tenant_id = $1 AND bucket = $2
+		  AND date >= date_trunc('month', CURRENT_DATE)`,
+		tenantID, bucket).Scan(&usedBytes)
+
+	pct := 0
+	if budgetBytes > 0 {
+		pct = int(usedBytes * 100 / budgetBytes)
+		if pct > 100 {
+			pct = 100
+		}
+	}
+
+	data["HasBudget"] = true
+	data["BudgetUsed"] = formatBytes(usedBytes)
+	data["BudgetLimit"] = formatBytes(budgetBytes)
+	data["BudgetPct"] = pct
+}
+
+func populateCountries(ctx context.Context, db *sql.DB, tenantID, bucket string, data map[string]any) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT country, COUNT(*) AS requests, SUM(bytes_sent) AS bandwidth
+		FROM cdn_access_log
+		WHERE tenant_id = $1 AND bucket = $2
+		  AND accessed_at >= NOW() - INTERVAL '30 days'
+		GROUP BY country
+		ORDER BY COUNT(*) DESC
+		LIMIT 20`, tenantID, bucket)
+	if err != nil {
+		data["Countries"] = nil
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var countries []CountryRow
+	for rows.Next() {
+		var c CountryRow
+		var bw int64
+		if err := rows.Scan(&c.Code, &c.Requests, &bw); err != nil {
+			continue
+		}
+		if c.Code == "" {
+			c.Code = "Unknown"
+		}
+		c.Bandwidth = formatBytes(bw)
+		countries = append(countries, c)
+	}
+	data["Countries"] = countries
+}
+
+func setAnalyticsDefaults(data map[string]any) {
+	data["Downloads24h"] = int64(0)
+	data["Downloads7d"] = int64(0)
+	data["Downloads30d"] = int64(0)
+	data["Bandwidth24h"] = "0 B"
+	data["Bandwidth7d"] = "0 B"
+	data["Bandwidth30d"] = "0 B"
+	data["HasData"] = false
+	data["TopObjects"] = nil
+	data["HasBudget"] = false
+	data["BudgetUsed"] = "0 B"
+	data["BudgetLimit"] = "0 B"
+	data["BudgetPct"] = 0
+	data["Countries"] = nil
+}

--- a/internal/dashboard/handlers/bucket_analytics_test.go
+++ b/internal/dashboard/handlers/bucket_analytics_test.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func testAnalyticsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Analytics{{end}}` +
+			`{{define "content"}}` +
+			`<h1>{{.BucketName}}</h1>` +
+			`<span class="dl24">{{.Downloads24h}}</span>` +
+			`<span class="bw24">{{.Bandwidth24h}}</span>` +
+			`<span class="dl7">{{.Downloads7d}}</span>` +
+			`<span class="dl30">{{.Downloads30d}}</span>` +
+			`<span class="hasdata">{{.HasData}}</span>` +
+			`{{if .HasBudget}}<span class="budget">{{.BudgetPct}}%</span>{{end}}` +
+			`{{range .TopObjects}}<span class="top">{{.Key}}</span>{{end}}` +
+			`{{range .Countries}}<span class="geo">{{.Code}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleBucketAnalytics_NilDB(t *testing.T) {
+	// Arrange
+	tmpl := testAnalyticsTemplate(t)
+	handler := HandleBucketAnalytics(tmpl, nil, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "test-bucket")
+
+	sd := &dashauth.SessionData{
+		UserID: "user-1", TenantID: "tenant-1",
+		Email: "test@stored.ge", Role: "user",
+	}
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets/test-bucket/analytics", nil)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert — renders with defaults, no crash
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "test-bucket")
+	assert.Contains(t, body, `<span class="dl24">0</span>`)
+	assert.Contains(t, body, `<span class="bw24">0 B</span>`)
+	assert.Contains(t, body, `<span class="hasdata">false</span>`)
+}
+
+func TestHandleBucketAnalytics_NoSession(t *testing.T) {
+	tmpl := testAnalyticsTemplate(t)
+	handler := HandleBucketAnalytics(tmpl, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets/test-bucket/analytics", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert — redirects to login
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleBucketAnalytics_EmptyBucketName(t *testing.T) {
+	tmpl := testAnalyticsTemplate(t)
+	handler := HandleBucketAnalytics(tmpl, nil, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	// No "name" param set
+
+	sd := &dashauth.SessionData{
+		UserID: "user-1", TenantID: "tenant-1",
+		Email: "test@stored.ge", Role: "user",
+	}
+
+	req := httptest.NewRequest("GET", "/dashboard/buckets//analytics", nil)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert — redirects to bucket list
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/buckets", w.Header().Get("Location"))
+}
+
+func TestSetAnalyticsDefaults(t *testing.T) {
+	data := map[string]any{}
+
+	setAnalyticsDefaults(data)
+
+	assert.Equal(t, int64(0), data["Downloads24h"])
+	assert.Equal(t, int64(0), data["Downloads7d"])
+	assert.Equal(t, int64(0), data["Downloads30d"])
+	assert.Equal(t, "0 B", data["Bandwidth24h"])
+	assert.Equal(t, "0 B", data["Bandwidth7d"])
+	assert.Equal(t, "0 B", data["Bandwidth30d"])
+	assert.Equal(t, false, data["HasData"])
+	assert.Equal(t, false, data["HasBudget"])
+	assert.Nil(t, data["TopObjects"])
+	assert.Nil(t, data["Countries"])
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -123,6 +123,13 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Get("/buckets/{name}/settings", handlers.HandleBucketSettings(bucketSettingsTmpl, deps.DB, deps.Logger))
 		dr.Post("/buckets/{name}/settings", handlers.HandleUpdateBucketSettings(bucketSettingsTmpl, deps.DB, deps.Logger))
 
+		// Bucket CDN analytics.
+		analyticsTmpl := template.Must(baseTmpl.Clone())
+		template.Must(analyticsTmpl.ParseFS(Templates,
+			"templates/customer/bucket_analytics.html",
+		))
+		dr.Get("/buckets/{name}/analytics", handlers.HandleBucketAnalytics(analyticsTmpl, deps.DB, deps.Logger))
+
 		// API key management.
 		apikeysTmpl := template.Must(baseTmpl.Clone())
 		template.Must(apikeysTmpl.ParseFS(Templates,

--- a/internal/dashboard/templates/customer/bucket_analytics.html
+++ b/internal/dashboard/templates/customer/bucket_analytics.html
@@ -1,0 +1,115 @@
+{{define "title"}}{{.BucketName}} Analytics — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>{{.BucketName}}</h1>
+        <p class="text-muted">CDN Analytics</p>
+    </div>
+    <a href="/dashboard/buckets/{{.BucketName}}/settings" class="btn">Settings</a>
+</div>
+
+<nav class="breadcrumb">
+    <a href="/dashboard/">Dashboard</a> /
+    <a href="/dashboard/buckets">Buckets</a> /
+    <a href="/dashboard/buckets/{{.BucketName}}">{{.BucketName}}</a> /
+    <strong>Analytics</strong>
+</nav>
+
+{{if not .HasData}}
+<div class="card" style="text-align:center;padding:3rem 1.5rem;">
+    <div style="font-size:2rem;margin-bottom:0.75rem;">&#128202;</div>
+    <h2 style="margin-bottom:0.5rem;">No CDN traffic yet</h2>
+    <p class="text-muted">Analytics will appear once objects in this bucket are accessed via the CDN.</p>
+    <a href="/dashboard/buckets/{{.BucketName}}/settings" class="btn btn-primary" style="margin-top:1rem;">Configure CDN</a>
+</div>
+{{else}}
+
+<div class="stats-grid stats-grid-3">
+    <div class="stat-card">
+        <div class="stat-label">Downloads (24h)</div>
+        <div class="stat-value">{{.Downloads24h}}</div>
+        <div class="stat-sub">{{.Bandwidth24h}} transferred</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Downloads (7d)</div>
+        <div class="stat-value">{{.Downloads7d}}</div>
+        <div class="stat-sub">{{.Bandwidth7d}} transferred</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Downloads (30d)</div>
+        <div class="stat-value">{{.Downloads30d}}</div>
+        <div class="stat-sub">{{.Bandwidth30d}} transferred</div>
+    </div>
+</div>
+
+{{if .HasBudget}}
+<div class="card">
+    <div class="card-title">Bandwidth Budget</div>
+    <div class="gauge-row">
+        <div class="gauge-bar">
+            <div class="gauge-fill{{if ge .BudgetPct 90}} gauge-danger{{else if ge .BudgetPct 75}} gauge-warn{{end}}" style="width:{{.BudgetPct}}%"></div>
+        </div>
+        <span class="gauge-text">{{.BudgetUsed}} / {{.BudgetLimit}} ({{.BudgetPct}}%)</span>
+    </div>
+    {{if ge .BudgetPct 90}}
+    <p class="text-muted" style="margin-top:0.5rem;color:var(--danger);">
+        Approaching budget limit. CDN serving will pause when the budget is exceeded.
+    </p>
+    {{end}}
+</div>
+{{end}}
+
+{{if .TopObjects}}
+<div class="card">
+    <div class="card-title">Top Objects (30 days)</div>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Object Key</th>
+                    <th style="text-align:right">Downloads</th>
+                    <th style="text-align:right">Bandwidth</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .TopObjects}}
+                <tr>
+                    <td><code style="font-size:0.85rem;word-break:break-all;">{{.Key}}</code></td>
+                    <td style="text-align:right">{{.Downloads}}</td>
+                    <td style="text-align:right">{{.Bandwidth}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}
+
+{{if .Countries}}
+<div class="card">
+    <div class="card-title">Geographic Breakdown (30 days)</div>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Country</th>
+                    <th style="text-align:right">Requests</th>
+                    <th style="text-align:right">Bandwidth</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Countries}}
+                <tr>
+                    <td>{{.Code}}</td>
+                    <td style="text-align:right">{{.Requests}}</td>
+                    <td style="text-align:right">{{.Bandwidth}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}
+
+{{end}}
+{{end}}

--- a/internal/dashboard/templates/customer/bucket_objects.html
+++ b/internal/dashboard/templates/customer/bucket_objects.html
@@ -5,7 +5,10 @@
         <h1>{{.BucketName}}</h1>
         <p class="text-muted">{{.ObjectCount}} object{{if ne .ObjectCount 1}}s{{end}} &middot; {{.TotalSizeFmt}}</p>
     </div>
-    <a href="/dashboard/buckets/{{.BucketName}}/settings" class="btn">Settings</a>
+    <div>
+        {{if .CDNBaseURL}}<a href="/dashboard/buckets/{{.BucketName}}/analytics" class="btn">Analytics</a>{{end}}
+        <a href="/dashboard/buckets/{{.BucketName}}/settings" class="btn">Settings</a>
+    </div>
 </div>
 
 <nav class="breadcrumb">

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -26,6 +26,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 032 | STS temporary credentials: `sts_tokens` table (access_key PK, secret_key, tenant_id, parent_key_id, permissions JSONB, bucket_scope TEXT[], ip_restrict TEXT[], expires_at, created_at) |
 | 033 | Event log + webhooks: `events` table, `webhook_endpoints` table (with secret, event_filter TEXT[]), `webhook_deliveries` table (status, response_code, latency_ms, retry support) |
 | 034 | Free tier defaults: `tenant_quotas` column defaults changed to tier='free', storage_limit_bytes=5368709120 (5 GB). Existing rows unchanged. |
+| 035 | CDN analytics: `cdn_access_log` (per-request log), `cdn_stats_daily` (tenant+bucket+date rollup) |
 
 ## Key Tables
 
@@ -48,6 +49,8 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **events** — `id (PK)`, `type`, `tenant_id`, `data` (JSONB), `created_at` — persistent event log
 - **webhook_endpoints** — `id (PK)`, `tenant_id`, `url`, `event_filter` (TEXT[]), `secret`, `enabled`, `created_at`, `updated_at` — webhook subscriptions
 - **webhook_deliveries** — `id (PK)`, `webhook_id → webhook_endpoints`, `event_id → events`, `status`, `response_code`, `response_body`, `latency_ms`, `retry_count`, `next_retry_at`, `created_at` — delivery tracking
+- **cdn_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `bytes_sent`, `country`, `referer`, `accessed_at` — raw CDN access events
+- **cdn_stats_daily** — `(tenant_id, bucket, date) PK`, `requests`, `bytes_sent`, `unique_objects` — daily CDN rollup
 
 ## Connection
 

--- a/internal/database/migrations/035_cdn_analytics.sql
+++ b/internal/database/migrations/035_cdn_analytics.sql
@@ -1,0 +1,30 @@
+-- 035_cdn_analytics.sql
+-- Phase 5.11.12: CDN access analytics and bandwidth budgets [CD-8]
+-- Idempotent — safe to re-run on every deploy
+
+CREATE TABLE IF NOT EXISTS cdn_access_log (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    object_key TEXT NOT NULL,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    country TEXT NOT NULL DEFAULT '',
+    referer TEXT NOT NULL DEFAULT '',
+    accessed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cdn_access_log_tenant_bucket
+    ON cdn_access_log (tenant_id, bucket, accessed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cdn_access_log_accessed
+    ON cdn_access_log (accessed_at);
+
+CREATE TABLE IF NOT EXISTS cdn_stats_daily (
+    tenant_id TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
+    requests BIGINT NOT NULL DEFAULT 0,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    unique_objects INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, bucket, date)
+);


### PR DESCRIPTION
## Summary

- Wire `CDNAnalyticsTracker` into server: buffered CDN access event logging (5s flush / 100-event auto-flush), hourly rollup into `cdn_stats_daily`
- Bandwidth budget enforcement in CDN handler — returns 429 with `Retry-After` when a bucket's monthly budget is exceeded
- Dashboard analytics page at `/dashboard/buckets/{name}/analytics`: 24h/7d/30d download counts + bandwidth, top objects, geographic breakdown, budget gauge
- "Analytics" nav link on bucket objects page (only for public-read CDN-enabled buckets)
- Migration 035: `cdn_access_log` + `cdn_stats_daily` tables

## Files

| Area | Files | Purpose |
|------|-------|---------|
| Tracker | `cdn_analytics.go`, `cdn_analytics_test.go` | Buffered writer + budget check + rollup |
| CDN handler | `cdn.go` | Record() after GET, CheckBudget() before object lookup |
| Server init | `server.go` | Init tracker, start flusher + rollup goroutines |
| Dashboard | `router.go`, `bucket_analytics.go`, `bucket_analytics_test.go` | Route + handler + tests |
| Template | `bucket_analytics.html`, `bucket_objects.html` | Analytics page + nav link |
| Migration | `035_cdn_analytics.sql` | Two new tables |

## Test plan

- [x] All existing tests pass (`go test -race -short ./...`)
- [x] Pre-commit hooks pass (fmt, test, lint)
- [x] 5 unit tests for CDNAnalyticsTracker (record, skip empty, flush, auto-flush, nil DB budget)
- [x] 4 unit tests for HandleBucketAnalytics (nil DB, no session, empty bucket, defaults)
- [ ] CI build-and-test