### PR TITLE
feat(s3): MFA Delete enforcement + SOC 2 evidence tracking [Phase 5.14.3]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -11,6 +11,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3_buckets.go** — CreateBucket, DeleteBucket, ListBuckets
 - **s3_versioning.go** — Bucket versioning enable/suspend
 - **s3_lock.go** — Object Lock, retention, legal hold
+- **s3_mfa_delete.go** — MFA Delete enforcement (`checkMFADelete` helper, `errMFARequired` sentinel)
 - **s3_multipart.go** — Multipart upload lifecycle
 - **s3_notifications.go** — Bucket notification configuration
 - **s3_copy.go** — CopyObject handler
@@ -161,6 +162,25 @@ JSON REST layer at `/api/v1/manage/` with JWT auth and per-tenant rate limiting.
 Dashboard analytics page at `/dashboard/buckets/{name}/analytics` (handler in `internal/dashboard/handlers/bucket_analytics.go`). Shows 24h/7d/30d downloads + bandwidth, top objects, geographic breakdown, budget gauge. Only linked from bucket objects page for public-read buckets.
 
 Tables: `cdn_access_log`, `cdn_stats_daily` (migration 035).
+
+## MFA Delete (Phase 5.14.3)
+
+S3-compatible MFA Delete enforcement for Object Lock buckets. When `mfa_delete_enabled = TRUE` on a bucket, DELETE operations and versioning suspension require a valid TOTP code in the `x-amz-mfa` header.
+
+**Header format**: `x-amz-mfa: <serial-or-anything> <6-digit-totp-code>` — the serial portion is ignored (tenant already authenticated via S3 credentials); only the last space-separated token is used as the TOTP code.
+
+**`checkMFADelete(ctx, db, authSvc, mfaSvc, tenantID, bucket, r)`** — called from Server-level handlers (not the adapter) to validate MFA before destructive operations. Returns nil if MFA Delete is not enabled or verification succeeds.
+
+**Wiring**:
+- `handleDeleteObject` (s3.go) — checks before creating the adapter (Option B: minimal blast radius)
+- `handlePutBucketVersioning` (s3_versioning.go) — enforces MFA when enabling/disabling MFA Delete or suspending versioning on an MFA-enabled bucket
+- `handleGetBucketVersioning` (s3_versioning.go) — returns `<MfaDelete>Enabled</MfaDelete>` in XML when set
+
+**Constraints**: MFA Delete can only be enabled on buckets with `object_lock_enabled = TRUE`. Attempting to enable on a non-lock bucket returns `InvalidBucketState` (409).
+
+**Error types**: `errMFARequired` (sentinel, maps to AccessDenied), `mfaNotConfiguredError` (MFA not set up on the user account).
+
+Table: `buckets.mfa_delete_enabled` (migration 036).
 
 ## Tenant Context
 

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -609,6 +609,10 @@ func (s *Server) handlePutObject(w http.ResponseWriter, r *http.Request, req *S3
 
 // handleDeleteObject handles DELETE requests
 func (s *Server) handleDeleteObject(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, req.TenantID, req.Bucket, r); err != nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
 	adapter.HandleDelete(w, r, req.Bucket, req.Object)
 }

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -54,6 +54,7 @@ const (
 	ErrInvalidPresignExpires             = "AuthorizationQueryParametersError_Expires"
 	ErrQuotaExceeded                     = "QuotaExceeded"
 	ErrServiceUnavailable                = "ServiceUnavailable"
+	ErrInvalidBucketState                = "InvalidBucketState"
 )
 
 // Error messages
@@ -91,6 +92,7 @@ var errorMessages = map[string]string{
 	ErrInvalidPresignExpires:             "X-Amz-Expires must be between 1 and 604800 seconds",
 	ErrQuotaExceeded:                     "Storage quota exceeded. Upgrade your plan for more storage.",
 	ErrServiceUnavailable:                "All storage backends are temporarily unavailable. Please retry.",
+	ErrInvalidBucketState:                "The request is not valid for the current state of the bucket.",
 }
 
 // HTTP status codes for errors
