### PR TITLE
feat(gdpr): data export + account deletion [Phase 5.14.1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The `engine.Driver` interface (in `internal/engine/interface.go`) is the sacred 
 
 Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries `tenants` first (primary key, full access), then falls back to `api_keys` for scoped VLT_ keys, then `sts_tokens` for ASIA-prefixed temporary credentials.
 
-Other critical tables (32 migrations through `032_sts_tokens.sql`):
+Other critical tables (36 migrations through `036_account_deletion.sql`):
 - `object_head_cache` — HEAD/GET metadata cache (~1ms), content-type, ETag, metadata JSONB
 - `buckets` — bucket registry with visibility, CORS, cache TTL, metadata JSONB, slug
 - `multipart_uploads`, `multipart_parts` — in-progress multipart state

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -29,6 +29,8 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **events.go** — Event emitter (`emitEvent`), webhook dispatch, HMAC signing, `GET /api/v1/events` list endpoint
 - **webhooks_routes.go** — Webhook CRUD API (`/api/v1/webhooks`): create, list, update, delete, delivery history, test fire
 - **llms_txt.go** — Static `/llms.txt` endpoint (plain-text API summary for LLMs)
+- **account_export.go** — `AccountExporter`: GDPR data export service (CreateExport collects user/tenant/quota/buckets/objects/keys/bandwidth/events into JSON)
+- **account_deletion.go** — `AccountDeletionService`: 30-day grace period deletion (ScheduleDeletion, CancelDeletion, GetDeletionStatus, ExecuteDeletion)
 
 ## Error Response Pattern
 

--- a/internal/api/account_deletion.go
+++ b/internal/api/account_deletion.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const deletionGracePeriod = 30 * 24 * time.Hour // 30 days
+
+type DeletionStatus struct {
+	Scheduled   bool      `json:"scheduled"`
+	ScheduledAt time.Time `json:"scheduled_at,omitempty"`
+	Reason      string    `json:"reason,omitempty"`
+}
+
+type AccountDeletionService struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+func NewAccountDeletionService(db *sql.DB, logger *zap.Logger) *AccountDeletionService {
+	return &AccountDeletionService{db: db, logger: logger}
+}
+
+func (s *AccountDeletionService) ScheduleDeletion(ctx context.Context, userID, tenantID, reason string) (time.Time, error) {
+	if s.db == nil {
+		return time.Time{}, fmt.Errorf("database unavailable")
+	}
+
+	// If already scheduled, return the existing date.
+	var existing sql.NullTime
+	err := s.db.QueryRowContext(ctx,
+		`SELECT deletion_scheduled_at FROM users WHERE id = $1`, userID).Scan(&existing)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("check existing deletion: %w", err)
+	}
+	if existing.Valid {
+		return existing.Time, nil
+	}
+
+	scheduledAt := time.Now().Add(deletionGracePeriod)
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE users SET deletion_scheduled_at = $1, deletion_reason = $2, status = 'pending_deletion' WHERE id = $3`,
+		scheduledAt, reason, userID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("schedule deletion: %w", err)
+	}
+
+	s.logger.Info("account deletion scheduled",
+		zap.String("user_id", userID),
+		zap.String("tenant_id", tenantID),
+		zap.Time("scheduled_at", scheduledAt))
+
+	return scheduledAt, nil
+}
+
+func (s *AccountDeletionService) CancelDeletion(ctx context.Context, userID string) error {
+	if s.db == nil {
+		return fmt.Errorf("database unavailable")
+	}
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE users SET deletion_scheduled_at = NULL, deletion_reason = NULL, status = 'active' WHERE id = $1 AND deletion_scheduled_at IS NOT NULL`,
+		userID)
+	if err != nil {
+		return fmt.Errorf("cancel deletion: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("no pending deletion to cancel")
+	}
+
+	s.logger.Info("account deletion cancelled", zap.String("user_id", userID))
+	return nil
+}
+
+func (s *AccountDeletionService) GetDeletionStatus(ctx context.Context, userID string) (*DeletionStatus, error) {
+	if s.db == nil {
+		return &DeletionStatus{}, nil
+	}
+
+	var scheduledAt sql.NullTime
+	var reason sql.NullString
+	err := s.db.QueryRowContext(ctx,
+		`SELECT deletion_scheduled_at, deletion_reason FROM users WHERE id = $1`, userID).
+		Scan(&scheduledAt, &reason)
+	if err != nil {
+		return nil, fmt.Errorf("get deletion status: %w", err)
+	}
+
+	status := &DeletionStatus{}
+	if scheduledAt.Valid {
+		status.Scheduled = true
+		status.ScheduledAt = scheduledAt.Time
+	}
+	if reason.Valid {
+		status.Reason = reason.String
+	}
+	return status, nil
+}
+
+func (s *AccountDeletionService) ExecuteDeletion(ctx context.Context, userID, tenantID string) error {
+	if s.db == nil {
+		return fmt.Errorf("database unavailable")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin deletion tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deletes := []struct {
+		query string
+		arg   string
+	}{
+		{`DELETE FROM object_head_cache WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM buckets WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM api_keys WHERE user_id = $1`, userID},
+		{`DELETE FROM tenant_quotas WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM dashboard_sessions WHERE user_id = $1`, userID},
+		{`DELETE FROM events WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM webhook_endpoints WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM bandwidth_usage_daily WHERE tenant_id = $1`, tenantID},
+		{`DELETE FROM account_exports WHERE user_id = $1`, userID},
+		{`DELETE FROM users WHERE id = $1`, userID},
+		{`DELETE FROM tenants WHERE id = $1`, tenantID},
+	}
+
+	for _, d := range deletes {
+		if _, err := tx.ExecContext(ctx, d.query, d.arg); err != nil {
+			return fmt.Errorf("delete from %s: %w", d.query, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit deletion: %w", err)
+	}
+
+	s.logger.Info("account deleted",
+		zap.String("user_id", userID),
+		zap.String("tenant_id", tenantID))
+
+	return nil
+}

--- a/internal/api/account_deletion_test.go
+++ b/internal/api/account_deletion_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestScheduleDeletion_SetsDate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Check existing.
+	mock.ExpectQuery(`SELECT deletion_scheduled_at FROM users WHERE id`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"deletion_scheduled_at"}).AddRow(nil))
+
+	// Schedule.
+	mock.ExpectExec(`UPDATE users SET deletion_scheduled_at`).
+		WithArgs(sqlmock.AnyArg(), "leaving", "user-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	scheduledAt, err := svc.ScheduleDeletion(context.Background(), "user-1", "tenant-1", "leaving")
+
+	require.NoError(t, err)
+	// Should be ~30 days in the future.
+	expected := time.Now().Add(30 * 24 * time.Hour)
+	assert.WithinDuration(t, expected, scheduledAt, 5*time.Second)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestScheduleDeletion_AlreadyScheduled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	existingDate := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT deletion_scheduled_at FROM users WHERE id`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"deletion_scheduled_at"}).AddRow(existingDate))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	scheduledAt, err := svc.ScheduleDeletion(context.Background(), "user-1", "tenant-1", "leaving again")
+
+	require.NoError(t, err)
+	assert.Equal(t, existingDate, scheduledAt)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCancelDeletion_ClearsSchedule(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE users SET deletion_scheduled_at = NULL`).
+		WithArgs("user-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	err = svc.CancelDeletion(context.Background(), "user-1")
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCancelDeletion_NoPending(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE users SET deletion_scheduled_at = NULL`).
+		WithArgs("user-1").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	err = svc.CancelDeletion(context.Background(), "user-1")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no pending deletion")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExecuteDeletion_RemovesAllData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM object_head_cache WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`DELETE FROM buckets WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(`DELETE FROM api_keys WHERE user_id`).WithArgs("user-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM tenant_quotas WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM dashboard_sessions WHERE user_id`).WithArgs("user-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM events WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 10))
+	mock.ExpectExec(`DELETE FROM webhook_endpoints WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`DELETE FROM bandwidth_usage_daily WHERE tenant_id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 30))
+	mock.ExpectExec(`DELETE FROM account_exports WHERE user_id`).WithArgs("user-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM users WHERE id`).WithArgs("user-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM tenants WHERE id`).WithArgs("tenant-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	err = svc.ExecuteDeletion(context.Background(), "user-1", "tenant-1")
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetDeletionStatus_Scheduled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	scheduledAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT deletion_scheduled_at, deletion_reason FROM users`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"deletion_scheduled_at", "deletion_reason"}).
+			AddRow(scheduledAt, "switching providers"))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	status, err := svc.GetDeletionStatus(context.Background(), "user-1")
+
+	require.NoError(t, err)
+	assert.True(t, status.Scheduled)
+	assert.Equal(t, scheduledAt, status.ScheduledAt)
+	assert.Equal(t, "switching providers", status.Reason)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetDeletionStatus_NotScheduled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT deletion_scheduled_at, deletion_reason FROM users`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"deletion_scheduled_at", "deletion_reason"}).
+			AddRow(nil, nil))
+
+	svc := NewAccountDeletionService(db, zap.NewNop())
+	status, err := svc.GetDeletionStatus(context.Background(), "user-1")
+
+	require.NoError(t, err)
+	assert.False(t, status.Scheduled)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestScheduleDeletion_NilDB(t *testing.T) {
+	svc := NewAccountDeletionService(nil, zap.NewNop())
+	_, err := svc.ScheduleDeletion(context.Background(), "user-1", "tenant-1", "test")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
+}

--- a/internal/api/account_export.go
+++ b/internal/api/account_export.go
@@ -1,0 +1,329 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type ExportResult struct {
+	ID        string          `json:"id"`
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	SizeBytes int64           `json:"file_size_bytes"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+type AccountExporter struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+func NewAccountExporter(db *sql.DB, logger *zap.Logger) *AccountExporter {
+	return &AccountExporter{db: db, logger: logger}
+}
+
+func (e *AccountExporter) CreateExport(ctx context.Context, userID, tenantID string) (*ExportResult, error) {
+	if e.db == nil {
+		return &ExportResult{Status: "completed", Data: json.RawMessage(`{}`), CreatedAt: time.Now().UTC()}, nil
+	}
+
+	var exportID string
+	err := e.db.QueryRowContext(ctx,
+		`INSERT INTO account_exports (user_id, tenant_id, status) VALUES ($1, $2, 'processing') RETURNING id`,
+		userID, tenantID).Scan(&exportID)
+	if err != nil {
+		return nil, fmt.Errorf("create export record: %w", err)
+	}
+
+	data := make(map[string]interface{})
+
+	// User profile (never expose password_hash).
+	var profile struct {
+		ID        string         `json:"id"`
+		Email     string         `json:"email"`
+		Company   sql.NullString `json:"-"`
+		Role      sql.NullString `json:"-"`
+		Status    sql.NullString `json:"-"`
+		CreatedAt sql.NullTime   `json:"-"`
+	}
+	err = e.db.QueryRowContext(ctx,
+		`SELECT id, email, company, role, status, created_at FROM users WHERE id = $1`, userID).
+		Scan(&profile.ID, &profile.Email, &profile.Company, &profile.Role, &profile.Status, &profile.CreatedAt)
+	if err == nil {
+		userData := map[string]interface{}{
+			"id":    profile.ID,
+			"email": profile.Email,
+		}
+		if profile.Company.Valid {
+			userData["company"] = profile.Company.String
+		}
+		if profile.Role.Valid {
+			userData["role"] = profile.Role.String
+		}
+		if profile.Status.Valid {
+			userData["status"] = profile.Status.String
+		}
+		if profile.CreatedAt.Valid {
+			userData["created_at"] = profile.CreatedAt.Time
+		}
+		data["user"] = userData
+	} else {
+		e.logger.Warn("export: failed to query user profile", zap.Error(err))
+	}
+
+	// Tenant info.
+	var tenantName, tenantPlan sql.NullString
+	err = e.db.QueryRowContext(ctx,
+		`SELECT name, plan FROM tenants WHERE id = $1`, tenantID).Scan(&tenantName, &tenantPlan)
+	if err == nil {
+		tenantData := map[string]interface{}{"id": tenantID}
+		if tenantName.Valid {
+			tenantData["name"] = tenantName.String
+		}
+		if tenantPlan.Valid {
+			tenantData["plan"] = tenantPlan.String
+		}
+		data["tenant"] = tenantData
+	} else {
+		e.logger.Warn("export: failed to query tenant", zap.Error(err))
+	}
+
+	// Quota info.
+	var storageUsed, storageLimit sql.NullInt64
+	var tier sql.NullString
+	err = e.db.QueryRowContext(ctx,
+		`SELECT storage_used_bytes, storage_limit_bytes, tier FROM tenant_quotas WHERE tenant_id = $1`, tenantID).
+		Scan(&storageUsed, &storageLimit, &tier)
+	if err == nil {
+		quotaData := map[string]interface{}{}
+		if storageUsed.Valid {
+			quotaData["storage_used_bytes"] = storageUsed.Int64
+		}
+		if storageLimit.Valid {
+			quotaData["storage_limit_bytes"] = storageLimit.Int64
+		}
+		if tier.Valid {
+			quotaData["tier"] = tier.String
+		}
+		data["quota"] = quotaData
+	} else {
+		e.logger.Warn("export: failed to query quota", zap.Error(err))
+	}
+
+	// Buckets.
+	data["buckets"] = e.collectBuckets(ctx, tenantID)
+
+	// Objects (from head cache).
+	data["objects"] = e.collectObjects(ctx, tenantID)
+
+	// API keys (never expose secret_hash or secret_key).
+	data["api_keys"] = e.collectAPIKeys(ctx, userID)
+
+	// Bandwidth usage (last 90 days).
+	data["bandwidth_usage"] = e.collectBandwidth(ctx, tenantID)
+
+	// Events (last 1000).
+	data["events"] = e.collectEvents(ctx, tenantID)
+
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		_, _ = e.db.ExecContext(ctx,
+			`UPDATE account_exports SET status = 'failed', error_message = $1 WHERE id = $2`,
+			err.Error(), exportID)
+		return nil, fmt.Errorf("marshal export data: %w", err)
+	}
+
+	_, _ = e.db.ExecContext(ctx,
+		`UPDATE account_exports SET status = 'completed', file_size_bytes = $1, completed_at = NOW() WHERE id = $2`,
+		len(jsonData), exportID)
+
+	return &ExportResult{
+		ID:        exportID,
+		Status:    "completed",
+		Data:      jsonData,
+		SizeBytes: int64(len(jsonData)),
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (e *AccountExporter) GetExport(ctx context.Context, exportID, userID string) (*ExportResult, error) {
+	if e.db == nil {
+		return nil, fmt.Errorf("database unavailable")
+	}
+
+	var result ExportResult
+	err := e.db.QueryRowContext(ctx,
+		`SELECT id, status, file_size_bytes, created_at FROM account_exports WHERE id = $1 AND user_id = $2`,
+		exportID, userID).Scan(&result.ID, &result.Status, &result.SizeBytes, &result.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("get export: %w", err)
+	}
+	return &result, nil
+}
+
+func (e *AccountExporter) collectBuckets(ctx context.Context, tenantID string) []map[string]interface{} {
+	rows, err := e.db.QueryContext(ctx,
+		`SELECT name, visibility, created_at, COALESCE(metadata, '{}') FROM buckets WHERE tenant_id = $1 ORDER BY name`, tenantID)
+	if err != nil {
+		e.logger.Warn("export: failed to query buckets", zap.Error(err))
+		return []map[string]interface{}{}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var buckets []map[string]interface{}
+	for rows.Next() {
+		var name, visibility string
+		var createdAt time.Time
+		var metaJSON []byte
+		if err := rows.Scan(&name, &visibility, &createdAt, &metaJSON); err != nil {
+			continue
+		}
+		b := map[string]interface{}{
+			"name":       name,
+			"visibility": visibility,
+			"created_at": createdAt,
+		}
+		var meta map[string]interface{}
+		if json.Unmarshal(metaJSON, &meta) == nil && len(meta) > 0 {
+			b["metadata"] = meta
+		}
+		buckets = append(buckets, b)
+	}
+	if buckets == nil {
+		return []map[string]interface{}{}
+	}
+	return buckets
+}
+
+func (e *AccountExporter) collectObjects(ctx context.Context, tenantID string) []map[string]interface{} {
+	rows, err := e.db.QueryContext(ctx,
+		`SELECT bucket, object_key, size, content_type, last_modified FROM object_head_cache WHERE tenant_id = $1 ORDER BY bucket, object_key`, tenantID)
+	if err != nil {
+		e.logger.Warn("export: failed to query objects", zap.Error(err))
+		return []map[string]interface{}{}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var objects []map[string]interface{}
+	for rows.Next() {
+		var bucket, key, contentType string
+		var size int64
+		var lastModified time.Time
+		if err := rows.Scan(&bucket, &key, &size, &contentType, &lastModified); err != nil {
+			continue
+		}
+		objects = append(objects, map[string]interface{}{
+			"bucket":        bucket,
+			"key":           key,
+			"size":          size,
+			"content_type":  contentType,
+			"last_modified": lastModified,
+		})
+	}
+	if objects == nil {
+		return []map[string]interface{}{}
+	}
+	return objects
+}
+
+func (e *AccountExporter) collectAPIKeys(ctx context.Context, userID string) []map[string]interface{} {
+	rows, err := e.db.QueryContext(ctx,
+		`SELECT id, name, COALESCE(permissions, '["*"]'), created_at FROM api_keys WHERE user_id = $1 ORDER BY created_at`, userID)
+	if err != nil {
+		e.logger.Warn("export: failed to query api keys", zap.Error(err))
+		return []map[string]interface{}{}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var keys []map[string]interface{}
+	for rows.Next() {
+		var id, name string
+		var permsJSON []byte
+		var createdAt time.Time
+		if err := rows.Scan(&id, &name, &permsJSON, &createdAt); err != nil {
+			continue
+		}
+		k := map[string]interface{}{
+			"id":         id,
+			"name":       name,
+			"created_at": createdAt,
+		}
+		var perms []string
+		if json.Unmarshal(permsJSON, &perms) == nil {
+			k["permissions"] = perms
+		}
+		keys = append(keys, k)
+	}
+	if keys == nil {
+		return []map[string]interface{}{}
+	}
+	return keys
+}
+
+func (e *AccountExporter) collectBandwidth(ctx context.Context, tenantID string) []map[string]interface{} {
+	rows, err := e.db.QueryContext(ctx,
+		`SELECT date, ingress_bytes, egress_bytes, requests FROM bandwidth_usage_daily WHERE tenant_id = $1 AND date >= NOW() - INTERVAL '90 days' ORDER BY date DESC`, tenantID)
+	if err != nil {
+		e.logger.Warn("export: failed to query bandwidth", zap.Error(err))
+		return []map[string]interface{}{}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var usage []map[string]interface{}
+	for rows.Next() {
+		var date time.Time
+		var ingress, egress, requests int64
+		if err := rows.Scan(&date, &ingress, &egress, &requests); err != nil {
+			continue
+		}
+		usage = append(usage, map[string]interface{}{
+			"date":          date.Format("2006-01-02"),
+			"ingress_bytes": ingress,
+			"egress_bytes":  egress,
+			"requests":      requests,
+		})
+	}
+	if usage == nil {
+		return []map[string]interface{}{}
+	}
+	return usage
+}
+
+func (e *AccountExporter) collectEvents(ctx context.Context, tenantID string) []map[string]interface{} {
+	rows, err := e.db.QueryContext(ctx,
+		`SELECT id, type, data, created_at FROM events WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 1000`, tenantID)
+	if err != nil {
+		e.logger.Warn("export: failed to query events", zap.Error(err))
+		return []map[string]interface{}{}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []map[string]interface{}
+	for rows.Next() {
+		var id, eventType string
+		var dataJSON []byte
+		var createdAt time.Time
+		if err := rows.Scan(&id, &eventType, &dataJSON, &createdAt); err != nil {
+			continue
+		}
+		ev := map[string]interface{}{
+			"id":         id,
+			"type":       eventType,
+			"created_at": createdAt,
+		}
+		var evData map[string]interface{}
+		if json.Unmarshal(dataJSON, &evData) == nil {
+			ev["data"] = evData
+		}
+		events = append(events, ev)
+	}
+	if events == nil {
+		return []map[string]interface{}{}
+	}
+	return events
+}

--- a/internal/api/account_export_test.go
+++ b/internal/api/account_export_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCreateExport_NilDB(t *testing.T) {
+	exporter := NewAccountExporter(nil, zap.NewNop())
+	result, err := exporter.CreateExport(context.Background(), "user-1", "tenant-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, json.RawMessage(`{}`), result.Data)
+}
+
+func TestCreateExport_CollectsUserData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// INSERT export record.
+	mock.ExpectQuery(`INSERT INTO account_exports`).
+		WithArgs("user-1", "tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("export-uuid"))
+
+	// User profile.
+	mock.ExpectQuery(`SELECT id, email, company, role, status, created_at FROM users`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "company", "role", "status", "created_at"}).
+			AddRow("user-1", "test@example.com", "Acme Inc", "user", "active", time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)))
+
+	// Tenant.
+	mock.ExpectQuery(`SELECT name, plan FROM tenants`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "plan"}).
+			AddRow("Acme Tenant", "starter"))
+
+	// Quota.
+	mock.ExpectQuery(`SELECT storage_used_bytes, storage_limit_bytes, tier FROM tenant_quotas`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"storage_used_bytes", "storage_limit_bytes", "tier"}).
+			AddRow(1000, 5000000000, "starter"))
+
+	// Buckets.
+	mock.ExpectQuery(`SELECT name, visibility, created_at, COALESCE`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "visibility", "created_at", "metadata"}).
+			AddRow("my-bucket", "private", time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), []byte("{}")))
+
+	// Objects.
+	mock.ExpectQuery(`SELECT bucket, object_key, size, content_type, last_modified FROM object_head_cache`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"bucket", "object_key", "size", "content_type", "last_modified"}).
+			AddRow("my-bucket", "file.txt", 42, "text/plain", time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)))
+
+	// API keys.
+	mock.ExpectQuery(`SELECT id, name, COALESCE\(permissions`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "permissions", "created_at"}).
+			AddRow("key-1", "main-key", []byte(`["*"]`), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)))
+
+	// Bandwidth.
+	mock.ExpectQuery(`SELECT date, ingress_bytes, egress_bytes, requests FROM bandwidth_usage_daily`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"date", "ingress_bytes", "egress_bytes", "requests"}))
+
+	// Events.
+	mock.ExpectQuery(`SELECT id, type, data, created_at FROM events`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "data", "created_at"}))
+
+	// Update export status.
+	mock.ExpectExec(`UPDATE account_exports SET status = 'completed'`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	exporter := NewAccountExporter(db, zap.NewNop())
+	result, err := exporter.CreateExport(context.Background(), "user-1", "tenant-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, "export-uuid", result.ID)
+	assert.Greater(t, result.SizeBytes, int64(0))
+
+	// Verify JSON structure.
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(result.Data, &data))
+	assert.Contains(t, data, "user")
+	assert.Contains(t, data, "tenant")
+	assert.Contains(t, data, "quota")
+	assert.Contains(t, data, "buckets")
+	assert.Contains(t, data, "objects")
+	assert.Contains(t, data, "api_keys")
+	assert.Contains(t, data, "bandwidth_usage")
+	assert.Contains(t, data, "events")
+
+	// Verify no password_hash in user data.
+	userData, ok := data["user"].(map[string]interface{})
+	require.True(t, ok, "user data should be a map")
+	assert.NotContains(t, userData, "password_hash")
+	assert.Equal(t, "test@example.com", userData["email"])
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetExport_NilDB(t *testing.T) {
+	exporter := NewAccountExporter(nil, zap.NewNop())
+	_, err := exporter.GetExport(context.Background(), "some-id", "user-1")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
+}

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -36,6 +36,11 @@ func (s *Server) registerManagementRoutes() {
 		r.Delete("/keys/{id}", s.handleMgmtDeleteKey)
 
 		r.Get("/usage", s.handleMgmtGetUsage)
+
+		r.Post("/account/export", s.handleMgmtExportData)
+		r.Get("/account/export/{id}", s.handleMgmtGetExport)
+		r.Delete("/account", s.handleMgmtDeleteAccount)
+		r.Post("/account/cancel-deletion", s.handleMgmtCancelDeletion)
 	})
 }
 
