### PR TITLE
feat(legal): privacy, terms, DPA, cookie, AUP pages [Phase 5.14.2]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -48,6 +48,11 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/register` | GET | none | Registration page |
 | `/register` | POST | none | Create user+tenant, create session, redirect to /dashboard |
 | `/logout` | GET | none | Delete session, clear cookie, redirect to /login |
+| `/legal/privacy` | GET | none | Privacy Policy (GDPR-compliant) |
+| `/legal/terms` | GET | none | Terms of Service |
+| `/legal/dpa` | GET | none | Data Processing Agreement (Article 28) |
+| `/legal/cookies` | GET | none | Cookie Policy |
+| `/legal/aup` | GET | none | Acceptable Use Policy |
 | `/dashboard/` | GET | session | Overview: storage gauge, bandwidth, stats, activity |
 | `/dashboard/buckets` | GET | session | Bucket list with counts + sizes |
 | `/dashboard/buckets` | POST | session | Create new bucket (validates name, creates directory) |

--- a/internal/dashboard/handlers/legal.go
+++ b/internal/dashboard/handlers/legal.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+)
+
+// HandleLegalPage renders a public legal document page.
+// No session or database access required.
+func HandleLegalPage(tmpl *template.Template) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = tmpl.ExecuteTemplate(w, "base", map[string]any{"Page": "legal"})
+	}
+}

--- a/internal/dashboard/handlers/legal_test.go
+++ b/internal/dashboard/handlers/legal_test.go
@@ -1,0 +1,139 @@
+package handlers_test
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/dashboard/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const baseLayout = `{{define "base"}}<!DOCTYPE html><html><body>{{block "content" .}}{{end}}</body></html>{{end}}`
+
+func legalTmpl(t *testing.T, content string) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(baseLayout))
+	template.Must(tmpl.Parse(content))
+	return tmpl
+}
+
+func TestHandleLegalPage_ReturnsHTML(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "title"}}Test — stored.ge{{end}}{{define "content"}}<h1>Test Page</h1>{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/test", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, rec.Body.String(), "<h1>Test Page</h1>")
+}
+
+func TestLegalPrivacy_ContainsGDPRSections(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<h2 id="data-subject-rights">Data Subject Rights</h2>`+
+		`<h2 id="lawful-basis">Lawful Basis for Processing</h2>`+
+		`<h2 id="retention">Retention Periods</h2>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/privacy", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Data Subject Rights")
+	assert.Contains(t, body, "Lawful Basis")
+	assert.Contains(t, body, "Retention")
+}
+
+func TestLegalTerms_ContainsSLA(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<h2 id="service-level">Service Level Agreement</h2>`+
+		`<h2 id="liability">Limitation of Liability</h2>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/terms", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Service Level")
+	assert.Contains(t, body, "Limitation of Liability")
+}
+
+func TestLegalDPA_ContainsArticle28(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<p>Article 28 of the GDPR</p>`+
+		`<h2 id="sub-processors">Sub-processors</h2>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/dpa", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Article 28")
+	assert.Contains(t, body, "Sub-processors")
+}
+
+func TestLegalCookies_NoTracking(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<h2 id="no-tracking">No Tracking Cookies</h2>`+
+		`<p>stored.ge does <strong>not</strong> use analytics or advertising cookies.</p>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/cookies", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "No Tracking Cookies")
+	assert.Contains(t, body, "not")
+}
+
+func TestLegalAUP_ContainsProhibited(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<h2 id="prohibited-content">Prohibited Content</h2>`+
+		`<h2 id="enforcement">Enforcement</h2>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/aup", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Prohibited Content")
+	assert.Contains(t, body, "Enforcement")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -92,6 +92,20 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 			deps.Auth, deps.Sessions, deps.DB, deps.Logger))
 	}
 
+	// --- Legal pages (public) ---
+	legalPages := map[string]string{
+		"privacy": "templates/legal/privacy.html",
+		"terms":   "templates/legal/terms.html",
+		"dpa":     "templates/legal/dpa.html",
+		"cookies": "templates/legal/cookies.html",
+		"aup":     "templates/legal/aup.html",
+	}
+	for slug, tmplPath := range legalPages {
+		pageTmpl := template.Must(baseTmpl.Clone())
+		template.Must(pageTmpl.ParseFS(Templates, tmplPath))
+		r.Get("/legal/"+slug, handlers.HandleLegalPage(pageTmpl))
+	}
+
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
 		dr.Use(middleware.Recovery(deps.Logger))

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -289,6 +289,10 @@ th {
     border-top: 1px solid var(--border);
     margin-top: 3rem;
 }
+.footer .container { display: flex; justify-content: center; align-items: center; gap: 1rem; flex-wrap: wrap; }
+.footer-links { display: flex; gap: 0.75rem; }
+.footer-links a { color: var(--text-muted); text-decoration: none; }
+.footer-links a:hover { color: var(--primary); }
 
 /* Dashboard header */
 .dashboard-header { margin-bottom: 1.5rem; }

--- a/internal/dashboard/templates/layouts/base.html
+++ b/internal/dashboard/templates/layouts/base.html
@@ -54,6 +54,11 @@
     <footer class="footer">
         <div class="container">
             <span>&copy; 2026 FairForge LLC &mdash; stored.ge</span>
+            <span class="footer-links">
+                <a href="/legal/privacy">Privacy</a>
+                <a href="/legal/terms">Terms</a>
+                <a href="/legal/cookies">Cookies</a>
+            </span>
         </div>
     </footer>
 </body>

--- a/internal/dashboard/templates/legal/aup.html
+++ b/internal/dashboard/templates/legal/aup.html
@@ -1,0 +1,60 @@
+{{define "title"}}Acceptable Use Policy — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Acceptable Use Policy</h1>
+    <p>This Acceptable Use Policy ("AUP") defines prohibited content and activities on the stored.ge object storage service operated by FairForge LLC. This policy supplements the <a href="/legal/terms">Terms of Service</a>.</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#prohibited-content">Prohibited Content</a></li>
+        <li><a href="#prohibited-activities">Prohibited Activities</a></li>
+        <li><a href="#enforcement">Enforcement</a></li>
+        <li><a href="#reporting">Reporting Abuse</a></li>
+        <li><a href="#contact">Contact</a></li>
+    </ul>
+
+    <h2 id="prohibited-content">Prohibited Content</h2>
+    <p>You may not use stored.ge to store, distribute, or serve any of the following:</p>
+    <ul>
+        <li><strong>Malware</strong> — viruses, trojans, ransomware, spyware, or any other malicious software designed to damage or gain unauthorized access to systems.</li>
+        <li><strong>Child sexual abuse material (CSAM)</strong> — any content that depicts the sexual exploitation or abuse of minors. We report all CSAM to the National Center for Missing &amp; Exploited Children (NCMEC) and relevant law enforcement.</li>
+        <li><strong>Phishing</strong> — pages, files, or assets designed to deceive users into revealing credentials, financial information, or personal data.</li>
+        <li><strong>Copyright infringement</strong> — content that you do not have the right to distribute, including pirated software, media, or other copyrighted material. We respond to valid DMCA takedown notices.</li>
+        <li><strong>Illegal content</strong> — any content that violates applicable law in the United States or the jurisdiction of the uploader, including but not limited to content promoting terrorism, trafficking, or fraud.</li>
+    </ul>
+
+    <h2 id="prohibited-activities">Prohibited Activities</h2>
+    <p>You may not use stored.ge to:</p>
+    <ul>
+        <li><strong>Launch or facilitate DDoS attacks</strong> — using our infrastructure to amplify, relay, or originate denial-of-service attacks against any target.</li>
+        <li><strong>Scrape or abuse other services</strong> — using stored.ge as a staging area for automated scraping, credential stuffing, or attacks against third-party services.</li>
+        <li><strong>Mine cryptocurrency</strong> — using our compute or network resources for cryptocurrency mining or proof-of-work operations.</li>
+        <li><strong>Distribute spam</strong> — hosting content used in unsolicited bulk email campaigns, SMS spam, or social media spam.</li>
+        <li><strong>Circumvent access controls</strong> — attempting to access other customers' data, bypassing authentication mechanisms, or exploiting vulnerabilities in the service.</li>
+    </ul>
+
+    <h2 id="enforcement">Enforcement</h2>
+    <p>Violations of this AUP are handled through a graduated enforcement process:</p>
+    <ol>
+        <li><strong>Warning</strong> — for first-time or minor violations, we will notify you by email and request remediation within 48 hours.</li>
+        <li><strong>Suspension</strong> — if the violation is not remediated, or for repeated violations, your account will be suspended. Suspended accounts cannot upload or serve objects, but existing data is preserved.</li>
+        <li><strong>Termination</strong> — for severe or repeated violations, your account will be permanently terminated and all data deleted.</li>
+    </ol>
+    <p><strong>Immediate action:</strong> For severe violations (CSAM, active malware distribution, ongoing DDoS), we may suspend or terminate your account immediately without prior warning. We will notify you by email with an explanation.</p>
+
+    <h2 id="reporting">Reporting Abuse</h2>
+    <p>To report content or activity that violates this policy:</p>
+    <ul>
+        <li><strong>Email:</strong> abuse@stored.ge</li>
+    </ul>
+    <p>Please include the URL or bucket/object path of the offending content, a description of the violation, and your contact information. We investigate all reports and respond within 48 hours.</p>
+
+    <h2 id="contact">Contact</h2>
+    <p>For questions about this Acceptable Use Policy:</p>
+    <ul>
+        <li><strong>Email:</strong> abuse@stored.ge</li>
+        <li><strong>Entity:</strong> FairForge LLC</li>
+    </ul>
+</div>
+{{end}}

--- a/internal/dashboard/templates/legal/cookies.html
+++ b/internal/dashboard/templates/legal/cookies.html
@@ -1,0 +1,77 @@
+{{define "title"}}Cookie Policy — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Cookie Policy</h1>
+    <p>This Cookie Policy explains how FairForge LLC ("stored.ge", "we", "us") uses cookies on the stored.ge website and dashboard.</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#what-are-cookies">What Are Cookies</a></li>
+        <li><a href="#cookies-we-use">Cookies We Use</a></li>
+        <li><a href="#no-tracking">No Tracking Cookies</a></li>
+        <li><a href="#lawful-basis">Lawful Basis</a></li>
+        <li><a href="#managing-cookies">Managing Cookies</a></li>
+        <li><a href="#contact">Contact</a></li>
+    </ul>
+
+    <h2 id="what-are-cookies">What Are Cookies</h2>
+    <p>Cookies are small text files placed on your device by your web browser when you visit a website. They are used to remember your preferences, maintain sessions, and provide security features.</p>
+
+    <h2 id="cookies-we-use">Cookies We Use</h2>
+    <p>stored.ge uses only strictly necessary cookies required for the service to function. We use the following cookies:</p>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Cookie Name</th>
+                <th>Purpose</th>
+                <th>Type</th>
+                <th>Duration</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>vaultaire_session</code></td>
+                <td>Maintains your authenticated session after login.</td>
+                <td>HttpOnly, Secure, SameSite=Lax</td>
+                <td>24 hours</td>
+            </tr>
+            <tr>
+                <td><code>csrf_token</code></td>
+                <td>Protects against cross-site request forgery attacks using the double-submit cookie pattern.</td>
+                <td>Secure, SameSite=Lax</td>
+                <td>Session (browser close)</td>
+            </tr>
+            <tr>
+                <td><code>flash</code></td>
+                <td>Displays one-time feedback messages (e.g., "Settings saved") after form submissions.</td>
+                <td>HttpOnly, SameSite=Lax</td>
+                <td>60 seconds</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2 id="no-tracking">No Tracking Cookies</h2>
+    <p>stored.ge does <strong>not</strong> use:</p>
+    <ul>
+        <li>Analytics cookies (no Google Analytics, no Plausible, no Matomo).</li>
+        <li>Advertising or remarketing cookies.</li>
+        <li>Third-party cookies of any kind.</li>
+        <li>Fingerprinting or any other cross-site tracking technology.</li>
+    </ul>
+    <p>We do not track your browsing behavior, build advertising profiles, or share any data with ad networks.</p>
+
+    <h2 id="lawful-basis">Lawful Basis</h2>
+    <p>All cookies used by stored.ge are <strong>strictly necessary</strong> for the operation of the service (session management, security, and user feedback). Under GDPR and the ePrivacy Directive, strictly necessary cookies do not require consent. Therefore, no cookie consent banner is displayed.</p>
+
+    <h2 id="managing-cookies">Managing Cookies</h2>
+    <p>You can control cookies through your browser settings. Note that disabling cookies will prevent you from logging in to the stored.ge dashboard, as the session cookie is required for authentication. Clearing cookies will log you out of your current session.</p>
+
+    <h2 id="contact">Contact</h2>
+    <p>For questions about our use of cookies:</p>
+    <ul>
+        <li><strong>Email:</strong> privacy@stored.ge</li>
+        <li><strong>Entity:</strong> FairForge LLC</li>
+    </ul>
+</div>
+{{end}}

--- a/internal/dashboard/templates/legal/dpa.html
+++ b/internal/dashboard/templates/legal/dpa.html
@@ -1,0 +1,164 @@
+{{define "title"}}Data Processing Agreement — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Data Processing Agreement</h1>
+    <p>This Data Processing Agreement ("DPA") supplements the <a href="/legal/terms">Terms of Service</a> and is entered into between the customer identified below ("Controller") and FairForge LLC ("Processor", "stored.ge") pursuant to Article 28 of the General Data Protection Regulation (EU) 2016/679 ("GDPR").</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#definitions">Definitions and Roles</a></li>
+        <li><a href="#processing-purposes">Processing Purposes</a></li>
+        <li><a href="#obligations">Processor Obligations</a></li>
+        <li><a href="#security">Security Measures</a></li>
+        <li><a href="#sub-processors">Sub-processors</a></li>
+        <li><a href="#breach-notification">Breach Notification</a></li>
+        <li><a href="#audit-rights">Audit Rights</a></li>
+        <li><a href="#data-return">Data Return and Deletion</a></li>
+        <li><a href="#international-transfers">International Transfers</a></li>
+        <li><a href="#term">Term and Termination</a></li>
+        <li><a href="#countersign">Countersignature</a></li>
+    </ul>
+
+    <h2 id="definitions">Definitions and Roles</h2>
+    <ul>
+        <li><strong>Controller:</strong> The customer who determines the purposes and means of processing personal data by using the stored.ge service.</li>
+        <li><strong>Processor:</strong> FairForge LLC (stored.ge), which processes personal data on behalf of the Controller solely to provide the object storage service.</li>
+        <li><strong>Data Subjects:</strong> Individuals whose personal data is stored as objects or metadata within the Controller's stored.ge account.</li>
+    </ul>
+
+    <h2 id="processing-purposes">Processing Purposes</h2>
+    <p>The Processor processes personal data solely for the following purposes, as instructed by the Controller:</p>
+    <ul>
+        <li><strong>Storage</strong> — persisting objects uploaded by the Controller via the S3-compatible API.</li>
+        <li><strong>Delivery</strong> — serving objects to authorized requesters via API or CDN.</li>
+        <li><strong>Caching</strong> — temporarily caching object metadata for performance optimization.</li>
+    </ul>
+    <p>The Processor does not access, analyze, profile, or otherwise process the content of stored objects beyond the technical operations listed above.</p>
+
+    <h2 id="obligations">Processor Obligations</h2>
+    <p>The Processor shall:</p>
+    <ul>
+        <li>Process personal data only on documented instructions from the Controller.</li>
+        <li>Ensure that personnel authorized to process personal data are bound by confidentiality obligations.</li>
+        <li>Implement appropriate technical and organizational security measures.</li>
+        <li>Assist the Controller in responding to data subject requests (access, portability, erasure, rectification).</li>
+        <li>Assist the Controller with data protection impact assessments where required.</li>
+        <li>Delete or return all personal data upon termination of the service, at the Controller's choice.</li>
+        <li>Make available all information necessary to demonstrate compliance with Article 28.</li>
+    </ul>
+
+    <h2 id="security">Security Measures</h2>
+    <p>The Processor implements the following technical and organizational measures:</p>
+    <ul>
+        <li><strong>Encryption in transit</strong> — all API and dashboard traffic is encrypted via TLS 1.2 or higher.</li>
+        <li><strong>Encryption at rest</strong> — objects are stored on encrypted storage volumes.</li>
+        <li><strong>Access controls</strong> — production access is limited to authorized personnel via SSH key authentication. Customer data access requires S3 credentials (access key + secret key) or authenticated dashboard session.</li>
+        <li><strong>Authentication</strong> — passwords hashed with bcrypt (cost 12), TOTP two-factor authentication available, session tokens are cryptographically random.</li>
+        <li><strong>Monitoring</strong> — access logs retained for 90 days, anomaly detection on API usage patterns.</li>
+        <li><strong>Backups</strong> — daily PostgreSQL backups with 7-day retention, stored in a separate location from production data.</li>
+    </ul>
+
+    <h2 id="sub-processors">Sub-processors</h2>
+    <p>The Controller authorizes the Processor to engage the following sub-processors:</p>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Sub-processor</th>
+                <th>Purpose</th>
+                <th>Location</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>iDrive Inc.</td>
+                <td>Object storage infrastructure</td>
+                <td>United States</td>
+            </tr>
+            <tr>
+                <td>Stripe Inc.</td>
+                <td>Payment processing</td>
+                <td>United States</td>
+            </tr>
+            <tr>
+                <td>Cloudflare Inc.</td>
+                <td>CDN and DDoS protection</td>
+                <td>Global (edge network)</td>
+            </tr>
+        </tbody>
+    </table>
+    <p>The Processor will notify the Controller at least 30 days before adding or replacing a sub-processor, giving the Controller the opportunity to object.</p>
+
+    <h2 id="breach-notification">Breach Notification</h2>
+    <p>In the event of a personal data breach, the Processor shall:</p>
+    <ul>
+        <li>Notify the Controller without undue delay, and in any event within <strong>72 hours</strong> of becoming aware of the breach.</li>
+        <li>Provide details of the nature of the breach, categories and approximate number of data subjects affected, likely consequences, and measures taken or proposed to mitigate the breach.</li>
+        <li>Cooperate with the Controller in notifying the relevant supervisory authority and affected data subjects where required.</li>
+    </ul>
+
+    <h2 id="audit-rights">Audit Rights</h2>
+    <p>The Controller has the right to audit the Processor's compliance with this DPA. Audits may be conducted:</p>
+    <ul>
+        <li>No more than once per calendar year, with at least 30 days' written notice.</li>
+        <li>During normal business hours, at the Controller's expense.</li>
+        <li>By the Controller or a mutually agreed independent third-party auditor bound by confidentiality.</li>
+    </ul>
+    <p>The Processor will provide reasonable cooperation, including access to relevant documentation, facilities, and personnel.</p>
+
+    <h2 id="data-return">Data Return and Deletion</h2>
+    <p>Upon termination of the service agreement:</p>
+    <ul>
+        <li>The Controller may export all stored data via the S3-compatible API or the data export feature in account settings.</li>
+        <li>After a 30-day grace period following account deletion, the Processor will permanently delete all Controller data from production and backup systems within 90 days.</li>
+        <li>The Processor will provide written confirmation of deletion upon request.</li>
+    </ul>
+
+    <h2 id="international-transfers">International Transfers</h2>
+    <p>Where personal data is transferred outside the European Economic Area, the Processor ensures adequate protection through Standard Contractual Clauses (SCCs) as approved by the European Commission (Commission Implementing Decision (EU) 2021/914). The applicable SCCs are incorporated by reference into this DPA.</p>
+
+    <h2 id="term">Term and Termination</h2>
+    <p>This DPA takes effect when the Controller begins using the stored.ge service and remains in effect for the duration of the service agreement. The data protection obligations in this DPA survive termination of the service agreement until all personal data has been deleted or returned.</p>
+
+    <h2 id="countersign">Countersignature</h2>
+    <p>To execute this DPA, please complete the following and send a signed copy to <strong>privacy@stored.ge</strong>:</p>
+    <table class="table">
+        <tbody>
+            <tr>
+                <td><strong>Customer Name:</strong></td>
+                <td>________________________________________</td>
+            </tr>
+            <tr>
+                <td><strong>Customer Address:</strong></td>
+                <td>________________________________________</td>
+            </tr>
+            <tr>
+                <td><strong>Authorized Signatory:</strong></td>
+                <td>________________________________________</td>
+            </tr>
+            <tr>
+                <td><strong>Signature Date:</strong></td>
+                <td>________________________________________</td>
+            </tr>
+        </tbody>
+    </table>
+    <br>
+    <p><strong>For FairForge LLC:</strong></p>
+    <table class="table">
+        <tbody>
+            <tr>
+                <td><strong>Entity:</strong></td>
+                <td>FairForge LLC</td>
+            </tr>
+            <tr>
+                <td><strong>Address:</strong></td>
+                <td>Salt Lake City, Utah, United States</td>
+            </tr>
+            <tr>
+                <td><strong>Contact:</strong></td>
+                <td>privacy@stored.ge</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+{{end}}

--- a/internal/dashboard/templates/legal/privacy.html
+++ b/internal/dashboard/templates/legal/privacy.html
@@ -1,0 +1,94 @@
+{{define "title"}}Privacy Policy — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Privacy Policy</h1>
+    <p>This Privacy Policy describes how FairForge LLC ("<strong>stored.ge</strong>", "we", "us") collects, uses, and protects your personal data when you use our S3-compatible object storage service.</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#lawful-basis">Lawful Basis for Processing</a></li>
+        <li><a href="#data-categories">Data Categories</a></li>
+        <li><a href="#retention">Retention Periods</a></li>
+        <li><a href="#data-subject-rights">Data Subject Rights</a></li>
+        <li><a href="#sub-processors">Sub-processors</a></li>
+        <li><a href="#international-transfers">International Transfers</a></li>
+        <li><a href="#security">Security Measures</a></li>
+        <li><a href="#changes">Changes to This Policy</a></li>
+        <li><a href="#contact">Contact</a></li>
+    </ul>
+
+    <h2 id="lawful-basis">Lawful Basis for Processing</h2>
+    <p>We process your personal data under the following lawful bases as defined by the General Data Protection Regulation (GDPR):</p>
+    <ul>
+        <li><strong>Performance of a contract</strong> — processing necessary to provide the storage service you signed up for, including account management, billing, and service delivery.</li>
+        <li><strong>Legitimate interest</strong> — processing necessary for service security, fraud prevention, abuse detection, and service improvement, where these interests are not overridden by your rights.</li>
+    </ul>
+
+    <h2 id="data-categories">Data Categories</h2>
+    <p>We collect and process the following categories of personal data:</p>
+    <ul>
+        <li><strong>Account data</strong> — email address, company name, hashed password, account creation date, email verification status.</li>
+        <li><strong>Usage data</strong> — storage consumption, bandwidth usage, API request counts, bucket and object metadata (names, sizes, content types, ETags). We never access or process the content of your stored objects.</li>
+        <li><strong>Billing data</strong> — subscription plan, payment method (processed by Stripe; we do not store card numbers), invoice history, Stripe customer ID.</li>
+        <li><strong>Session data</strong> — IP address, user agent, session creation and last-active timestamps, used for active session management and security.</li>
+    </ul>
+    <p><strong>Important:</strong> We never access, read, analyze, or process the content of objects you store in our service. Object content is encrypted in transit (TLS) and treated as opaque data.</p>
+
+    <h2 id="retention">Retention Periods</h2>
+    <ul>
+        <li><strong>Account data</strong> — retained for the lifetime of your account plus 30 days after account deletion (grace period for recovery).</li>
+        <li><strong>Session and access logs</strong> — retained for 90 days, then automatically purged.</li>
+        <li><strong>Billing records</strong> — retained for 7 years to comply with financial reporting and tax obligations.</li>
+        <li><strong>Object metadata</strong> — deleted immediately when you delete the corresponding object, or within 30 days of account deletion.</li>
+    </ul>
+
+    <h2 id="data-subject-rights">Data Subject Rights</h2>
+    <p>Under the GDPR, you have the following rights regarding your personal data:</p>
+    <ul>
+        <li><strong>Right of access</strong> — request a copy of all personal data we hold about you.</li>
+        <li><strong>Right to data portability</strong> — receive your data in a structured, machine-readable format (JSON export).</li>
+        <li><strong>Right to erasure</strong> — request deletion of your account and all associated personal data, subject to a 30-day grace period.</li>
+        <li><strong>Right to rectification</strong> — correct inaccurate personal data (e.g., update your email or company name via account settings).</li>
+        <li><strong>Right to restrict processing</strong> — request that we limit how we use your data while a dispute is resolved.</li>
+        <li><strong>Right to object</strong> — object to processing based on legitimate interest.</li>
+    </ul>
+    <p>To exercise any of these rights, contact us at <strong>privacy@stored.ge</strong>. We will respond within 30 days.</p>
+
+    <h2 id="sub-processors">Sub-processors</h2>
+    <p>We use the following third-party sub-processors to deliver our service:</p>
+    <ul>
+        <li><strong>iDrive Inc.</strong> — object storage infrastructure (data storage and retrieval).</li>
+        <li><strong>Stripe Inc.</strong> — payment processing and subscription management.</li>
+        <li><strong>Cloudflare Inc.</strong> — CDN, DDoS protection, and TLS termination.</li>
+    </ul>
+    <p>Each sub-processor is bound by a Data Processing Agreement that requires GDPR-equivalent protections.</p>
+
+    <h2 id="international-transfers">International Transfers</h2>
+    <p>Your data may be transferred to and processed in the United States. We ensure adequate protection for international transfers through:</p>
+    <ul>
+        <li>Standard Contractual Clauses (SCCs) approved by the European Commission.</li>
+        <li>Sub-processor agreements that incorporate GDPR-equivalent data protection terms.</li>
+    </ul>
+
+    <h2 id="security">Security Measures</h2>
+    <ul>
+        <li>All data in transit is protected by TLS 1.2 or higher.</li>
+        <li>Passwords are hashed using bcrypt with a cost factor of 12.</li>
+        <li>Sessions use cryptographically random tokens with HttpOnly, Secure, and SameSite cookies.</li>
+        <li>Two-factor authentication (TOTP) is available for all accounts.</li>
+        <li>Access to production systems is restricted to authorized personnel with SSH key authentication.</li>
+    </ul>
+
+    <h2 id="changes">Changes to This Policy</h2>
+    <p>We may update this Privacy Policy from time to time. Material changes will be communicated via email to registered users at least 30 days before they take effect. The "Last updated" date at the top of this page reflects the most recent revision.</p>
+
+    <h2 id="contact">Contact</h2>
+    <p>For privacy-related inquiries, data subject requests, or complaints:</p>
+    <ul>
+        <li><strong>Email:</strong> privacy@stored.ge</li>
+        <li><strong>Entity:</strong> FairForge LLC</li>
+        <li><strong>Jurisdiction:</strong> State of Utah, United States</li>
+    </ul>
+</div>
+{{end}}

--- a/internal/dashboard/templates/legal/terms.html
+++ b/internal/dashboard/templates/legal/terms.html
@@ -1,0 +1,110 @@
+{{define "title"}}Terms of Service — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Terms of Service</h1>
+    <p>These Terms of Service ("Terms") govern your use of the stored.ge object storage service operated by FairForge LLC ("we", "us", "stored.ge"). By creating an account or using our service, you agree to these Terms.</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#service-description">Service Description</a></li>
+        <li><a href="#account-requirements">Account Requirements</a></li>
+        <li><a href="#acceptable-use">Acceptable Use</a></li>
+        <li><a href="#usage-limits">Usage Limits</a></li>
+        <li><a href="#service-level">Service Level Agreement</a></li>
+        <li><a href="#data-ownership">Data Ownership</a></li>
+        <li><a href="#billing">Billing and Payment</a></li>
+        <li><a href="#termination">Termination</a></li>
+        <li><a href="#liability">Limitation of Liability</a></li>
+        <li><a href="#governing-law">Governing Law and Disputes</a></li>
+        <li><a href="#changes">Changes to These Terms</a></li>
+        <li><a href="#contact">Contact</a></li>
+    </ul>
+
+    <h2 id="service-description">Service Description</h2>
+    <p>stored.ge provides S3-compatible object storage. You can store, retrieve, and manage objects (files) via our API, dashboard, or any S3-compatible client. The service includes:</p>
+    <ul>
+        <li>S3-compatible API for object operations (GET, PUT, DELETE, LIST, HEAD).</li>
+        <li>Web dashboard for account management, bucket configuration, and usage monitoring.</li>
+        <li>API key management with scoped access control.</li>
+        <li>CDN delivery for public buckets.</li>
+    </ul>
+
+    <h2 id="account-requirements">Account Requirements</h2>
+    <ul>
+        <li>You must provide a valid email address to create an account.</li>
+        <li>You are responsible for maintaining the security of your account credentials, API keys, and access tokens.</li>
+        <li>You must be at least 16 years old (or the minimum age in your jurisdiction) to use this service.</li>
+        <li>One person or entity may maintain multiple accounts, but each account must have a unique email address.</li>
+    </ul>
+
+    <h2 id="acceptable-use">Acceptable Use</h2>
+    <p>Your use of stored.ge is subject to our <a href="/legal/aup">Acceptable Use Policy</a>, which prohibits storing illegal content, distributing malware, and other abusive activities. Violations may result in immediate suspension or termination.</p>
+
+    <h2 id="usage-limits">Usage Limits</h2>
+    <p>Your storage, bandwidth, and API usage are subject to the limits of your subscription plan. Current plan limits are displayed on your dashboard. If you exceed your plan limits:</p>
+    <ul>
+        <li>Additional storage usage may be billed at the overage rate specified in your plan.</li>
+        <li>We may throttle API requests that exceed rate limits.</li>
+        <li>We will notify you before taking any action that affects your ability to access stored data.</li>
+    </ul>
+
+    <h2 id="service-level">Service Level Agreement</h2>
+    <p>We target <strong>99.9% monthly uptime</strong> for the stored.ge API, measured as the percentage of successful requests (non-5xx responses) relative to total requests in a calendar month. This excludes:</p>
+    <ul>
+        <li>Scheduled maintenance windows (announced at least 48 hours in advance).</li>
+        <li>Force majeure events.</li>
+        <li>Issues caused by client-side misconfiguration or abuse.</li>
+    </ul>
+    <p>If we fail to meet the 99.9% target in a given month, affected paid customers may request a service credit by contacting support within 30 days. Credits are applied as a percentage of that month's charges proportional to the downtime experienced.</p>
+
+    <h2 id="data-ownership">Data Ownership</h2>
+    <p><strong>You own your data.</strong> We claim no ownership rights over any content you upload to stored.ge. You retain all rights, title, and interest in your objects and metadata. We will not access, use, or disclose the content of your stored objects except:</p>
+    <ul>
+        <li>As necessary to provide the service (storage, delivery, caching).</li>
+        <li>As required by law (with notice to you where permitted).</li>
+    </ul>
+
+    <h2 id="billing">Billing and Payment</h2>
+    <ul>
+        <li>Paid plans are billed monthly in advance via Stripe.</li>
+        <li>You may upgrade or downgrade your plan at any time through the billing page.</li>
+        <li>Refunds are handled on a case-by-case basis; contact support within 14 days of a charge.</li>
+        <li>If payment fails, we will attempt to collect for up to 14 days before suspending your account. Your data is preserved during suspension.</li>
+    </ul>
+
+    <h2 id="termination">Termination</h2>
+    <ul>
+        <li><strong>By you:</strong> You may delete your account at any time through your account settings. Account deletion enters a 30-day grace period during which you can cancel the deletion and recover your data. After the grace period, all data is permanently deleted.</li>
+        <li><strong>By us (AUP violation):</strong> We may suspend or terminate your account immediately for Acceptable Use Policy violations. For severe violations (malware, CSAM, phishing), data may be deleted immediately without a grace period.</li>
+        <li><strong>By us (non-payment):</strong> Accounts suspended for non-payment are retained for 30 days. If payment is not resolved, the account enters the standard deletion process.</li>
+    </ul>
+
+    <h2 id="liability">Limitation of Liability</h2>
+    <p>To the maximum extent permitted by applicable law:</p>
+    <ul>
+        <li>stored.ge is provided "as is" without warranties of any kind, express or implied.</li>
+        <li>Our total liability for any claims arising from or related to this service shall not exceed the amount you paid us in the 12 months preceding the claim.</li>
+        <li>We are not liable for indirect, incidental, special, consequential, or punitive damages, including loss of data, revenue, or business opportunities.</li>
+        <li>We recommend maintaining independent backups of critical data.</li>
+    </ul>
+
+    <h2 id="governing-law">Governing Law and Disputes</h2>
+    <p>These Terms are governed by the laws of the <strong>State of Utah</strong>, United States, without regard to conflict of law principles. Any disputes shall be resolved through:</p>
+    <ol>
+        <li>Good-faith negotiation between the parties (30-day period).</li>
+        <li>If unresolved, binding arbitration under the rules of the American Arbitration Association, conducted in Salt Lake City, Utah.</li>
+    </ol>
+
+    <h2 id="changes">Changes to These Terms</h2>
+    <p>We may update these Terms from time to time. Material changes will be communicated via email at least 30 days before they take effect. Continued use of the service after the effective date constitutes acceptance of the updated Terms.</p>
+
+    <h2 id="contact">Contact</h2>
+    <p>For questions about these Terms:</p>
+    <ul>
+        <li><strong>Email:</strong> support@stored.ge</li>
+        <li><strong>Entity:</strong> FairForge LLC</li>
+        <li><strong>Jurisdiction:</strong> State of Utah, United States</li>
+    </ul>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

- Add five public legal document pages at `/legal/*`: Privacy Policy, Terms of Service, Data Processing Agreement (GDPR Article 28), Cookie Policy, and Acceptable Use Policy
- Legal pages are public routes (no session/auth required), reuse the existing base layout template
- Footer updated with Privacy, Terms, and Cookies links + CSS for footer link styling
- 6 handler tests covering all legal page types

## Details

Required before serving EU customers. Each page uses semantic HTML with section anchors, references stored.ge / FairForge LLC as entities, and includes effective date June 1, 2026.

- **Privacy Policy** — GDPR-compliant: lawful basis, data categories, retention periods, data subject rights, sub-processors, international transfers (SCCs)
- **Terms of Service** — service description, 99.9% SLA, data ownership, termination with 30-day grace, Utah governing law
- **DPA** — Article 28 template with countersignature section for business customers, 72-hour breach notification, audit rights
- **Cookie Policy** — only strictly necessary cookies (session, CSRF, flash), no tracking/analytics/third-party cookies, no consent banner needed
- **AUP** — prohibited content/activities, graduated enforcement (warning → suspension → termination), abuse@stored.ge reporting

No dependency on Phase 5.14.1 (GDPR export/deletion) — parallel compliance track.

## Test plan

- [x] All 6 legal handler tests pass (`go test ./internal/dashboard/handlers/ -run "TestLegal|TestHandleLegalPage"`)
- [x] Full test suite passes (`go test -short -race ./...`)
- [x] Build clean, lint clean
- [ ] CI `build-and-test` passes
- [ ] Verify pages render correctly at `/legal/privacy`, `/legal/terms`, `/legal/dpa`, `/legal/cookies`, `/legal/aup`
- [ ] Verify footer links appear on all pages