### PR TITLE
feat(engine): multi-backend failover + storage class routing [Phase 5.12.4]

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -155,6 +155,10 @@ func (s *Server) handleHealthEnhanced(w http.ResponseWriter, r *http.Request) {
 		"backends_total":   total,
 	}
 
+	if s.engine != nil {
+		resp["circuit_breakers"] = s.engine.GetFailoverStatus()
+	}
+
 	// Add backend details if requested
 	if r.URL.Query().Get("details") == "true" {
 		backends := make(map[string]interface{})

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	"github.com/FairForge/vaultaire/internal/common"
+	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/events"
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
@@ -525,12 +526,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	var etag, contentType string
 	var updatedAt time.Time
 	var metadataJSON []byte
+	var backendName string
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}')
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, '')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -565,7 +567,7 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	} else {
 		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
 	}
-	w.Header().Set("x-amz-storage-class", "STANDARD")
+	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(backendName))
 	w.Header().Set("x-amz-request-id", generateRequestID())
 	setS3MetadataHeaders(w, metadataJSON)
 	// HEAD must not write a body.

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -205,13 +206,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedETag string
 	var cachedUpdatedAt time.Time
 	var cachedMetadata []byte
+	var cachedBackendName string
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}')
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, '')
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName)
 		if err == nil {
 			cacheHit = true
 		}