@@ -580,6 +585,120 @@ func (s *Server) handleMgmtGetUsage(w http.ResponseWriter, r *http.Request) {
 		"usage_percent": float64(used) / float64(limit) * 100,
 		"tier":          tier,
 		"request_id":    getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- Account (GDPR) ---
+
+func (s *Server) handleMgmtExportData(w http.ResponseWriter, r *http.Request) {
+	userID, _ := r.Context().Value(userIDKey).(string)
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if userID == "" || tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_credentials", "user or tenant not found in token", "")
+		return
+	}
+
+	exporter := NewAccountExporter(s.db, s.logger)
+	result, err := exporter.CreateExport(r.Context(), userID, tenantID)
+	if err != nil {
+		s.logger.Error("management export data", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "export_failed", "failed to create data export", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "data_export",
+		"id":         result.ID,
+		"data":       json.RawMessage(result.Data),
+		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleMgmtGetExport(w http.ResponseWriter, r *http.Request) {
+	userID, _ := r.Context().Value(userIDKey).(string)
+	if userID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_user", "user not found in token", "")
+		return
+	}
+
+	exportID := chi.URLParam(r, "id")
+	exporter := NewAccountExporter(s.db, s.logger)
+	result, err := exporter.GetExport(r.Context(), exportID, userID)
+	if err != nil {
+		writeManagementError(w, ErrTypeNotFound, "export_not_found", "export not found", "id")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":          "data_export",
+		"id":              result.ID,
+		"status":          result.Status,
+		"file_size_bytes": result.SizeBytes,
+		"created_at":      result.CreatedAt,
+		"request_id":      getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleMgmtDeleteAccount(w http.ResponseWriter, r *http.Request) {
+	userID, _ := r.Context().Value(userIDKey).(string)
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if userID == "" || tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_credentials", "user or tenant not found in token", "")
+		return
+	}
+
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if req.Reason == "" {
+		writeManagementError(w, ErrTypeInvalidRequest, "missing_parameter", "reason is required", "reason")
+		return
+	}
+
+	svc := NewAccountDeletionService(s.db, s.logger)
+	scheduledAt, err := svc.ScheduleDeletion(r.Context(), userID, tenantID, req.Reason)
+	if err != nil {
+		s.logger.Error("management delete account", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "deletion_failed", "failed to schedule account deletion", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":       "account_deletion",
+		"scheduled_at": scheduledAt,
+		"message":      "Account scheduled for deletion. You have 30 days to cancel.",
+		"request_id":   getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleMgmtCancelDeletion(w http.ResponseWriter, r *http.Request) {
+	userID, _ := r.Context().Value(userIDKey).(string)
+	if userID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_user", "user not found in token", "")
+		return
+	}
+
+	svc := NewAccountDeletionService(s.db, s.logger)
+	if err := svc.CancelDeletion(r.Context(), userID); err != nil {
+		s.logger.Error("management cancel deletion", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "cancel_failed", "failed to cancel account deletion", "")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":     "account_deletion",
+		"cancelled":  true,
+		"message":    "Account deletion has been cancelled.",
+		"request_id": getRequestID(w),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/s3_presign_test.go
+++ b/internal/api/s3_presign_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
@@ -309,15 +310,16 @@ func TestVerifyPresignedURL_PathWithSpecialChars(t *testing.T) {
 }
 
 func TestPresignedURL_Integration(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	mock.MatchExpectationsInOrder(false)
 
 	tempDir, err := os.MkdirTemp("", "presign-integration-*")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	logger, _ := zap.NewDevelopment()
+	logger := zap.NewNop()
 	driver := drivers.NewLocalDriver(tempDir, logger)
 	eng := engine.NewEngine(nil, logger, nil)
 	eng.AddDriver("local", driver)
@@ -340,15 +342,59 @@ func TestPresignedURL_Integration(t *testing.T) {
 	testContent := "hello from presigned upload"
 	objectKey := "test-upload.txt"
 
-	// PUT
+	tenantRow := sqlmock.NewRows([]string{"secret_key", "id"}).
+		AddRow(testSecretKey, testPresignTenantID)
+	suspendedRow := sqlmock.NewRows([]string{"suspended_at"})
+
+	// Auth expectations (PUT + GET each do tenant lookup + suspended check)
 	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
 		WithArgs(testAccessKey).
-		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
-			AddRow(testSecretKey, testPresignTenantID))
+		WillReturnRows(tenantRow)
 	mock.ExpectQuery(`SELECT suspended_at FROM tenants WHERE id`).
 		WithArgs(testPresignTenantID).
-		WillReturnRows(sqlmock.NewRows([]string{"suspended_at"}))
+		WillReturnRows(suspendedRow)
 
+	tenantRow2 := sqlmock.NewRows([]string{"secret_key", "id"}).
+		AddRow(testSecretKey, testPresignTenantID)
+	suspendedRow2 := sqlmock.NewRows([]string{"suspended_at"})
+	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
+		WithArgs(testAccessKey).
+		WillReturnRows(tenantRow2)
+	mock.ExpectQuery(`SELECT suspended_at FROM tenants WHERE id`).
+		WithArgs(testPresignTenantID).
+		WillReturnRows(suspendedRow2)
+
+	// HandlePut internals: object_head_cache lookup, versioning check, cache upsert
+	mock.ExpectQuery(`SELECT etag FROM object_head_cache`).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT versioning_status FROM buckets`).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec(`INSERT INTO object_head_cache`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// HandleGet internals: versioning check, object_head_cache lookup
+	mock.ExpectQuery(`SELECT versioning_status FROM buckets`).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT content_type, size_bytes, etag`).
+		WillReturnError(sql.ErrNoRows)
+
+	// Async fire-and-forget: emitEvent inserts, notification/webhook dispatch queries.
+	// These may or may not execute before the test ends. Pre-register expectations
+	// so async goroutines don't race with mock setup on the main goroutine.
+	mock.ExpectExec(`INSERT INTO events`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO events`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`SELECT target_url, event_filter FROM bucket_notifications`).
+		WillReturnRows(sqlmock.NewRows([]string{"target_url", "event_filter"}))
+	mock.ExpectQuery(`SELECT target_url, event_filter FROM bucket_notifications`).
+		WillReturnRows(sqlmock.NewRows([]string{"target_url", "event_filter"}))
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+
+	// PUT
 	now := time.Now().UTC()
 	putQ := signPresignedURL("PUT", "/"+bucket+"/"+objectKey, "localhost:8000", testAccessKey, testSecretKey, 3600, now)
 
@@ -362,14 +408,6 @@ func TestPresignedURL_Integration(t *testing.T) {
 	assert.Equal(t, http.StatusOK, putW.Code, "PUT via presigned URL should succeed")
 
 	// GET
-	mock.ExpectQuery(`SELECT secret_key, id FROM tenants WHERE access_key`).
-		WithArgs(testAccessKey).
-		WillReturnRows(sqlmock.NewRows([]string{"secret_key", "id"}).
-			AddRow(testSecretKey, testPresignTenantID))
-	mock.ExpectQuery(`SELECT suspended_at FROM tenants WHERE id`).
-		WithArgs(testPresignTenantID).
-		WillReturnRows(sqlmock.NewRows([]string{"suspended_at"}))
-
 	now = time.Now().UTC()
 	getQ := signPresignedURL("GET", "/"+bucket+"/"+objectKey, "localhost:8000", testAccessKey, testSecretKey, 3600, now)
 

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -85,6 +85,9 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/dashboard/billing` | GET | session | Billing: plan, upgrade, value stack, cost comparison |
 | `/dashboard/billing/upgrade` | POST | session | Redirect to Stripe Checkout for chosen plan |
 | `/dashboard/billing/portal` | POST | session | Redirect to Stripe Billing Portal |
+| `/dashboard/settings/export` | POST | session | Download all user data as JSON (GDPR Article 20) |
+| `/dashboard/settings/delete-account` | POST | session | Schedule account deletion with 30-day grace (GDPR Article 17) |
+| `/dashboard/settings/cancel-deletion` | POST | session | Cancel pending account deletion |
 | `/admin/tenants/{id}/bandwidth-limit` | POST | session + admin | Update tenant bandwidth limit |
 | `/admin/tenants/{id}/reset-mfa` | POST | session + admin | Reset user's 2FA |
 | `/admin/*` | GET | session + admin role | Admin panel |

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -106,6 +106,15 @@ The onboarding card in `dashboard.html` shows a 3-item checklist (bucket, object
 
 Analytics link only appears in `bucket_objects.html` for public-read buckets (gated on `{{if .CDNBaseURL}}`).
 
+## Account / GDPR (`account.go`)
+
+Three handlers for GDPR compliance (Phase 5.14.1):
+- `HandleExportData(db, logger)` — POST `/dashboard/settings/export`. Collects user profile, tenant, quota, buckets, objects, API keys, bandwidth (90d) into JSON. Returns as `Content-Disposition: attachment` download.
+- `HandleRequestDeletion(db, sessions, logger)` — POST `/dashboard/settings/delete-account`. Requires password confirmation via bcrypt. Sets `deletion_scheduled_at` 30 days out and `status = 'pending_deletion'`. Flash message with scheduled date.
+- `HandleCancelDeletion(db, logger)` — POST `/dashboard/settings/cancel-deletion`. Nulls `deletion_scheduled_at`/`deletion_reason`, sets `status = 'active'`.
+
+`populateDeletionStatus(ctx, db, userID, data)` in `settings.go` queries `deletion_scheduled_at` from users and populates `DeletionScheduled` + `DeletionDate` template data.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/account.go
+++ b/internal/dashboard/handlers/account.go
@@ -1,0 +1,263 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func HandleExportData(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Database unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		data := collectExportData(r, db, sd.UserID, sd.TenantID, logger)
+
+		filename := fmt.Sprintf("stored-ge-export-%s.json", time.Now().Format("2006-01-02"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+		_, _ = w.Write(data)
+	}
+}
+
+func HandleRequestDeletion(db *sql.DB, sessions dashauth.SessionStore, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if db == nil {
+			middleware.SetFlash(w, "error", "Database unavailable.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		password := r.FormValue("password")
+		if password == "" {
+			middleware.SetFlash(w, "error", "Password is required to delete your account.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		var passwordHash string
+		err := db.QueryRowContext(r.Context(),
+			`SELECT password_hash FROM users WHERE id = $1`, sd.UserID).Scan(&passwordHash)
+		if err != nil {
+			logger.Error("fetch password hash for deletion", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to verify password.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)); err != nil {
+			middleware.SetFlash(w, "error", "Incorrect password.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		reason := r.FormValue("reason")
+		if reason == "" {
+			reason = "User requested deletion"
+		}
+
+		scheduledAt := time.Now().Add(30 * 24 * time.Hour)
+		_, err = db.ExecContext(r.Context(),
+			`UPDATE users SET deletion_scheduled_at = $1, deletion_reason = $2, status = 'pending_deletion' WHERE id = $3 AND deletion_scheduled_at IS NULL`,
+			scheduledAt, reason, sd.UserID)
+		if err != nil {
+			logger.Error("schedule account deletion", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to schedule account deletion.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success",
+			fmt.Sprintf("Account scheduled for deletion on %s. You can cancel anytime before then.", scheduledAt.Format("January 2, 2006")))
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+func HandleCancelDeletion(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if db == nil {
+			middleware.SetFlash(w, "error", "Database unavailable.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		_, err := db.ExecContext(r.Context(),
+			`UPDATE users SET deletion_scheduled_at = NULL, deletion_reason = NULL, status = 'active' WHERE id = $1`,
+			sd.UserID)
+		if err != nil {
+			logger.Error("cancel account deletion", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to cancel deletion.")
+			http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Account deletion has been cancelled.")
+		http.Redirect(w, r, "/dashboard/settings", http.StatusSeeOther)
+	}
+}
+
+func collectExportData(r *http.Request, db *sql.DB, userID, tenantID string, logger *zap.Logger) []byte {
+	data := map[string]interface{}{
+		"exported_at": time.Now().UTC(),
+		"format":      "json",
+	}
+
+	var email, company, role, status sql.NullString
+	var createdAt sql.NullTime
+	err := db.QueryRowContext(r.Context(),
+		`SELECT email, company, role, status, created_at FROM users WHERE id = $1`, userID).
+		Scan(&email, &company, &role, &status, &createdAt)
+	if err == nil {
+		u := map[string]interface{}{"id": userID}
+		if email.Valid {
+			u["email"] = email.String
+		}
+		if company.Valid {
+			u["company"] = company.String
+		}
+		if role.Valid {
+			u["role"] = role.String
+		}
+		if status.Valid {
+			u["status"] = status.String
+		}
+		if createdAt.Valid {
+			u["created_at"] = createdAt.Time
+		}
+		data["user"] = u
+	}
+
+	var tName, tPlan sql.NullString
+	err = db.QueryRowContext(r.Context(),
+		`SELECT name, plan FROM tenants WHERE id = $1`, tenantID).Scan(&tName, &tPlan)
+	if err == nil {
+		t := map[string]interface{}{"id": tenantID}
+		if tName.Valid {
+			t["name"] = tName.String
+		}
+		if tPlan.Valid {
+			t["plan"] = tPlan.String
+		}
+		data["tenant"] = t
+	}
+
+	var storageUsed, storageLimit sql.NullInt64
+	var tier sql.NullString
+	err = db.QueryRowContext(r.Context(),
+		`SELECT storage_used_bytes, storage_limit_bytes, tier FROM tenant_quotas WHERE tenant_id = $1`, tenantID).
+		Scan(&storageUsed, &storageLimit, &tier)
+	if err == nil {
+		q := map[string]interface{}{}
+		if storageUsed.Valid {
+			q["storage_used_bytes"] = storageUsed.Int64
+		}
+		if storageLimit.Valid {
+			q["storage_limit_bytes"] = storageLimit.Int64
+		}
+		if tier.Valid {
+			q["tier"] = tier.String
+		}
+		data["quota"] = q
+	}
+
+	bucketRows, err := db.QueryContext(r.Context(),
+		`SELECT name, visibility, created_at FROM buckets WHERE tenant_id = $1 ORDER BY name`, tenantID)
+	if err == nil {
+		defer func() { _ = bucketRows.Close() }()
+		var buckets []map[string]interface{}
+		for bucketRows.Next() {
+			var bName, bVis string
+			var bCreated time.Time
+			if bucketRows.Scan(&bName, &bVis, &bCreated) == nil {
+				buckets = append(buckets, map[string]interface{}{
+					"name": bName, "visibility": bVis, "created_at": bCreated,
+				})
+			}
+		}
+		data["buckets"] = buckets
+	}
+
+	objRows, err := db.QueryContext(r.Context(),
+		`SELECT bucket, object_key, size, content_type, last_modified FROM object_head_cache WHERE tenant_id = $1 ORDER BY bucket, object_key`, tenantID)
+	if err == nil {
+		defer func() { _ = objRows.Close() }()
+		var objects []map[string]interface{}
+		for objRows.Next() {
+			var oBucket, oKey, oCT string
+			var oSize int64
+			var oMod time.Time
+			if objRows.Scan(&oBucket, &oKey, &oSize, &oCT, &oMod) == nil {
+				objects = append(objects, map[string]interface{}{
+					"bucket": oBucket, "key": oKey, "size": oSize,
+					"content_type": oCT, "last_modified": oMod,
+				})
+			}
+		}
+		data["objects"] = objects
+	}
+
+	keyRows, err := db.QueryContext(r.Context(),
+		`SELECT id, name, created_at FROM api_keys WHERE user_id = $1 ORDER BY created_at`, userID)
+	if err == nil {
+		defer func() { _ = keyRows.Close() }()
+		var keys []map[string]interface{}
+		for keyRows.Next() {
+			var kID, kName string
+			var kCreated time.Time
+			if keyRows.Scan(&kID, &kName, &kCreated) == nil {
+				keys = append(keys, map[string]interface{}{
+					"id": kID, "name": kName, "created_at": kCreated,
+				})
+			}
+		}
+		data["api_keys"] = keys
+	}
+
+	bwRows, err := db.QueryContext(r.Context(),
+		`SELECT date, ingress_bytes, egress_bytes, requests FROM bandwidth_usage_daily WHERE tenant_id = $1 AND date >= NOW() - INTERVAL '90 days' ORDER BY date DESC`, tenantID)
+	if err == nil {
+		defer func() { _ = bwRows.Close() }()
+		var bw []map[string]interface{}
+		for bwRows.Next() {
+			var bDate time.Time
+			var ingress, egress, reqs int64
+			if bwRows.Scan(&bDate, &ingress, &egress, &reqs) == nil {
+				bw = append(bw, map[string]interface{}{
+					"date": bDate.Format("2006-01-02"), "ingress_bytes": ingress,
+					"egress_bytes": egress, "requests": reqs,
+				})
+			}
+		}
+		data["bandwidth_usage"] = bw
+	}
+
+	out, _ := json.MarshalIndent(data, "", "  ")
+	return out
+}

--- a/internal/dashboard/handlers/account_test.go
+++ b/internal/dashboard/handlers/account_test.go
@@ -1,0 +1,191 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func injectAccountSession(req *http.Request) *http.Request {
+	sd := &dashauth.SessionData{
+		UserID:   "user-123",
+		TenantID: "tenant-456",
+		Email:    "test@stored.ge",
+		Role:     "user",
+	}
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	return req.WithContext(ctx)
+}
+
+func TestHandleExportData_NoSession(t *testing.T) {
+	handler := HandleExportData(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/export", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleExportData_NoDB(t *testing.T) {
+	handler := HandleExportData(nil, zap.NewNop())
+
+	req := injectAccountSession(httptest.NewRequest("POST", "/dashboard/settings/export", nil))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleExportData_ReturnsJSON(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// User query.
+	mock.ExpectQuery(`SELECT email, company, role, status, created_at FROM users`).
+		WithArgs("user-123").
+		WillReturnRows(sqlmock.NewRows([]string{"email", "company", "role", "status", "created_at"}).
+			AddRow("test@stored.ge", "TestCo", "user", "active", time.Now()))
+
+	// Tenant query.
+	mock.ExpectQuery(`SELECT name, plan FROM tenants`).
+		WithArgs("tenant-456").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "plan"}).
+			AddRow("Test Tenant", "starter"))
+
+	// Quota query.
+	mock.ExpectQuery(`SELECT storage_used_bytes, storage_limit_bytes, tier FROM tenant_quotas`).
+		WithArgs("tenant-456").
+		WillReturnRows(sqlmock.NewRows([]string{"storage_used_bytes", "storage_limit_bytes", "tier"}).
+			AddRow(500, 5000000000, "starter"))
+
+	// Buckets query.
+	mock.ExpectQuery(`SELECT name, visibility, created_at FROM buckets`).
+		WithArgs("tenant-456").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "visibility", "created_at"}))
+
+	// Objects query.
+	mock.ExpectQuery(`SELECT bucket, object_key, size, content_type, last_modified FROM object_head_cache`).
+		WithArgs("tenant-456").
+		WillReturnRows(sqlmock.NewRows([]string{"bucket", "object_key", "size", "content_type", "last_modified"}))
+
+	// API keys query.
+	mock.ExpectQuery(`SELECT id, name, created_at FROM api_keys`).
+		WithArgs("user-123").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "created_at"}))
+
+	// Bandwidth query.
+	mock.ExpectQuery(`SELECT date, ingress_bytes, egress_bytes, requests FROM bandwidth_usage_daily`).
+		WithArgs("tenant-456").
+		WillReturnRows(sqlmock.NewRows([]string{"date", "ingress_bytes", "egress_bytes", "requests"}))
+
+	handler := HandleExportData(db, zap.NewNop())
+
+	req := injectAccountSession(httptest.NewRequest("POST", "/dashboard/settings/export", nil))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "stored-ge-export-")
+	assert.Contains(t, w.Body.String(), `"exported_at"`)
+	assert.Contains(t, w.Body.String(), `"user"`)
+}
+
+func TestHandleRequestDeletion_NoSession(t *testing.T) {
+	handler := HandleRequestDeletion(nil, nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/delete-account", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleRequestDeletion_WrongPassword(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
+	mock.ExpectQuery(`SELECT password_hash FROM users`).
+		WithArgs("user-123").
+		WillReturnRows(sqlmock.NewRows([]string{"password_hash"}).AddRow(string(hash)))
+
+	handler := HandleRequestDeletion(db, nil, zap.NewNop())
+
+	form := url.Values{"password": {"wrong-password"}}
+	req := injectAccountSession(httptest.NewRequest("POST", "/dashboard/settings/delete-account", strings.NewReader(form.Encode())))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+	// Flash cookie should contain error.
+	cookies := w.Result().Cookies()
+	hasFlash := false
+	for _, c := range cookies {
+		if c.Name == "flash" {
+			hasFlash = true
+			decoded, _ := url.ParseQuery(c.Value)
+			assert.Contains(t, decoded.Get("error"), "Incorrect password")
+		}
+	}
+	assert.True(t, hasFlash, "should set flash cookie on wrong password")
+}
+
+func TestHandleCancelDeletion_NoSession(t *testing.T) {
+	handler := HandleCancelDeletion(nil, zap.NewNop())
+
+	req := httptest.NewRequest("POST", "/dashboard/settings/cancel-deletion", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleCancelDeletion_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE users SET deletion_scheduled_at = NULL`).
+		WithArgs("user-123").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	handler := HandleCancelDeletion(db, zap.NewNop())
+
+	req := injectAccountSession(httptest.NewRequest("POST", "/dashboard/settings/cancel-deletion", nil))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/dashboard/settings", w.Header().Get("Location"))
+	// Flash cookie should contain success.
+	cookies := w.Result().Cookies()
+	hasFlash := false
+	for _, c := range cookies {
+		if c.Name == "flash" {
+			hasFlash = true
+			decoded, _ := url.ParseQuery(c.Value)
+			assert.Contains(t, decoded.Get("success"), "cancelled")
+		}
+	}
+	assert.True(t, hasFlash, "should set flash cookie on cancel success")
+}

--- a/internal/dashboard/handlers/settings.go
+++ b/internal/dashboard/handlers/settings.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"database/sql"
 	"html/template"
 	"net/http"
@@ -34,6 +35,9 @@ func HandleSettings(tmpl *template.Template, authSvc *auth.AuthService, db *sql.
 
 		// Active sessions list.
 		data["SessionRows"] = loadSessionRows(r, sessions, sd.UserID, logger)
+
+		// Account deletion status.
+		populateDeletionStatus(r.Context(), db, sd.UserID, data)
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
@@ -244,5 +248,18 @@ func populateProfile(authSvc *auth.AuthService, db *sql.DB, r *http.Request, sd 
 		if err == nil && prefs != nil {
 			data["EmailNotifications"] = prefs.EmailNotifications
 		}
+	}
+}
+
+func populateDeletionStatus(ctx context.Context, db *sql.DB, userID string, data map[string]any) {
+	if db == nil {
+		return
+	}
+	var scheduledAt sql.NullTime
+	err := db.QueryRowContext(ctx,
+		`SELECT deletion_scheduled_at FROM users WHERE id = $1`, userID).Scan(&scheduledAt)
+	if err == nil && scheduledAt.Valid {
+		data["DeletionScheduled"] = true
+		data["DeletionDate"] = scheduledAt.Time.Format("January 2, 2006")
 	}
 }

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -186,6 +186,11 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Post("/settings/mfa/enable", handlers.HandleMFAEnable(settingsTmpl, deps.Auth, deps.MFA, deps.Logger))
 		dr.Post("/settings/mfa/disable", handlers.HandleMFADisable(settingsTmpl, deps.Auth, deps.Logger))
 
+		// GDPR: data export + account deletion.
+		dr.Post("/settings/export", handlers.HandleExportData(deps.DB, deps.Logger))
+		dr.Post("/settings/delete-account", handlers.HandleRequestDeletion(deps.DB, deps.Sessions, deps.Logger))
+		dr.Post("/settings/cancel-deletion", handlers.HandleCancelDeletion(deps.DB, deps.Logger))
+
 		// Email verification resend.
 		dr.Post("/settings/resend-verify", handlers.HandleResendVerification(deps.Auth, deps.Logger, deps.Email, deps.BaseURL))
 

--- a/internal/dashboard/templates/customer/settings.html
+++ b/internal/dashboard/templates/customer/settings.html
@@ -128,6 +128,42 @@
     {{end}}
 </div>
 
+<div class="card">
+    <div class="card-title">Export My Data</div>
+    <p class="text-muted" style="margin-bottom: 1rem;">Download all your data (profile, buckets, objects, usage, API keys) as a JSON file.</p>
+    <form method="POST" action="/dashboard/settings/export">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <button type="submit" class="btn btn-primary">Export Data</button>
+    </form>
+</div>
+
+<div class="card" style="border: 1px solid var(--danger, #dc3545);">
+    <div class="card-title" style="color: var(--danger, #dc3545);">Delete Account</div>
+    {{if .DeletionScheduled}}
+    <div class="alert alert-error" style="margin-bottom: 1rem;">
+        Your account is scheduled for deletion on <strong>{{.DeletionDate}}</strong>. All data will be permanently removed after this date.
+    </div>
+    <form method="POST" action="/dashboard/settings/cancel-deletion">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <button type="submit" class="btn btn-primary">Cancel Deletion</button>
+    </form>
+    {{else}}
+    <p class="text-muted" style="margin-bottom: 1rem;">Permanently delete your account and all associated data. You will have a 30-day grace period to change your mind.</p>
+    <form method="POST" action="/dashboard/settings/delete-account">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <div class="form-group">
+            <label>Confirm your password</label>
+            <input type="password" name="password" required>
+        </div>
+        <div class="form-group">
+            <label>Reason for leaving (optional)</label>
+            <textarea name="reason" rows="2" placeholder="Help us improve..."></textarea>
+        </div>
+        <button type="submit" class="btn btn-danger" onclick="return confirm('Are you sure? Your account will be scheduled for deletion in 30 days.');">Delete Account</button>
+    </form>
+    {{end}}
+</div>
+
 <div class="dashboard-actions">
     <a href="/dashboard/" class="btn">Back to Dashboard</a>
 </div>

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -28,10 +28,11 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 034 | Free tier defaults: `tenant_quotas` column defaults changed to tier='free', storage_limit_bytes=5368709120 (5 GB). Existing rows unchanged. |
 | 035 | CDN analytics: `cdn_access_log` (per-request log), `cdn_stats_daily` (tenant+bucket+date rollup) |
 | 036 | MFA Delete: `mfa_delete_enabled` BOOLEAN on `buckets` (default FALSE) |
+| 038 | Account deletion: `deletion_scheduled_at` + `deletion_reason` on users, `account_exports` table |
 
 ## Key Tables
 
-- **users** — `id (UUID)`, `email`, `password_hash`, `company`, `status`, `role`, `stripe_customer_id`
+- **users** — `id (UUID)`, `email`, `password_hash`, `company`, `status`, `role`, `stripe_customer_id`, `deletion_scheduled_at`, `deletion_reason`
 - **tenants** — `id`, `name`, `email`, `access_key`, `secret_key`, `slug`, `slug_locked`, `stripe_customer_id`, `stripe_subscription_id`, `subscription_status`, `plan`, `suspended_at`
 - **api_keys** — `id (UUID)`, `user_id → users`, `name`, `key_id`, `secret_hash`, `secret_key`, `permissions` (JSONB, default `["*"]`), `bucket_scope` (TEXT[]), `ip_allowlist` (TEXT[]), `expires_at`
 - **tenant_quotas** — `tenant_id (PK)`, `storage_limit_bytes`, `storage_used_bytes`, `tier`
@@ -52,6 +53,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **webhook_deliveries** — `id (PK)`, `webhook_id → webhook_endpoints`, `event_id → events`, `status`, `response_code`, `response_body`, `latency_ms`, `retry_count`, `next_retry_at`, `created_at` — delivery tracking
 - **cdn_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `bytes_sent`, `country`, `referer`, `accessed_at` — raw CDN access events
 - **cdn_stats_daily** — `(tenant_id, bucket, date) PK`, `requests`, `bytes_sent`, `unique_objects` — daily CDN rollup
+- **account_exports** — `id (UUID PK)`, `user_id → users`, `tenant_id`, `status` (pending/processing/completed/failed), `format`, `file_path`, `file_size_bytes`, `error_message`, `created_at`, `completed_at`, `expires_at` — GDPR data export tracking
 
 ## Connection
 

--- a/internal/database/migrations/038_account_deletion.sql
+++ b/internal/database/migrations/038_account_deletion.sql
@@ -1,0 +1,23 @@
+-- 036_account_deletion.sql
+-- Phase 5.14.1: GDPR Data Export + Account Deletion
+-- Idempotent — safe to re-run on every deploy
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deletion_scheduled_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deletion_reason TEXT;
+
+CREATE TABLE IF NOT EXISTS account_exports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tenant_id VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    format VARCHAR(20) NOT NULL DEFAULT 'json',
+    file_path TEXT,
+    file_size_bytes BIGINT DEFAULT 0,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    CONSTRAINT valid_export_status CHECK (status IN ('pending','processing','completed','failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_exports_user ON account_exports(user_id, created_at DESC);


### PR DESCRIPTION
## Summary

- **GDPR Article 20 (Data Portability)**: Self-service JSON export of all user data (profile, tenant, quota, buckets, objects, API keys, bandwidth, events) via management API and dashboard download button
- **GDPR Article 17 (Right to Erasure)**: Account deletion with 30-day grace period — password-confirmed scheduling, cancellation, and transactional cascading delete (wired for future background execution)
- **Migration 036**: `deletion_scheduled_at` + `deletion_reason` on `users` table, `account_exports` tracking table

### New files
| File | Purpose |
|------|---------|
| `internal/database/migrations/036_account_deletion.sql` | Schema changes |
| `internal/api/account_export.go` | `AccountExporter` — collects all user data into JSON |
| `internal/api/account_deletion.go` | `AccountDeletionService` — schedule/cancel/execute deletion |
| `internal/api/management_routes.go` (modified) | 4 new endpoints under `/api/v1/manage/account/` |
| `internal/dashboard/handlers/account.go` | Dashboard handlers: export download, request deletion, cancel deletion |
| `internal/dashboard/templates/customer/settings.html` (modified) | Export Data + Delete Account cards |
| `internal/dashboard/router.go` (modified) | 3 new POST routes wired |

### Management API endpoints
- `POST /api/v1/manage/account/export` — create data export, returns JSON inline
- `GET /api/v1/manage/account/export/{id}` — get export metadata
- `DELETE /api/v1/manage/account` — schedule deletion (requires `{"reason":"..."}`)
- `POST /api/v1/manage/account/cancel-deletion` — cancel pending deletion

### Dashboard routes
- `POST /dashboard/settings/export` — download JSON attachment
- `POST /dashboard/settings/delete-account` — password-confirmed deletion scheduling
- `POST /dashboard/settings/cancel-deletion` — cancel with flash message

## Test plan

- [x] 11 API tests (export with mock DB, nil DB, deletion schedule/cancel/execute/status)
- [x] 7 dashboard handler tests (no session redirects, export JSON response, wrong password flash, cancel success)
- [x] `make build` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass with `-race`
- [ ] CI `build-and-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)