### PR TITLE
feat(dashboard): admin backend health dashboard [Phase 5.12.5]

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	dashhandlers "github.com/FairForge/vaultaire/internal/dashboard/handlers"
 	"github.com/FairForge/vaultaire/internal/engine"
 )
 
@@ -234,6 +235,27 @@ func (s *Server) handleBackendsHealth(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(backends)
+}
+
+// healthCheckerAdapter adapts BackendHealthChecker to the dashboard
+// handlers.HealthChecker interface (different BackendState types).
+type healthCheckerAdapter struct {
+	inner *BackendHealthChecker
+}
+
+func (a *healthCheckerAdapter) GetBackendStates() map[string]*dashhandlers.BackendState {
+	raw := a.inner.GetBackendStates()
+	out := make(map[string]*dashhandlers.BackendState, len(raw))
+	for k, v := range raw {
+		out[k] = &dashhandlers.BackendState{
+			Healthy:   v.Healthy,
+			Score:     v.Score,
+			Latency:   v.Latency,
+			LastCheck: v.LastCheck,
+			LastError: v.LastError,
+		}
+	}
+	return out
 }
 
 // Helper functions

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -435,19 +435,21 @@ func (s *Server) setupRoutes() {
 		}
 	}
 	dashboard.RegisterRoutes(s.router, dashboard.Deps{
-		DB:          s.db,
-		Auth:        s.auth,
-		MFA:         s.mfaService,
-		MFAPending:  s.mfaPendingStore,
-		Sessions:    s.sessionStore,
-		Logger:      s.logger,
-		DataPath:    dataPath,
-		Stripe:      s.stripe,
-		Google:      s.googleOAuth,
-		GitHub:      s.githubOAuth,
-		StorageMode: storageMode,
-		Email:       s.emailSender,
-		BaseURL:     s.baseURL,
+		DB:            s.db,
+		Auth:          s.auth,
+		MFA:           s.mfaService,
+		MFAPending:    s.mfaPendingStore,
+		Sessions:      s.sessionStore,
+		Logger:        s.logger,
+		DataPath:      dataPath,
+		Stripe:        s.stripe,
+		Google:        s.googleOAuth,
+		GitHub:        s.githubOAuth,
+		StorageMode:   storageMode,
+		Email:         s.emailSender,
+		BaseURL:       s.baseURL,
+		Engine:        s.engine,
+		HealthChecker: &healthCheckerAdapter{s.healthChecker},
 	})
 
 	s.logger.Info("Registering management API routes")

