### PR TITLE
fix: gitignore bench-results subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,9 +128,9 @@ cmd/geyser-smoke/
 /vaultaire-bin
 
 # Benchmark result data (track .md docs, ignore raw data)
-bench-results/*.json
-bench-results/*.json.tmp
-bench-results/*.log
+bench-results/**/*.json
+bench-results/**/*.json.tmp
+bench-results/**/*.log
 bench-results/**/results.csv
 
 # Claude Code


### PR DESCRIPTION
## Summary

- Change `bench-results/*.json` to `bench-results/**/*.json` (and same for `.json.tmp` and `.log`)
- Single-level globs missed files in subdirectories like `bench-results/vaultaire-e2e/`

## Test plan

- [x] `git status` confirms the 6 untracked `vaultaire-e2e/*.json` files are now ignored