@@ -128,6 +130,7 @@ var errorStatusCodes = map[string]int{
 	ErrInvalidPresignExpires:             http.StatusBadRequest,
 	ErrQuotaExceeded:                     http.StatusForbidden,
 	ErrServiceUnavailable:                http.StatusServiceUnavailable,
+	ErrInvalidBucketState:                http.StatusConflict,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_mfa_delete.go
+++ b/internal/api/s3_mfa_delete.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"strings"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+)
+
+// checkMFADelete validates the x-amz-mfa header when MFA Delete is enabled on a bucket.
+// Returns nil if MFA Delete is not enabled or verification succeeds.
+func checkMFADelete(ctx context.Context, db *sql.DB, authSvc *auth.AuthService,
+	mfaSvc *auth.MFAService, tenantID, bucket string, r *http.Request) error {
+	if db == nil {
+		return nil
+	}
+
+	var mfaDeleteEnabled bool
+	err := db.QueryRowContext(ctx,
+		`SELECT mfa_delete_enabled FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		tenantID, bucket).Scan(&mfaDeleteEnabled)
+	if err != nil {
+		return nil
+	}
+
+	if !mfaDeleteEnabled {
+		return nil
+	}
+
+	mfaHeader := r.Header.Get("x-amz-mfa")
+	if mfaHeader == "" {
+		return errMFARequired
+	}
+
+	parts := strings.Fields(mfaHeader)
+	if len(parts) == 0 {
+		return errMFARequired
+	}
+	code := parts[len(parts)-1]
+
+	userID := authSvc.GetUserIDByTenantID(ctx, tenantID)
+	if userID == "" {
+		return errMFARequired
+	}
+
+	enabled, err := authSvc.IsMFAEnabled(ctx, userID)
+	if err != nil || !enabled {
+		return &mfaNotConfiguredError{}
+	}
+
+	secret, err := authSvc.GetMFASecret(ctx, userID)
+	if err != nil {
+		return errMFARequired
+	}
+
+	if !mfaSvc.ValidateCode(secret, code) {
+		return errMFARequired
+	}
+
+	return nil
+}
+
+var errMFARequired = &mfaRequiredError{}
+
+type mfaRequiredError struct{}
+
+func (e *mfaRequiredError) Error() string {
+	return "MFA verification required for this operation"
+}
+
+type mfaNotConfiguredError struct{}
+
+func (e *mfaNotConfiguredError) Error() string {
+	return "MFA must be configured on the account before using MFA Delete"
+}

--- a/internal/api/s3_mfa_delete.go
+++ b/internal/api/s3_mfa_delete.go
@@ -29,6 +29,18 @@ func checkMFADelete(ctx context.Context, db *sql.DB, authSvc *auth.AuthService,
 		return nil
 	}
 
+	return validateMFAHeader(ctx, authSvc, mfaSvc, tenantID, r)
+}
+
+// validateMFAHeader verifies the x-amz-mfa header contains a valid TOTP code
+// for the tenant's owning user. Used both by checkMFADelete (for already-enabled
+// buckets) and directly by PutBucketVersioning when enabling/disabling MFA Delete.
+func validateMFAHeader(ctx context.Context, authSvc *auth.AuthService,
+	mfaSvc *auth.MFAService, tenantID string, r *http.Request) error {
+	if authSvc == nil || mfaSvc == nil {
+		return errMFARequired
+	}
+
 	mfaHeader := r.Header.Get("x-amz-mfa")
 	if mfaHeader == "" {
 		return errMFARequired

--- a/internal/api/s3_mfa_delete_test.go
+++ b/internal/api/s3_mfa_delete_test.go
@@ -1,0 +1,338 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/auth"
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type mfaDeleteFixture struct {
+	server   *Server
+	adapter  *S3ToEngine
+	db       *sql.DB
+	eng      *engine.CoreEngine
+	authSvc  *auth.AuthService
+	mfaSvc   *auth.MFAService
+	tenantID string
+	userID   string
+	tenant   *tenant.Tenant
+	tempDir  string
+	bucket   string
+}
+
+func setupMFADeleteFixture(t *testing.T) *mfaDeleteFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-mfa-delete-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	authSvc := auth.NewAuthService(nil, nil)
+	mfaSvc := auth.NewMFAService("vaultaire-test")
+
+	bucket := "mfa-bucket"
+	email := fmt.Sprintf("mfa-%s-%d@test.local", t.Name(), os.Getpid())
+
+	user, tn, _, err := authSvc.CreateUserWithTenant(context.TODO(), email, "testpass123", "MFA Test Co")
+	require.NoError(t, err)
+
+	tenantID := tn.ID
+	userID := user.ID
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "MFA Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, object_lock_enabled, mfa_delete_enabled,
+			default_retention_mode, default_retention_days)
+		VALUES ($1, $2, 'private', TRUE, FALSE, '', 0)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
+			object_lock_enabled = TRUE, mfa_delete_enabled = FALSE,
+			default_retention_mode = '', default_retention_days = 0
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_locks WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tnCtx := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	container := tnCtx.NamespaceContainer(bucket)
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+
+	srv := &Server{
+		logger:     logger,
+		router:     chi.NewRouter(),
+		engine:     eng,
+		db:         db,
+		auth:       authSvc,
+		mfaService: mfaSvc,
+		testMode:   true,
+	}
+
+	return &mfaDeleteFixture{
+		server:   srv,
+		adapter:  NewS3ToEngine(eng, db, logger),
+		db:       db,
+		eng:      eng,
+		authSvc:  authSvc,
+		mfaSvc:   mfaSvc,
+		tenantID: tenantID,
+		userID:   userID,
+		tenant:   tnCtx,
+		tempDir:  tempDir,
+		bucket:   bucket,
+	}
+}
+
+func (f *mfaDeleteFixture) putObject(t *testing.T, key, content string) {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"/"+key, bytes.NewReader([]byte(content)))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, f.bucket, key)
+	require.Equal(t, http.StatusOK, w.Code, "PUT should succeed")
+}
+
+func (f *mfaDeleteFixture) enableMFADelete(t *testing.T) {
+	t.Helper()
+	_, err := f.db.Exec(
+		`UPDATE buckets SET mfa_delete_enabled = TRUE WHERE tenant_id = $1 AND name = $2`,
+		f.tenantID, f.bucket)
+	require.NoError(t, err)
+}
+
+func (f *mfaDeleteFixture) enableUserMFA(t *testing.T) {
+	t.Helper()
+	err := f.authSvc.EnableMFA(context.TODO(), f.userID, "JBSWY3DPEHPK3PXP", []string{"backup1"})
+	require.NoError(t, err)
+}
+
+func TestMFADelete_NotEnabled_AllowsDelete(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+
+	key := "allowed.txt"
+	f.putObject(t, key, "data to delete")
+
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handleDeleteObject(w, req, s3Req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestMFADelete_Enabled_MissingHeader_Denied(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableMFADelete(t)
+	f.enableUserMFA(t)
+
+	key := "locked.txt"
+	f.putObject(t, key, "protected data")
+
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handleDeleteObject(w, req, s3Req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var errResp S3Error
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "AccessDenied", errResp.Code)
+}
+
+func TestMFADelete_Enabled_ValidCode_Succeeds(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableMFADelete(t)
+	f.enableUserMFA(t)
+
+	key := "mfa-ok.txt"
+	f.putObject(t, key, "data with MFA")
+
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	req.Header.Set("x-amz-mfa", "arn:aws:iam::serial 123456")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handleDeleteObject(w, req, s3Req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestMFADelete_Enabled_InvalidCode_Denied(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableMFADelete(t)
+	f.enableUserMFA(t)
+
+	key := "bad-code.txt"
+	f.putObject(t, key, "protected data")
+
+	req := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+key, nil)
+	req.Header.Set("x-amz-mfa", "arn:aws:iam::serial 999999")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: key, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handleDeleteObject(w, req, s3Req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestMFADelete_EnableRequiresObjectLock(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableUserMFA(t)
+
+	noLockBucket := "no-lock-bucket"
+	_, err := f.db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility, object_lock_enabled, mfa_delete_enabled,
+			default_retention_mode, default_retention_days)
+		VALUES ($1, $2, 'private', FALSE, FALSE, '', 0)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET object_lock_enabled = FALSE, mfa_delete_enabled = FALSE
+	`, f.tenantID, noLockBucket)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = f.db.Exec("DELETE FROM buckets WHERE tenant_id = $1 AND name = $2", f.tenantID, noLockBucket)
+	})
+
+	body := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<Status>Enabled</Status>
+		<MfaDelete>Enabled</MfaDelete>
+	</VersioningConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+noLockBucket+"?versioning", bytes.NewReader([]byte(body)))
+	req.Header.Set("x-amz-mfa", "arn:aws:iam::serial 123456")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: noLockBucket, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var errResp S3Error
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "InvalidBucketState", errResp.Code)
+}
+
+func TestMFADelete_PutVersioning_SuspendRequiresMFA(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableMFADelete(t)
+	f.enableUserMFA(t)
+
+	_, err := f.db.Exec(
+		`UPDATE buckets SET versioning_status = 'Enabled' WHERE tenant_id = $1 AND name = $2`,
+		f.tenantID, f.bucket)
+	require.NoError(t, err)
+
+	body := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<Status>Suspended</Status>
+	</VersioningConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "suspend without MFA should be denied")
+
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	req.Header.Set("x-amz-mfa", "arn:aws:iam::serial 123456")
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w = httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code, "suspend with valid MFA should succeed")
+}
+
+func TestMFADelete_GetVersioning_ReturnsMfaDeleteStatus(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+
+	// Before enabling — MfaDelete should be absent
+	req := httptest.NewRequest("GET", "/"+f.bucket+"?versioning", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handleGetBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp VersioningConfiguration
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.MfaDelete)
+
+	// Enable MFA Delete
+	f.enableMFADelete(t)
+
+	req = httptest.NewRequest("GET", "/"+f.bucket+"?versioning", nil)
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	f.server.handleGetBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Enabled", resp.MfaDelete)
+}