--- a/internal/dashboard/handlers/admin_backends.go
+++ b/internal/dashboard/handlers/admin_backends.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"sort"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// HealthChecker provides backend health state without importing internal/api.
+type HealthChecker interface {
+	GetBackendStates() map[string]*BackendState
+}
+
+// BackendState mirrors the fields the dashboard needs from health state.
+type BackendState struct {
+	Healthy   bool
+	Score     float64
+	Latency   time.Duration
+	LastCheck time.Time
+	LastError string
+}
+
+// BackendInfo is the per-backend view model for the template.
+type BackendInfo struct {
+	Name         string
+	IsPrimary    bool
+	IsBackup     bool
+	Healthy      bool
+	Score        float64
+	LatencyMs    int64
+	LastCheck    string
+	LastError    string
+	CircuitState string
+	StorageClass string
+}
+
+// HandleAdminBackends renders the backend health dashboard page.
+func HandleAdminBackends(tmpl *template.Template, eng *engine.CoreEngine, hc HealthChecker, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-backends")
+		withCSRF(r.Context(), data)
+
+		primary := eng.GetPrimary()
+		backup := eng.GetBackup()
+		circuitStates := eng.GetFailoverStatus()
+
+		states := make(map[string]*BackendState)
+		if hc != nil {
+			for k, v := range hc.GetBackendStates() {
+				states[k] = &BackendState{
+					Healthy:   v.Healthy,
+					Score:     v.Score,
+					Latency:   v.Latency,
+					LastCheck: v.LastCheck,
+					LastError: v.LastError,
+				}
+			}
+		}
+
+		names := eng.GetDriverNames()
+		backends := make([]BackendInfo, 0, len(names))
+		for _, name := range names {
+			bi := BackendInfo{
+				Name:         name,
+				IsPrimary:    name == primary,
+				IsBackup:     name == backup,
+				CircuitState: circuitStates[name],
+				StorageClass: engine.BackendToStorageClass(name),
+			}
+			if bi.CircuitState == "" {
+				bi.CircuitState = "unknown"
+			}
+			if st, ok := states[name]; ok {
+				bi.Healthy = st.Healthy
+				bi.Score = st.Score
+				bi.LatencyMs = st.Latency.Milliseconds()
+				bi.LastCheck = relativeTime(st.LastCheck)
+				bi.LastError = st.LastError
+			}
+			backends = append(backends, bi)
+		}
+
+		sort.SliceStable(backends, func(i, j int) bool {
+			if backends[i].IsPrimary != backends[j].IsPrimary {
+				return backends[i].IsPrimary
+			}
+			return false
+		})
+
+		data["Backends"] = backends
+		data["BackendCount"] = len(backends)
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin backends", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleSetPrimary handles POST /admin/backends/{name}/primary.
+func HandleSetPrimary(eng *engine.CoreEngine, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		name := chi.URLParam(r, "name")
+		eng.SetPrimary(name)
+		logger.Info("primary backend changed via admin dashboard",
+			zap.String("backend", name),
+			zap.String("admin", sd.Email))
+
+		http.Redirect(w, r, "/admin/backends", http.StatusSeeOther)
+	}
+}
+
+// HandleForceHealthCheck handles POST /admin/backends/{name}/check.
+func HandleForceHealthCheck(eng *engine.CoreEngine, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		name := chi.URLParam(r, "name")
+		if err := eng.CheckDriver(r.Context(), name); err != nil {
+			logger.Warn("forced health check failed",
+				zap.String("backend", name),
+				zap.Error(err))
+		} else {
+			logger.Info("forced health check passed",
+				zap.String("backend", name),
+				zap.String("admin", sd.Email))
+		}
+
+		http.Redirect(w, r, "/admin/backends", http.StatusSeeOther)
+	}
+}