@@ -234,7 +236,10 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 
 	reader, err := a.engine.Get(r.Context(), container, artifact)
 	if err != nil {
-		if strings.Contains(err.Error(), "no such file or directory") ||
+		if errors.Is(err, engine.ErrAllBackendsUnavailable) {
+			w.Header().Set("Retry-After", "30")
+			WriteS3Error(w, ErrServiceUnavailable, r.URL.Path, generateRequestID())
+		} else if strings.Contains(err.Error(), "no such file or directory") ||
 			strings.Contains(err.Error(), "not found") {
 			reqID := generateRequestID()
 			if suggestion := keySuggestion(r.Context(), a.db, t.ID, bucket, artifact); suggestion != "" {
@@ -280,6 +285,7 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("Cache-Control", "private, no-cache")
+	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(cachedBackendName))
 	if cacheHit {
 		if cachedSize > 0 {
 			w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
@@ -416,14 +422,24 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	hasher := md5.New() // #nosec G401 — S3 spec requires MD5 for ETags
 	hashingBody := io.TeeReader(body, hasher)
 
-	backendName, err := a.engine.Put(r.Context(), container, artifact, hashingBody,
-		engine.WithContentLength(size))
+	storageClass := r.Header.Get("x-amz-storage-class")
+	putOpts := []engine.PutOption{engine.WithContentLength(size)}
+	if storageClass != "" {
+		putOpts = append(putOpts, engine.WithStorageClass(storageClass))
+	}
+
+	backendName, err := a.engine.Put(r.Context(), container, artifact, hashingBody, putOpts...)
 	if err != nil {
-		a.logger.Error("engine put failed",
-			zap.Error(err),
-			zap.String("container", container),
-			zap.String("artifact", artifact))
-		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		if errors.Is(err, engine.ErrAllBackendsUnavailable) {
+			w.Header().Set("Retry-After", "30")
+			WriteS3Error(w, ErrServiceUnavailable, r.URL.Path, generateRequestID())
+		} else {
+			a.logger.Error("engine put failed",
+				zap.Error(err),
+				zap.String("container", container),
+				zap.String("artifact", artifact))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		}
 		return
 	}
 

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -53,6 +53,7 @@ const (
 	ErrAuthorizationQueryParametersError = "AuthorizationQueryParametersError"
 	ErrInvalidPresignExpires             = "AuthorizationQueryParametersError_Expires"
 	ErrQuotaExceeded                     = "QuotaExceeded"
+	ErrServiceUnavailable                = "ServiceUnavailable"
 )
 
 // Error messages
@@ -89,6 +90,7 @@ var errorMessages = map[string]string{
 	ErrAuthorizationQueryParametersError: "Query-string authentication requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-SignedHeaders, and X-Amz-Signature parameters",
 	ErrInvalidPresignExpires:             "X-Amz-Expires must be between 1 and 604800 seconds",
 	ErrQuotaExceeded:                     "Storage quota exceeded. Upgrade your plan for more storage.",
+	ErrServiceUnavailable:                "All storage backends are temporarily unavailable. Please retry.",
 }
 
 // HTTP status codes for errors
@@ -125,6 +127,7 @@ var errorStatusCodes = map[string]int{
 	ErrAuthorizationQueryParametersError: http.StatusBadRequest,
 	ErrInvalidPresignExpires:             http.StatusBadRequest,
 	ErrQuotaExceeded:                     http.StatusForbidden,
+	ErrServiceUnavailable:                http.StatusServiceUnavailable,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/engine/CLAUDE.md
+++ b/internal/engine/CLAUDE.md
@@ -11,9 +11,9 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 
 ## Request Flow
 
-- **Put**: cost optimizer recommends backend → write to chosen driver → record mapping in `objectBackends` sync.Map → invalidate cache → optionally replicate to backup async
-- **Get**: check `objectBackends` map for backend name → check tiered cache (L1) → fetch from driver → cache result
-- **Delete**: delete from ALL backends → remove from `objectBackends` → invalidate cache
+- **Put**: resolve storage class → build candidate list (target, primary, others) → failover.Execute tries in order → record mapping in `objectBackends` sync.Map → invalidate cache → optionally replicate to backup async
+- **Get**: check `objectBackends` map for backend name → check tiered cache (L1) → failover.Execute with candidate list → cache result
+- **Delete**: failover.Execute against recorded backend (+ primary fallback) → remove from `objectBackends` → invalidate cache
 - **List**: delegates to primary driver only
 
 ## Important: objectBackends is in-memory
@@ -25,7 +25,7 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 | File | Type | Purpose |
 |------|------|---------|
 | `types.go` | `Container`, `Artifact` | Domain types (internal names for bucket/object) |
-| `errors.go` | `NotFoundError`, `PermissionError` | Error types + sentinels (`ErrQuotaExceeded`, `ErrInvalidInput`) |
+| `errors.go` | `NotFoundError`, `PermissionError` | Error types + sentinels (`ErrQuotaExceeded`, `ErrInvalidInput`, `ErrAllBackendsUnavailable`) |
 | `context.go` | helpers | `WithTenantID`, `TenantIDFromContext`, `WithRequestID` |
 | `selector.go` | `BackendSelector` | Chooses backend by health score (≥50 = healthy) |
 | `cost_optimizer.go` | `CostOptimizer` | Routes by size: small→fastest, large→cheapest |
@@ -37,6 +37,27 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 | `capacity.go` | `CapacityPlanner` | Linear regression to predict when backends fill |
 | `disaster_recovery.go` | `DisasterRecovery` | Failover configs, recovery plans (RTO/RPO) |
 | `sla.go` | `SLAMonitor` | SLA compliance tracking, violation detection |
+| `failover.go` | `FailoverManager`, `BackendCircuitBreaker` | Per-backend circuit breaker (5 failures/60s → open, 30s → half-open → probe) + ordered failover execution |
+| `storage_class.go` | `ResolveStorageClass`, `BackendToStorageClass` | S3 storage class ↔ backend name mapping (STANDARD→idrive, GLACIER→geyser, etc.) |
+
+## Circuit Breaker (Phase 5.12.4)
+
+Each registered backend gets an independent `BackendCircuitBreaker`:
+- **Closed** (healthy): all requests pass through
+- **Open** (broken): after 5 consecutive failures within 60s — all requests rejected
+- **Half-Open** (probing): after 30s in open state — allows one probe; success → closed, failure → open
+
+`FailoverManager.Execute(ctx, candidates, fn)` iterates the candidate list in order, skipping backends with open breakers, recording success/failure. Returns the first successful backend name.
+
+## Storage Class Routing (Phase 5.12.4)
+
+`x-amz-storage-class` header on PUT maps to a target backend:
+- STANDARD → idrive, STANDARD_IA → lyve, GLACIER/DEEP_ARCHIVE → geyser
+- ONEZONE_IA → onedrive, REDUCED_REDUNDANCY → local
+
+If the target backend isn't registered, falls back to primary silently. Storage class is a hint, never an error.
+
+`BackendToStorageClass(backendName)` provides the reverse mapping for GET/HEAD responses.
 
 ## Connection to Other Layers
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -33,6 +33,7 @@ type CoreEngine struct {
 	quota         QuotaManager
 	selector      *BackendSelector
 	costOptimizer *CostOptimizer
+	failover      *FailoverManager
 
 	intelligence *intelligence.AccessTracker
 	cache        *cache.TieredCache
@@ -76,6 +77,7 @@ func NewEngine(db *sql.DB, logger *zap.Logger, config *Config) *CoreEngine {
 		config:        config,
 		selector:      NewBackendSelector(),
 		costOptimizer: NewCostOptimizer(),
+		failover:      NewFailoverManager(logger),
 	}
 
 	if db != nil {
@@ -106,6 +108,7 @@ func (e *CoreEngine) AddDriver(name string, driver Driver) {
 	if e.primary == "" {
 		e.primary = name
 	}
+	e.failover.Register(name)
 	e.logger.Info("driver added",
 		zap.String("name", name),
 		zap.Bool("is_primary", e.primary == name))
@@ -167,10 +170,10 @@ func (e *CoreEngine) Get(ctx context.Context, container, artifact string) (io.Re
 	}
 
 	// L2: look up which backend this object was written to.
-	backendName := e.primary
+	preferredBackend := e.primary
 	if v, ok := e.objectBackends.Load(objectKey(container, artifact)); ok {
 		if name, ok := v.(string); ok && name != "" {
-			backendName = name
+			preferredBackend = name
 		}
 	}
 
@@ -178,26 +181,26 @@ func (e *CoreEngine) Get(ctx context.Context, container, artifact string) (io.Re
 	if e.intelligence != nil {
 		if rec := e.intelligence.GetRecommendation(tenantID, container, artifact); rec != nil {
 			e.logger.Debug("intelligence recommendation (not used for routing)",
-				zap.String("actual_backend", backendName),
+				zap.String("actual_backend", preferredBackend),
 				zap.String("recommended", rec.PreferredBackend),
 				zap.String("reason", rec.Reason))
 		}
 	}
 
-	driver, ok := e.drivers[backendName]
-	if !ok {
-		// Backend from the map no longer exists — fall back to primary.
-		e.logger.Warn("recorded backend not found, falling back to primary",
-			zap.String("recorded", backendName),
-			zap.String("primary", e.primary))
-		driver, ok = e.drivers[e.primary]
-		if !ok {
-			return nil, fmt.Errorf("no driver available")
-		}
-		backendName = e.primary
-	}
+	// Build candidate list: preferred backend first, then primary, then others.
+	candidates := e.buildCandidateList(preferredBackend)
 
-	reader, err := driver.Get(ctx, container, artifact)
+	var reader io.ReadCloser
+	usedBackend, err := e.failover.Execute(ctx, candidates, func(driverName string) error {
+		d, ok := e.drivers[driverName]
+		if !ok {
+			return fmt.Errorf("driver %s not found", driverName)
+		}
+		var getErr error
+		reader, getErr = d.Get(ctx, container, artifact)
+		return getErr
+	})
+
 	if e.intelligence != nil {
 		e.intelligence.LogAccess(ctx, intelligence.AccessEvent{
 			TenantID:  tenantID,
@@ -205,14 +208,14 @@ func (e *CoreEngine) Get(ctx context.Context, container, artifact string) (io.Re
 			Artifact:  artifact,
 			Operation: "GET",
 			Latency:   time.Since(start),
-			Backend:   backendName,
+			Backend:   usedBackend,
 			CacheHit:  false,
 			Timestamp: time.Now(),
 			Success:   err == nil,
 		})
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get from %s: %w", backendName, err)
+		return nil, fmt.Errorf("get %s/%s: %w", container, artifact, err)
 	}
 
 	if e.cache != nil && e.config.EnableCaching {
@@ -252,16 +255,16 @@ func (e *CoreEngine) Put(ctx context.Context, container, artifact string, data i
 		}()
 	}
 
-	// Select the backend for this write.
-	// Intelligence recommendations are accepted here — on PUT we want smart
-	// routing. The key guarantee is that we record what we chose so Get
-	// can honour it exactly.
-	backendName := e.primary
-	if e.intelligence != nil {
+	// Resolve storage class from options to determine target backend.
+	options := ApplyPutOptions(opts...)
+	targetBackend, _ := ResolveStorageClass(options.StorageClass, e.primary, e.drivers)
+
+	// Intelligence recommendations override if no explicit storage class was set.
+	if options.StorageClass == "" && e.intelligence != nil {
 		if rec := e.intelligence.GetRecommendation(tenantID, container, artifact); rec != nil {
 			if rec.PreferredBackend != "" {
 				if _, exists := e.drivers[rec.PreferredBackend]; exists {
-					backendName = rec.PreferredBackend
+					targetBackend = rec.PreferredBackend
 				} else {
 					e.logger.Warn("intelligence recommended non-existent backend, using primary",
 						zap.String("recommended", rec.PreferredBackend),
@@ -271,12 +274,16 @@ func (e *CoreEngine) Put(ctx context.Context, container, artifact string, data i
 		}
 	}
 
-	driver, ok := e.drivers[backendName]
-	if !ok {
-		return "", fmt.Errorf("driver %s not found", backendName)
-	}
+	// Build candidate list: target first, then primary, then others.
+	candidates := e.buildCandidateList(targetBackend)
 
-	err := driver.Put(ctx, container, artifact, sizeReader, opts...)
+	usedBackend, err := e.failover.Execute(ctx, candidates, func(driverName string) error {
+		d, ok := e.drivers[driverName]
+		if !ok {
+			return fmt.Errorf("driver %s not found", driverName)
+		}
+		return d.Put(ctx, container, artifact, sizeReader, opts...)
+	})
 
 	if e.intelligence != nil {
 		e.intelligence.LogAccess(ctx, intelligence.AccessEvent{
@@ -286,18 +293,17 @@ func (e *CoreEngine) Put(ctx context.Context, container, artifact string, data i
 			Operation: "PUT",
 			Size:      sizeReader.bytesRead,
 			Latency:   time.Since(start),
-			Backend:   backendName,
+			Backend:   usedBackend,
 			Timestamp: time.Now(),
 			Success:   err == nil,
 		})
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("put to %s: %w", backendName, err)
+		return "", fmt.Errorf("put %s/%s: %w", container, artifact, err)
 	}
 
-	// Record backend for this object so Get always routes correctly.
-	e.objectBackends.Store(objectKey(container, artifact), backendName)
+	e.objectBackends.Store(objectKey(container, artifact), usedBackend)
 
 	if e.cache != nil {
 		cacheKey := fmt.Sprintf("%s/%s/%s", tenantID, container, artifact)
@@ -308,7 +314,7 @@ func (e *CoreEngine) Put(ctx context.Context, container, artifact string, data i
 		go e.replicateToBackup(ctx, container, artifact)
 	}
 
-	return backendName, nil
+	return usedBackend, nil
 }
 
 // Delete removes an artifact from all backends
@@ -316,24 +322,24 @@ func (e *CoreEngine) Delete(ctx context.Context, container, artifact string) err
 	start := time.Now()
 	tenantID := common.GetTenantID(ctx)
 
-	// Delete from the backend where the object was stored, not all backends.
-	// Scatter-delete across all drivers causes slow retries on backends that
-	// don't have the object (e.g. locked Quotaless returns 401 with retries).
 	key := objectKey(container, artifact)
 	targetBackend := e.primary
 	if stored, ok := e.objectBackends.Load(key); ok {
 		targetBackend = stored.(string)
 	}
 
-	var lastErr error
-	if driver, ok := e.drivers[targetBackend]; ok {
-		if err := driver.Delete(ctx, container, artifact); err != nil {
-			e.logger.Warn("delete failed",
-				zap.String("driver", targetBackend),
-				zap.Error(err))
-			lastErr = err
-		}
+	candidates := []string{targetBackend}
+	if targetBackend != e.primary {
+		candidates = append(candidates, e.primary)
 	}
+
+	_, lastErr := e.failover.Execute(ctx, candidates, func(driverName string) error {
+		d, ok := e.drivers[driverName]
+		if !ok {
+			return fmt.Errorf("driver %s not found", driverName)
+		}
+		return d.Delete(ctx, container, artifact)
+	})
 
 	e.objectBackends.Delete(key)
 
@@ -547,6 +553,34 @@ func (r *cachingReader) Read(p []byte) (n int, err error) {
 		_ = r.cache.Set(r.key, r.buffer.Bytes())
 	}
 	return
+}
+
+// buildCandidateList returns an ordered list of backends to try: preferred
+// first, then primary (if different), then any remaining registered backends.
+func (e *CoreEngine) buildCandidateList(preferred string) []string {
+	seen := make(map[string]bool)
+	var candidates []string
+
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			if _, ok := e.drivers[name]; ok {
+				candidates = append(candidates, name)
+				seen[name] = true
+			}
+		}
+	}
+
+	add(preferred)
+	add(e.primary)
+	for name := range e.drivers {
+		add(name)
+	}
+	return candidates
+}
+
+// GetFailoverStatus returns circuit breaker states for all backends.
+func (e *CoreEngine) GetFailoverStatus() map[string]string {
+	return e.failover.GetAllStatuses()
 }
 
 // Shutdown gracefully shuts down the engine

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -34,7 +34,8 @@ func WrapError(err error, message string) error {
 
 // Common errors
 var (
-	ErrQuotaExceeded = fmt.Errorf("quota exceeded")
-	ErrInvalidInput  = fmt.Errorf("invalid input")
-	ErrTimeout       = fmt.Errorf("operation timeout")
+	ErrQuotaExceeded          = fmt.Errorf("quota exceeded")
+	ErrInvalidInput           = fmt.Errorf("invalid input")
+	ErrTimeout                = fmt.Errorf("operation timeout")
+	ErrAllBackendsUnavailable = fmt.Errorf("all backends unavailable")
 )

--- a/internal/engine/failover.go
+++ b/internal/engine/failover.go
@@ -1,0 +1,188 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type CircuitState int
+
+const (
+	StateClosed   CircuitState = iota // healthy — requests flow through
+	StateOpen                         // broken — requests are rejected
+	StateHalfOpen                     // probing — one request allowed to test recovery
+)
+
+func (s CircuitState) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	failureThreshold = 5
+	failureWindow    = 60 * time.Second
+	openDuration     = 30 * time.Second
+)
+
+type BackendCircuitBreaker struct {
+	mu           sync.Mutex
+	state        CircuitState
+	failures     []time.Time
+	lastOpenedAt time.Time
+}
+
+func NewBackendCircuitBreaker() *BackendCircuitBreaker {
+	return &BackendCircuitBreaker{
+		state: StateClosed,
+	}
+}
+
+func (b *BackendCircuitBreaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case StateClosed:
+		return true
+	case StateOpen:
+		if time.Since(b.lastOpenedAt) >= openDuration {
+			b.state = StateHalfOpen
+			return true
+		}
+		return false
+	case StateHalfOpen:
+		return true
+	default:
+		return true
+	}
+}
+
+func (b *BackendCircuitBreaker) RecordSuccess() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.state = StateClosed
+	b.failures = nil
+}
+
+func (b *BackendCircuitBreaker) RecordFailure() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-failureWindow)
+	var recent []time.Time
+	for _, t := range b.failures {
+		if t.After(cutoff) {
+			recent = append(recent, t)
+		}
+	}
+	recent = append(recent, now)
+	b.failures = recent
+
+	if len(recent) >= failureThreshold {
+		b.state = StateOpen
+		b.lastOpenedAt = now
+	}
+}
+
+func (b *BackendCircuitBreaker) State() CircuitState {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.state == StateOpen && time.Since(b.lastOpenedAt) >= openDuration {
+		b.state = StateHalfOpen
+	}
+	return b.state
+}
+
+type FailoverManager struct {
+	mu       sync.RWMutex
+	breakers map[string]*BackendCircuitBreaker
+	logger   *zap.Logger
+}
+
+func NewFailoverManager(logger *zap.Logger) *FailoverManager {
+	return &FailoverManager{
+		breakers: make(map[string]*BackendCircuitBreaker),
+		logger:   logger,
+	}
+}
+
+func (f *FailoverManager) Register(backend string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, exists := f.breakers[backend]; !exists {
+		f.breakers[backend] = NewBackendCircuitBreaker()
+	}
+}
+
+func (f *FailoverManager) Execute(ctx context.Context, backends []string, fn func(driverName string) error) (string, error) {
+	var lastErr error
+
+	for _, backend := range backends {
+		f.mu.RLock()
+		breaker, exists := f.breakers[backend]
+		f.mu.RUnlock()
+
+		if !exists {
+			continue
+		}
+
+		if !breaker.Allow() {
+			f.logger.Debug("circuit breaker open, skipping backend",
+				zap.String("backend", backend))
+			continue
+		}
+
+		if err := fn(backend); err != nil {
+			breaker.RecordFailure()
+			lastErr = err
+			f.logger.Warn("backend failed, trying next",
+				zap.String("backend", backend),
+				zap.Error(err))
+			continue
+		}
+
+		breaker.RecordSuccess()
+		return backend, nil
+	}
+
+	if lastErr != nil {
+		return "", fmt.Errorf("all backends failed: %w", lastErr)
+	}
+	return "", ErrAllBackendsUnavailable
+}
+
+func (f *FailoverManager) GetStatus(backend string) string {
+	f.mu.RLock()
+	breaker, exists := f.breakers[backend]
+	f.mu.RUnlock()
+	if !exists {
+		return "unknown"
+	}
+	return breaker.State().String()
+}
+
+func (f *FailoverManager) GetAllStatuses() map[string]string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	statuses := make(map[string]string, len(f.breakers))
+	for name, breaker := range f.breakers {
+		statuses[name] = breaker.State().String()
+	}
+	return statuses
+}

--- a/internal/engine/failover_test.go
+++ b/internal/engine/failover_test.go
@@ -1,0 +1,391 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCircuitBreaker_AllowWhenClosed(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+	assert.True(t, cb.Allow())
+	assert.Equal(t, StateClosed, cb.State())
+}
+
+func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+
+	for i := 0; i < failureThreshold; i++ {
+		assert.True(t, cb.Allow())
+		cb.RecordFailure()
+	}
+
+	assert.Equal(t, StateOpen, cb.State())
+	assert.False(t, cb.Allow())
+}
+
+func TestCircuitBreaker_DoesNotOpenOnScatteredFailures(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+
+	// 4 failures (below threshold) should not open
+	for i := 0; i < failureThreshold-1; i++ {
+		cb.RecordFailure()
+	}
+
+	assert.Equal(t, StateClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreaker_HalfOpenAfterTimeout(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+
+	for i := 0; i < failureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	assert.Equal(t, StateOpen, cb.State())
+
+	// Simulate time passing
+	cb.mu.Lock()
+	cb.lastOpenedAt = time.Now().Add(-openDuration - time.Second)
+	cb.mu.Unlock()
+
+	assert.Equal(t, StateHalfOpen, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreaker_ClosesOnSuccess(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+
+	for i := 0; i < failureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	assert.Equal(t, StateOpen, cb.State())
+
+	// Advance past open duration
+	cb.mu.Lock()
+	cb.lastOpenedAt = time.Now().Add(-openDuration - time.Second)
+	cb.mu.Unlock()
+
+	assert.True(t, cb.Allow())
+	cb.RecordSuccess()
+
+	assert.Equal(t, StateClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreaker_ReopensOnHalfOpenFailure(t *testing.T) {
+	cb := NewBackendCircuitBreaker()
+
+	for i := 0; i < failureThreshold; i++ {
+		cb.RecordFailure()
+	}
+
+	cb.mu.Lock()
+	cb.lastOpenedAt = time.Now().Add(-openDuration - time.Second)
+	cb.mu.Unlock()
+
+	assert.True(t, cb.Allow())
+	cb.RecordFailure()
+
+	assert.Equal(t, StateOpen, cb.State())
+}
+
+func TestFailoverManager_TriesNextOnFailure(t *testing.T) {
+	logger := zap.NewNop()
+	fm := NewFailoverManager(logger)
+	fm.Register("backend-a")
+	fm.Register("backend-b")
+
+	callOrder := []string{}
+	used, err := fm.Execute(context.Background(), []string{"backend-a", "backend-b"}, func(name string) error {
+		callOrder = append(callOrder, name)
+		if name == "backend-a" {
+			return fmt.Errorf("backend-a failed")
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "backend-b", used)
+	assert.Equal(t, []string{"backend-a", "backend-b"}, callOrder)
+}
+
+func TestFailoverManager_AllFail(t *testing.T) {
+	logger := zap.NewNop()
+	fm := NewFailoverManager(logger)
+	fm.Register("backend-a")
+	fm.Register("backend-b")
+
+	_, err := fm.Execute(context.Background(), []string{"backend-a", "backend-b"}, func(name string) error {
+		return fmt.Errorf("%s failed", name)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all backends failed")
+}
+
+func TestFailoverManager_SkipsOpenCircuitBreaker(t *testing.T) {
+	logger := zap.NewNop()
+	fm := NewFailoverManager(logger)
+	fm.Register("backend-a")
+	fm.Register("backend-b")
+
+	// Trip backend-a's circuit breaker
+	for i := 0; i < failureThreshold; i++ {
+		fm.breakers["backend-a"].RecordFailure()
+	}
+
+	callOrder := []string{}
+	used, err := fm.Execute(context.Background(), []string{"backend-a", "backend-b"}, func(name string) error {
+		callOrder = append(callOrder, name)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "backend-b", used)
+	assert.Equal(t, []string{"backend-b"}, callOrder)
+}
+
+func TestFailoverManager_GetAllStatuses(t *testing.T) {
+	logger := zap.NewNop()
+	fm := NewFailoverManager(logger)
+	fm.Register("a")
+	fm.Register("b")
+
+	statuses := fm.GetAllStatuses()
+	assert.Equal(t, "closed", statuses["a"])
+	assert.Equal(t, "closed", statuses["b"])
+
+	for i := 0; i < failureThreshold; i++ {
+		fm.breakers["a"].RecordFailure()
+	}
+
+	statuses = fm.GetAllStatuses()
+	assert.Equal(t, "open", statuses["a"])
+	assert.Equal(t, "closed", statuses["b"])
+}
+
+func TestResolveStorageClass_Mapping(t *testing.T) {
+	drivers := map[string]Driver{
+		"idrive":   &mockDriver{name: "idrive"},
+		"lyve":     &mockDriver{name: "lyve"},
+		"geyser":   &mockDriver{name: "geyser"},
+		"onedrive": &mockDriver{name: "onedrive"},
+		"local":    &mockDriver{name: "local"},
+	}
+
+	tests := []struct {
+		class           string
+		expectedBackend string
+		expectedClass   string
+	}{
+		{"STANDARD", "idrive", "STANDARD"},
+		{"STANDARD_IA", "lyve", "STANDARD_IA"},
+		{"GLACIER", "geyser", "GLACIER"},
+		{"DEEP_ARCHIVE", "geyser", "DEEP_ARCHIVE"},
+		{"ONEZONE_IA", "onedrive", "ONEZONE_IA"},
+		{"REDUCED_REDUNDANCY", "local", "REDUCED_REDUNDANCY"},
+		{"", "idrive", "STANDARD"},
+	}
+
+	for _, tt := range tests {
+		backend, class := ResolveStorageClass(tt.class, "idrive", drivers)
+		assert.Equal(t, tt.expectedBackend, backend, "class=%s", tt.class)
+		assert.Equal(t, tt.expectedClass, class, "class=%s", tt.class)
+	}
+}
+
+func TestResolveStorageClass_FallbackWhenMissing(t *testing.T) {
+	drivers := map[string]Driver{
+		"idrive": &mockDriver{name: "idrive"},
+		"local":  &mockDriver{name: "local"},
+	}
+
+	// GLACIER maps to geyser which isn't registered → falls back to primary
+	backend, class := ResolveStorageClass("GLACIER", "idrive", drivers)
+	assert.Equal(t, "idrive", backend)
+	assert.Equal(t, "GLACIER", class)
+}
+
+func TestResolveStorageClass_UnknownClass(t *testing.T) {
+	drivers := map[string]Driver{
+		"idrive": &mockDriver{name: "idrive"},
+	}
+
+	backend, class := ResolveStorageClass("INVALID_CLASS", "idrive", drivers)
+	assert.Equal(t, "idrive", backend)
+	assert.Equal(t, "STANDARD", class)
+}
+
+func TestBackendToStorageClass(t *testing.T) {
+	assert.Equal(t, "STANDARD", BackendToStorageClass("idrive"))
+	assert.Equal(t, "STANDARD_IA", BackendToStorageClass("lyve"))
+	assert.Equal(t, "GLACIER", BackendToStorageClass("geyser"))
+	assert.Equal(t, "ONEZONE_IA", BackendToStorageClass("onedrive"))
+	assert.Equal(t, "REDUCED_REDUNDANCY", BackendToStorageClass("local"))
+	assert.Equal(t, "STANDARD", BackendToStorageClass("s3"))
+	assert.Equal(t, "STANDARD", BackendToStorageClass("unknown"))
+}
+
+func TestEnginePut_WithStorageClass(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "idrive"})
+
+	idriveMock := &mockDriver{name: "idrive"}
+	geyserMock := &mockDriver{name: "geyser"}
+	eng.AddDriver("idrive", idriveMock)
+	eng.AddDriver("geyser", geyserMock)
+
+	ctx := context.Background()
+	data := strings.NewReader("test data")
+
+	backend, err := eng.Put(ctx, "container", "artifact.dat", data, WithStorageClass("GLACIER"))
+	require.NoError(t, err)
+	assert.Equal(t, "geyser", backend)
+	assert.Equal(t, 1, geyserMock.putCount)
+	assert.Equal(t, 0, idriveMock.putCount)
+}
+
+func TestEnginePut_StorageClassFallback(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "idrive"})
+
+	idriveMock := &mockDriver{name: "idrive"}
+	eng.AddDriver("idrive", idriveMock)
+
+	ctx := context.Background()
+	data := strings.NewReader("test data")
+
+	// GLACIER maps to geyser which doesn't exist → falls back to primary (idrive)
+	backend, err := eng.Put(ctx, "container", "artifact.dat", data, WithStorageClass("GLACIER"))
+	require.NoError(t, err)
+	assert.Equal(t, "idrive", backend)
+	assert.Equal(t, 1, idriveMock.putCount)
+}
+
+func TestEngineGet_FailoverOnError(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "primary"})
+
+	primaryMock := &mockDriver{name: "primary", getErr: fmt.Errorf("primary down")}
+	backupMock := &mockDriver{name: "backup", getData: "hello from backup"}
+	eng.AddDriver("primary", primaryMock)
+	eng.AddDriver("backup", backupMock)
+
+	// Record object on primary
+	eng.objectBackends.Store("container/obj.txt", "primary")
+
+	ctx := context.Background()
+	reader, err := eng.Get(ctx, "container", "obj.txt")
+	require.NoError(t, err)
+	defer func() { _ = reader.Close() }()
+
+	data, _ := io.ReadAll(reader)
+	assert.Equal(t, "hello from backup", string(data))
+}
+
+func TestEngineGet_AllBackendsFail(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "primary"})
+
+	primaryMock := &mockDriver{name: "primary", getErr: fmt.Errorf("down")}
+	backupMock := &mockDriver{name: "backup", getErr: fmt.Errorf("also down")}
+	eng.AddDriver("primary", primaryMock)
+	eng.AddDriver("backup", backupMock)
+
+	ctx := context.Background()
+	_, err := eng.Get(ctx, "container", "obj.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all backends failed")
+}
+
+func TestEnginePut_FailoverOnError(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "primary"})
+
+	primaryMock := &mockDriver{name: "primary", putErr: fmt.Errorf("write failed")}
+	backupMock := &mockDriver{name: "backup"}
+	eng.AddDriver("primary", primaryMock)
+	eng.AddDriver("backup", backupMock)
+
+	ctx := context.Background()
+	data := strings.NewReader("hello")
+
+	backend, err := eng.Put(ctx, "container", "obj.txt", data)
+	require.NoError(t, err)
+	assert.Equal(t, "backup", backend)
+}
+
+func TestBuildCandidateList(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "primary"})
+	eng.AddDriver("primary", &mockDriver{name: "primary"})
+	eng.AddDriver("backup", &mockDriver{name: "backup"})
+	eng.AddDriver("archive", &mockDriver{name: "archive"})
+
+	candidates := eng.buildCandidateList("archive")
+	assert.Equal(t, "archive", candidates[0])
+	assert.Equal(t, "primary", candidates[1])
+	assert.Len(t, candidates, 3)
+}
+
+func TestGetFailoverStatus(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, &Config{DefaultBackend: "primary"})
+	eng.AddDriver("primary", &mockDriver{name: "primary"})
+	eng.AddDriver("backup", &mockDriver{name: "backup"})
+
+	statuses := eng.GetFailoverStatus()
+	assert.Equal(t, "closed", statuses["primary"])
+	assert.Equal(t, "closed", statuses["backup"])
+}
+
+// mockDriver implements the Driver interface for testing.
+type mockDriver struct {
+	name     string
+	getErr   error
+	putErr   error
+	getData  string
+	putCount int
+}
+
+func (d *mockDriver) Name() string { return d.name }
+
+func (d *mockDriver) Get(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	if d.getErr != nil {
+		return nil, d.getErr
+	}
+	data := d.getData
+	if data == "" {
+		data = "mock data"
+	}
+	return io.NopCloser(strings.NewReader(data)), nil
+}
+
+func (d *mockDriver) Put(_ context.Context, _, _ string, _ io.Reader, _ ...PutOption) error {
+	d.putCount++
+	return d.putErr
+}
+
+func (d *mockDriver) Delete(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (d *mockDriver) List(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (d *mockDriver) Exists(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
+func (d *mockDriver) HealthCheck(_ context.Context) error {
+	return nil
+}

--- a/internal/engine/interface.go
+++ b/internal/engine/interface.go
@@ -75,6 +75,7 @@ type PutOptions struct {
 	ContentEncoding string
 	ContentLanguage string
 	ContentLength   int64
+	StorageClass    string
 	UserMetadata    map[string]string
 }
 
@@ -107,5 +108,12 @@ func WithUserMetadata(meta map[string]string) PutOption {
 func WithContentLength(n int64) PutOption {
 	return func(o *PutOptions) {
 		o.ContentLength = n
+	}
+}
+
+// WithStorageClass sets the S3 storage class hint for backend routing.
+func WithStorageClass(class string) PutOption {
+	return func(o *PutOptions) {
+		o.StorageClass = class
 	}
 }

--- a/internal/engine/storage_class.go
+++ b/internal/engine/storage_class.go
@@ -1,0 +1,44 @@
+package engine
+
+var storageClassToBackend = map[string]string{
+	"STANDARD":           "idrive",
+	"STANDARD_IA":        "lyve",
+	"GLACIER":            "geyser",
+	"DEEP_ARCHIVE":       "geyser",
+	"ONEZONE_IA":         "onedrive",
+	"REDUCED_REDUNDANCY": "local",
+}
+
+var backendToStorageClass = map[string]string{
+	"idrive":   "STANDARD",
+	"lyve":     "STANDARD_IA",
+	"geyser":   "GLACIER",
+	"onedrive": "ONEZONE_IA",
+	"local":    "REDUCED_REDUNDANCY",
+	"s3":       "STANDARD",
+}
+
+func ResolveStorageClass(class string, primaryBackend string, availableDrivers map[string]Driver) (driverName, resolvedClass string) {
+	if class == "" {
+		return primaryBackend, "STANDARD"
+	}
+
+	canonical := class
+	targetBackend, mapped := storageClassToBackend[class]
+	if !mapped {
+		return primaryBackend, "STANDARD"
+	}
+
+	if _, available := availableDrivers[targetBackend]; available {
+		return targetBackend, canonical
+	}
+
+	return primaryBackend, canonical
+}
+
+func BackendToStorageClass(backendName string) string {
+	if class, ok := backendToStorageClass[backendName]; ok {
+		return class
+	}
+	return "STANDARD"
+}


### PR DESCRIPTION
## Summary

- Add per-backend circuit breaker (`BackendCircuitBreaker`) with three states: closed → open (5 failures/60s) → half-open (30s cooldown) → probe → closed on success
- Add `FailoverManager` that executes operations across an ordered candidate list, skipping open breakers and recording success/failure
- Add S3 storage class → backend routing (`ResolveStorageClass`): STANDARD→idrive, STANDARD_IA→lyve, GLACIER/DEEP_ARCHIVE→geyser, ONEZONE_IA→onedrive, REDUCED_REDUNDANCY→local
- Wire failover into CoreEngine Get/Put/Delete with `buildCandidateList` (preferred → primary → others)
- S3 PUT now passes `x-amz-storage-class` header as `WithStorageClass` option
- GET/HEAD responses return real storage class from `backend_name` column instead of hardcoded "STANDARD"
- All-backends-unavailable returns 503 + `Retry-After: 30` via new `ErrServiceUnavailable` S3 error
- Health endpoint now includes `circuit_breakers` map in response

## Test plan

- [x] TestCircuitBreaker_AllowWhenClosed — closed state always allows
- [x] TestCircuitBreaker_OpensAfterFailures — 5 failures → state becomes open
- [x] TestCircuitBreaker_HalfOpenAfterTimeout — open → wait → half-open → allow probe
- [x] TestCircuitBreaker_ClosesOnSuccess — half-open + success → closed
- [x] TestCircuitBreaker_ReopensOnHalfOpenFailure — half-open + failure → open again
- [x] TestFailoverManager_TriesNextOnFailure — first backend fails, second succeeds
- [x] TestFailoverManager_AllFail — all backends fail → returns error
- [x] TestFailoverManager_SkipsOpenCircuitBreaker — open breaker skipped entirely
- [x] TestResolveStorageClass_Mapping — all 6 classes map correctly
- [x] TestResolveStorageClass_FallbackWhenMissing — target not registered → primary
- [x] TestResolveStorageClass_UnknownClass — unknown class → primary + STANDARD
- [x] TestBackendToStorageClass — reverse mapping for all backends
- [x] TestEnginePut_WithStorageClass — GLACIER routes to geyser
- [x] TestEnginePut_StorageClassFallback — missing backend falls through to primary
- [x] TestEngineGet_FailoverOnError — primary fails, backup succeeds
- [x] TestEngineGet_AllBackendsFail — all fail → error
- [x] TestEnginePut_FailoverOnError — primary fails, backup used
- [x] Full test suite: 74 packages pass with -race, 0 failures
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)