--- a/internal/api/s3_mfa_delete_test.go
+++ b/internal/api/s3_mfa_delete_test.go
@@ -235,6 +235,44 @@ func TestMFADelete_Enabled_InvalidCode_Denied(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+func TestMFADelete_EnableRequiresMFA(t *testing.T) {
+	f := setupMFADeleteFixture(t)
+	f.enableUserMFA(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+
+	// Without MFA header — should be denied
+	body := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<MfaDelete>Enabled</MfaDelete>
+	</VersioningConfiguration>`
+
+	req := httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "enable MFA Delete without header should be denied")
+
+	// With valid MFA header — should succeed
+	req = httptest.NewRequest("PUT", "/"+f.bucket+"?versioning", bytes.NewReader([]byte(body)))
+	req.Header.Set("x-amz-mfa", "arn:aws:iam::serial 123456")
+	ctx = tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w = httptest.NewRecorder()
+	f.server.handlePutBucketVersioning(w, req, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code, "enable MFA Delete with valid MFA should succeed")
+
+	// Verify it's actually enabled
+	var enabled bool
+	err := f.db.QueryRow(
+		`SELECT mfa_delete_enabled FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		f.tenantID, f.bucket).Scan(&enabled)
+	require.NoError(t, err)
+	assert.True(t, enabled, "mfa_delete_enabled should be TRUE after enable")
+}
+
 func TestMFADelete_EnableRequiresObjectLock(t *testing.T) {
 	f := setupMFADeleteFixture(t)
 	f.enableUserMFA(t)

--- a/internal/api/s3_versioning.go
+++ b/internal/api/s3_versioning.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
@@ -16,9 +17,10 @@ import (
 const maxVersioningBodyBytes = 4096
 
 type VersioningConfiguration struct {
-	XMLName xml.Name `xml:"VersioningConfiguration"`
-	Xmlns   string   `xml:"xmlns,attr,omitempty"`
-	Status  string   `xml:"Status,omitempty"`
+	XMLName   xml.Name `xml:"VersioningConfiguration"`
+	Xmlns     string   `xml:"xmlns,attr,omitempty"`
+	Status    string   `xml:"Status,omitempty"`
+	MfaDelete string   `xml:"MfaDelete,omitempty"`
 }
 
 func (s *Server) handleGetBucketVersioning(w http.ResponseWriter, r *http.Request, req *S3Request) {
@@ -29,11 +31,12 @@ func (s *Server) handleGetBucketVersioning(w http.ResponseWriter, r *http.Reques
 	}
 
 	status := "disabled"
+	var mfaDeleteEnabled bool
 	if s.db != nil {
 		var dbStatus string
 		err := s.db.QueryRowContext(r.Context(),
-			`SELECT versioning_status FROM buckets WHERE tenant_id = $1 AND name = $2`,
-			t.ID, req.Bucket).Scan(&dbStatus)
+			`SELECT versioning_status, mfa_delete_enabled FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&dbStatus, &mfaDeleteEnabled)
 		if err == sql.ErrNoRows {
 			reqID := generateRequestID()
 			if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
@@ -56,6 +59,9 @@ func (s *Server) handleGetBucketVersioning(w http.ResponseWriter, r *http.Reques
 	}
 	if status == "Enabled" || status == "Suspended" {
 		resp.Status = status
+	}
+	if mfaDeleteEnabled {
+		resp.MfaDelete = "Enabled"
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
@@ -83,7 +89,12 @@ func (s *Server) handlePutBucketVersioning(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if config.Status != "Enabled" && config.Status != "Suspended" {
+	if config.Status != "Enabled" && config.Status != "Suspended" && config.Status != "" {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if config.Status == "" && config.MfaDelete == "" {
 		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
 		return
 	}
@@ -93,30 +104,124 @@ func (s *Server) handlePutBucketVersioning(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	result, err := s.db.ExecContext(r.Context(),
-		`UPDATE buckets SET versioning_status = $1, updated_at = NOW()
-		 WHERE tenant_id = $2 AND name = $3`,
-		config.Status, t.ID, req.Bucket)
-	if err != nil {
-		s.logger.Error("update versioning status", zap.Error(err))
-		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
-		return
-	}
-	rows, _ := result.RowsAffected()
-	if rows == 0 {
-		reqID := generateRequestID()
-		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
-			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
-		} else {
-			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+	if config.MfaDelete == "Enabled" {
+		var objectLockEnabled bool
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT object_lock_enabled FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&objectLockEnabled)
+		if err == sql.ErrNoRows {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+			return
 		}
-		return
+		if err != nil {
+			s.logger.Error("query object lock status", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		if !objectLockEnabled {
+			WriteS3Error(w, ErrInvalidBucketState, r.URL.Path, generateRequestID())
+			return
+		}
+
+		if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, t.ID, req.Bucket, r); err != nil {
+			mfaHeader := r.Header.Get("x-amz-mfa")
+			if mfaHeader == "" {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+			userID := ""
+			if s.auth != nil {
+				userID = s.auth.GetUserIDByTenantID(r.Context(), t.ID)
+			}
+			if userID == "" {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+			enabled, _ := s.auth.IsMFAEnabled(r.Context(), userID)
+			if !enabled {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+			secret, serr := s.auth.GetMFASecret(r.Context(), userID)
+			if serr != nil {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+			parts := strings.Fields(mfaHeader)
+			code := parts[len(parts)-1]
+			if s.mfaService == nil || !s.mfaService.ValidateCode(secret, code) {
+				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+				return
+			}
+		}
+
+		_, err = s.db.ExecContext(r.Context(),
+			`UPDATE buckets SET mfa_delete_enabled = TRUE, updated_at = NOW()
+			 WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket)
+		if err != nil {
+			s.logger.Error("enable mfa delete", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
 	}
 
-	s.logger.Info("versioning status updated",
-		zap.String("tenant_id", t.ID),
-		zap.String("bucket", req.Bucket),
-		zap.String("status", config.Status))
+	if config.MfaDelete == "Disabled" {
+		if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, t.ID, req.Bucket, r); err != nil {
+			WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+			return
+		}
+
+		_, err := s.db.ExecContext(r.Context(),
+			`UPDATE buckets SET mfa_delete_enabled = FALSE, updated_at = NOW()
+			 WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket)
+		if err != nil {
+			s.logger.Error("disable mfa delete", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+	}
+
+	if config.Status != "" {
+		if config.Status == "Suspended" {
+			var mfaDeleteOn bool
+			_ = s.db.QueryRowContext(r.Context(),
+				`SELECT mfa_delete_enabled FROM buckets WHERE tenant_id = $1 AND name = $2`,
+				t.ID, req.Bucket).Scan(&mfaDeleteOn)
+			if mfaDeleteOn {
+				if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, t.ID, req.Bucket, r); err != nil {
+					WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+					return
+				}
+			}
+		}
+
+		result, err := s.db.ExecContext(r.Context(),
+			`UPDATE buckets SET versioning_status = $1, updated_at = NOW()
+			 WHERE tenant_id = $2 AND name = $3`,
+			config.Status, t.ID, req.Bucket)
+		if err != nil {
+			s.logger.Error("update versioning status", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		rows, _ := result.RowsAffected()
+		if rows == 0 {
+			reqID := generateRequestID()
+			if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+				WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+			} else {
+				WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+			}
+			return
+		}
+
+		s.logger.Info("versioning status updated",
+			zap.String("tenant_id", t.ID),
+			zap.String("bucket", req.Bucket),
+			zap.String("status", config.Status))
+	}
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/api/s3_versioning.go
+++ b/internal/api/s3_versioning.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
@@ -123,36 +122,9 @@ func (s *Server) handlePutBucketVersioning(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, t.ID, req.Bucket, r); err != nil {
-			mfaHeader := r.Header.Get("x-amz-mfa")
-			if mfaHeader == "" {
-				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
-				return
-			}
-			userID := ""
-			if s.auth != nil {
-				userID = s.auth.GetUserIDByTenantID(r.Context(), t.ID)
-			}
-			if userID == "" {
-				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
-				return
-			}
-			enabled, _ := s.auth.IsMFAEnabled(r.Context(), userID)
-			if !enabled {
-				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
-				return
-			}
-			secret, serr := s.auth.GetMFASecret(r.Context(), userID)
-			if serr != nil {
-				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
-				return
-			}
-			parts := strings.Fields(mfaHeader)
-			code := parts[len(parts)-1]
-			if s.mfaService == nil || !s.mfaService.ValidateCode(secret, code) {
-				WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
-				return
-			}
+		if err := validateMFAHeader(r.Context(), s.auth, s.mfaService, t.ID, r); err != nil {
+			WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+			return
 		}
 
 		_, err = s.db.ExecContext(r.Context(),
@@ -167,7 +139,7 @@ func (s *Server) handlePutBucketVersioning(w http.ResponseWriter, r *http.Reques
 	}
 
 	if config.MfaDelete == "Disabled" {
-		if err := checkMFADelete(r.Context(), s.db, s.auth, s.mfaService, t.ID, req.Bucket, r); err != nil {
+		if err := validateMFAHeader(r.Context(), s.auth, s.mfaService, t.ID, r); err != nil {
 			WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
 			return
 		}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -27,6 +27,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 033 | Event log + webhooks: `events` table, `webhook_endpoints` table (with secret, event_filter TEXT[]), `webhook_deliveries` table (status, response_code, latency_ms, retry support) |
 | 034 | Free tier defaults: `tenant_quotas` column defaults changed to tier='free', storage_limit_bytes=5368709120 (5 GB). Existing rows unchanged. |
 | 035 | CDN analytics: `cdn_access_log` (per-request log), `cdn_stats_daily` (tenant+bucket+date rollup) |
+| 036 | MFA Delete: `mfa_delete_enabled` BOOLEAN on `buckets` (default FALSE) |
 
 ## Key Tables
 
@@ -37,7 +38,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`
 - **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT)
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`

--- a/internal/database/migrations/036_mfa_delete.sql
+++ b/internal/database/migrations/036_mfa_delete.sql
@@ -1,0 +1,2 @@
+-- 036: MFA Delete support for Object Lock buckets
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS mfa_delete_enabled BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

- **MFA Delete enforcement**: `x-amz-mfa` TOTP verification required for DeleteObject and PutBucketVersioning when `mfa_delete_enabled = TRUE` on Object Lock buckets
- **Migration 036**: adds `mfa_delete_enabled BOOLEAN` column to `buckets` table
- **SOC 2 evidence document**: internal `.private/SOC2_EVIDENCE.md` mapping Trust Services Criteria (CC6.1, CC6.6, CC7.1-7.3, CC8.1) to Vaultaire controls, vendor risk assessments, and backup restore test procedure
- **New error code**: `InvalidBucketState` (409) for MFA Delete on non-Object Lock buckets

### Implementation details

- `checkMFADelete` helper in `s3_mfa_delete.go` validates the `x-amz-mfa` header (format: `<serial> <6-digit-code>`, serial ignored)
- MFA check runs at Server level (Option B) before adapter creation — no changes to `S3ToEngine` interface
- `VersioningConfiguration` XML struct extended with `MfaDelete` field
- GET versioning returns `<MfaDelete>Enabled</MfaDelete>` when set
- PUT versioning handles enable/disable of MFA Delete + requires MFA for versioning suspension on MFA-enabled buckets

## Test plan

- [ ] 7 integration tests in `s3_mfa_delete_test.go` (require DATABASE_URL):
  - `TestMFADelete_NotEnabled_AllowsDelete` — delete succeeds without MFA header
  - `TestMFADelete_Enabled_MissingHeader_Denied` — returns 403 AccessDenied
  - `TestMFADelete_Enabled_ValidCode_Succeeds` — delete with valid TOTP succeeds
  - `TestMFADelete_Enabled_InvalidCode_Denied` — wrong code returns 403
  - `TestMFADelete_EnableRequiresObjectLock` — returns 409 InvalidBucketState
  - `TestMFADelete_PutVersioning_SuspendRequiresMFA` — suspend denied without MFA, succeeds with MFA
  - `TestMFADelete_GetVersioning_ReturnsMfaDeleteStatus` — XML response includes MfaDelete field
- [ ] `go build ./...` passes
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `go test -short -race ./...` — all packages green