--- a/internal/dashboard/handlers/admin_backends_test.go
+++ b/internal/dashboard/handlers/admin_backends_test.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"context"
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testBackendsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Backends{{end}}` +
+			`{{define "content"}}` +
+			`<h1>Storage Backends</h1>` +
+			`<span class="count">{{.BackendCount}}</span>` +
+			`{{range .Backends}}` +
+			`<span class="backend">{{.Name}}</span>` +
+			`<span class="healthy">{{.Healthy}}</span>` +
+			`<span class="primary">{{.IsPrimary}}</span>` +
+			`<span class="circuit">{{.CircuitState}}</span>` +
+			`<span class="class">{{.StorageClass}}</span>` +
+			`{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+type mockHealthChecker struct {
+	states map[string]*BackendState
+}
+
+func (m *mockHealthChecker) GetBackendStates() map[string]*BackendState {
+	return m.states
+}
+
+func testEngine(t *testing.T, drivers ...string) *engine.CoreEngine {
+	t.Helper()
+	eng := engine.NewEngine(nil, zap.NewNop(), &engine.Config{
+		DefaultBackend: drivers[0],
+	})
+	for _, name := range drivers {
+		eng.AddDriver(name, &stubDriver{name: name})
+	}
+	return eng
+}
+
+type stubDriver struct {
+	name     string
+	checkErr error
+}
+
+func (d *stubDriver) Name() string { return d.name }
+func (d *stubDriver) Get(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (d *stubDriver) Put(_ context.Context, _, _ string, _ io.Reader, _ ...engine.PutOption) error {
+	return nil
+}
+func (d *stubDriver) Delete(_ context.Context, _, _ string) error { return nil }
+func (d *stubDriver) List(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (d *stubDriver) Exists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+func (d *stubDriver) HealthCheck(_ context.Context) error                 { return d.checkErr }
+
+func TestHandleAdminBackends_NoSession(t *testing.T) {
+	eng := testEngine(t, "local")
+	handler := HandleAdminBackends(testBackendsTemplate(t), eng, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/backends", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminBackends_RendersList(t *testing.T) {
+	eng := testEngine(t, "local", "s3")
+	hc := &mockHealthChecker{
+		states: map[string]*BackendState{
+			"local": {Healthy: true, Score: 95.0, Latency: 2 * time.Millisecond, LastCheck: time.Now()},
+			"s3":    {Healthy: true, Score: 88.0, Latency: 15 * time.Millisecond, LastCheck: time.Now()},
+		},
+	}
+	handler := HandleAdminBackends(testBackendsTemplate(t), eng, hc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/backends", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Storage Backends")
+	assert.Contains(t, body, "local")
+	assert.Contains(t, body, "s3")
+	assert.Contains(t, body, `<span class="count">2</span>`)
+}
+
+func TestHandleAdminBackends_ShowsCircuitState(t *testing.T) {
+	eng := testEngine(t, "local")
+	hc := &mockHealthChecker{
+		states: map[string]*BackendState{
+			"local": {Healthy: true, Score: 100.0, LastCheck: time.Now()},
+		},
+	}
+	handler := HandleAdminBackends(testBackendsTemplate(t), eng, hc, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/backends", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "closed")
+}
+
+func TestHandleSetPrimary(t *testing.T) {
+	eng := testEngine(t, "local", "s3")
+	handler := HandleSetPrimary(eng, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "s3")
+	req := httptest.NewRequest("POST", "/admin/backends/s3/primary", nil)
+	req = req.WithContext(context.WithValue(adminCtx(t), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/backends", w.Header().Get("Location"))
+	assert.Equal(t, "s3", eng.GetPrimary())
+}
+
+func TestHandleForceHealthCheck(t *testing.T) {
+	eng := testEngine(t, "local")
+	handler := HandleForceHealthCheck(eng, zap.NewNop())
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "local")
+	req := httptest.NewRequest("POST", "/admin/backends/local/check", nil)
+	req = req.WithContext(context.WithValue(adminCtx(t), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/backends", w.Header().Get("Location"))
+}
+
+func TestHandleAdminBackends_PrimaryFirst(t *testing.T) {
+	eng := testEngine(t, "s3", "local")
+	eng.SetPrimary("local")
+	hc := &mockHealthChecker{
+		states: map[string]*BackendState{
+			"local": {Healthy: true, Score: 95.0, LastCheck: time.Now()},
+			"s3":    {Healthy: true, Score: 88.0, LastCheck: time.Now()},
+		},
+	}
+
+	handler := HandleAdminBackends(testBackendsTemplate(t), eng, hc, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/backends", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	require.Contains(t, body, `<span class="backend">local</span>`)
+	require.Contains(t, body, `<span class="primary">true</span>`)
+}
+
+func TestHandleAdminBackends_NilHealthChecker(t *testing.T) {
+	eng := testEngine(t, "local")
+	handler := HandleAdminBackends(testBackendsTemplate(t), eng, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/admin/backends", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "local")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
 	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
 	"github.com/FairForge/vaultaire/internal/email"
+	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -23,19 +24,21 @@ const sessionTTL = 24 * time.Hour
 
 // Deps groups the dependencies the dashboard routes need.
 type Deps struct {
-	DB          *sql.DB
-	Auth        *auth.AuthService
-	MFA         *auth.MFAService // TOTP secret generation / validation.
-	MFAPending  *MFAPendingStore // Short-lived store for 2FA login challenges.
-	Sessions    dashauth.SessionStore
-	Logger      *zap.Logger
-	DataPath    string                 // Local storage root for bucket creation.
-	Stripe      *billing.StripeService // Nil when STRIPE_SECRET_KEY is not set.
-	Google      *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
-	GitHub      *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
-	StorageMode string                 // e.g. "local", "s3", "quotaless", "geyser", "idrive"
-	Email       email.Sender           // Email sender (LogSender if unconfigured).
-	BaseURL     string                 // Base URL for email links (e.g. "https://stored.ge").
+	DB            *sql.DB
+	Auth          *auth.AuthService
+	MFA           *auth.MFAService // TOTP secret generation / validation.
+	MFAPending    *MFAPendingStore // Short-lived store for 2FA login challenges.
+	Sessions      dashauth.SessionStore
+	Logger        *zap.Logger
+	DataPath      string                 // Local storage root for bucket creation.
+	Stripe        *billing.StripeService // Nil when STRIPE_SECRET_KEY is not set.
+	Google        *oauth2.Config         // Nil when GOOGLE_CLIENT_ID is not set.
+	GitHub        *oauth2.Config         // Nil when GITHUB_CLIENT_ID is not set.
+	StorageMode   string                 // e.g. "local", "s3", "quotaless", "geyser", "idrive"
+	Email         email.Sender           // Email sender (LogSender if unconfigured).
+	BaseURL       string                 // Base URL for email links (e.g. "https://stored.ge").
+	Engine        *engine.CoreEngine     // Nil-safe; used by admin backends page.
+	HealthChecker handlers.HealthChecker // Nil-safe; backend health state provider.
 }
 
 // RegisterRoutes mounts the dashboard, auth, admin, and static-asset
@@ -202,6 +205,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/system.html",
 	))
+	backendsTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/backends.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -218,6 +225,11 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/bandwidth-limit", handlers.HandleUpdateBandwidthLimit(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/reset-mfa", handlers.HandleAdminResetMFA(deps.Auth, deps.Logger))
 		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
+		if deps.Engine != nil {
+			ar.Get("/backends", handlers.HandleAdminBackends(backendsTmpl, deps.Engine, deps.HealthChecker, deps.Logger))
+			ar.Post("/backends/{name}/primary", handlers.HandleSetPrimary(deps.Engine, deps.Logger))
+			ar.Post("/backends/{name}/check", handlers.HandleForceHealthCheck(deps.Engine, deps.Logger))
+		}
 	})
 }
 

--- a/internal/dashboard/templates/admin/backends.html
+++ b/internal/dashboard/templates/admin/backends.html
@@ -1,0 +1,80 @@
+{{define "title"}}Storage Backends — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Storage Backends <span class="badge">{{.BackendCount}} backends</span></h1>
+</div>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+{{if not .Backends}}
+<div class="card">
+    <div class="card-title">No backends registered</div>
+    <div class="card-detail">Storage drivers have not been initialized yet.</div>
+</div>
+{{else}}
+<div class="card-grid">
+    {{range .Backends}}
+    <div class="card">
+        <div class="card-title">
+            {{.Name}}
+            {{if .IsPrimary}} <span class="badge badge-success">primary</span>{{end}}
+            {{if .IsBackup}} <span class="badge badge-warning">backup</span>{{end}}
+        </div>
+
+        <div style="margin:0.75rem 0">
+            {{if .Healthy}}
+                <span class="badge badge-success">healthy</span>
+            {{else}}
+                <span class="badge badge-danger">unhealthy</span>
+            {{end}}
+
+            {{if eq .CircuitState "closed"}}
+                <span class="badge badge-success">circuit closed</span>
+            {{else if eq .CircuitState "open"}}
+                <span class="badge badge-danger">circuit open</span>
+            {{else if eq .CircuitState "half-open"}}
+                <span class="badge badge-warning">circuit half-open</span>
+            {{else}}
+                <span class="badge">circuit {{.CircuitState}}</span>
+            {{end}}
+        </div>
+
+        <div class="card-detail">
+            <strong>Score:</strong> {{printf "%.0f" .Score}}%
+            &nbsp;&middot;&nbsp;
+            <strong>Latency:</strong> {{.LatencyMs}}ms
+            &nbsp;&middot;&nbsp;
+            <strong>Class:</strong> {{.StorageClass}}
+        </div>
+
+        {{if .LastCheck}}
+        <div class="card-detail"><strong>Last checked:</strong> {{.LastCheck}}</div>
+        {{end}}
+
+        {{if .LastError}}
+        <div class="card-detail" style="color:var(--color-danger,#e74c3c)"><strong>Error:</strong> {{.LastError}}</div>
+        {{end}}
+
+        <div style="margin-top:0.75rem;display:flex;gap:0.5rem">
+            {{if not .IsPrimary}}
+            <form method="POST" action="/admin/backends/{{.Name}}/primary" style="margin:0">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="btn btn-sm">Set as Primary</button>
+            </form>
+            {{end}}
+            <form method="POST" action="/admin/backends/{{.Name}}/check" style="margin:0">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="btn btn-sm">Check Now</button>
+            </form>
+        </div>
+    </div>
+    {{end}}
+</div>
+{{end}}
+
+<div class="dashboard-actions">
+    <a href="/admin" class="btn">Admin Overview</a>
+    <a href="/admin/system" class="btn">System Health</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -20,6 +20,7 @@
                 <a href="/admin" class="sidebar-link{{if eq .Page "admin-overview"}} sidebar-link--active{{end}}">Overview</a>
                 <a href="/admin/tenants" class="sidebar-link{{if eq .Page "admin-tenants"}} sidebar-link--active{{end}}">Tenants</a>
                 <a href="/admin/system" class="sidebar-link{{if eq .Page "admin-system"}} sidebar-link--active{{end}}">System</a>
+                <a href="/admin/backends" class="sidebar-link{{if eq .Page "admin-backends"}} sidebar-link--active{{end}}">Backends</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -126,6 +127,43 @@ func (e *CoreEngine) SetBackup(name string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.backup = name
+}
+
+// GetDriverNames returns a sorted list of registered driver names.
+func (e *CoreEngine) GetDriverNames() []string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	names := make([]string, 0, len(e.drivers))
+	for name := range e.drivers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// GetPrimary returns the current primary backend name.
+func (e *CoreEngine) GetPrimary() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.primary
+}
+
+// GetBackup returns the current backup backend name.
+func (e *CoreEngine) GetBackup() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.backup
+}
+
+// CheckDriver runs HealthCheck on a single named driver.
+func (e *CoreEngine) CheckDriver(ctx context.Context, name string) error {
+	e.mu.RLock()
+	driver, exists := e.drivers[name]
+	e.mu.RUnlock()
+	if !exists {
+		return fmt.Errorf("driver %q not found", name)
+	}
+	return driver.HealthCheck(ctx)
 }
 
 // objectKey returns the sync.Map key for a container+artifact pair.


### PR DESCRIPTION
## Summary

- Add `/admin/backends` page showing all registered storage backends with live health status, circuit breaker state, latency, storage class mapping, and primary/backup badges
- Add admin actions: "Set as Primary" and "Check Now" per backend (POST with CSRF)
- Add engine getter methods (`GetDriverNames`, `GetPrimary`, `GetBackup`, `CheckDriver`) for safe read-only access to private fields
- Wire `Engine` and `HealthChecker` through `dashboard.Deps` with a type adapter bridging `api.BackendHealthState` → `handlers.BackendState`

## Files changed

| File | Change |
|------|--------|
| `internal/engine/engine.go` | +4 methods: `GetDriverNames`, `GetPrimary`, `GetBackup`, `CheckDriver` |
| `internal/dashboard/handlers/admin_backends.go` | New: 3 handlers + `HealthChecker` interface + `BackendState`/`BackendInfo` types |
| `internal/dashboard/handlers/admin_backends_test.go` | New: 7 tests covering no-session, render, circuit state, set primary, force check, nil health checker |
| `internal/dashboard/templates/admin/backends.html` | New: card grid template with health/circuit badges and action forms |
| `internal/dashboard/router.go` | Add `Engine`/`HealthChecker` to Deps, parse template, register 3 routes |
| `internal/dashboard/templates/layouts/admin.html` | Add "Backends" sidebar nav link |
| `internal/api/health_handlers.go` | Add `healthCheckerAdapter` bridging api→dashboard types |
| `internal/api/server.go` | Pass `Engine` and adapted `HealthChecker` to dashboard Deps |

## Test plan

- [x] `TestHandleAdminBackends_NoSession` — redirects to /login
- [x] `TestHandleAdminBackends_RendersList` — renders 2 backends with count badge
- [x] `TestHandleAdminBackends_ShowsCircuitState` — "closed" appears in output
- [x] `TestHandleSetPrimary` — POST changes primary, redirects
- [x] `TestHandleForceHealthCheck` — POST triggers check, redirects
- [x] `TestHandleAdminBackends_PrimaryFirst` — primary backend sorts first
- [x] `TestHandleAdminBackends_NilHealthChecker` — degrades gracefully with nil
- [x] Full suite: 74 packages pass, 0 failures
- [x] Lint clean