### PR TITLE
feat(crypto): post-quantum SSE-S3 encryption at rest [Phase 5.14.4]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ GitHub Actions Deploy (`.github/workflows/deploy.yml`):
 | `IDRIVE_ACCESS_KEY`, `IDRIVE_SECRET_KEY` | — | iDrive E2 S3 credentials |
 | `IDRIVE_ENDPOINT`, `IDRIVE_REGION` | — | iDrive endpoint and region |
 | `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_SECRET`, `ONEDRIVE_TENANT_ID` | — | OneDrive OAuth (future) |
+| `ENCRYPTION_MASTER_KEY` | — | SSE-S3 master key (64 hex chars = 32 bytes). Absent = encryption disabled |
 
 ## Production
 

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -182,6 +182,32 @@ S3-compatible MFA Delete enforcement for Object Lock buckets. When `mfa_delete_e
 
 Table: `buckets.mfa_delete_enabled` (migration 036).
 
+## SSE-S3 Server-Side Encryption (Phase 5.14.4)
+
+Transparent server-side encryption at rest using ML-KEM-768 (post-quantum key encapsulation) + AES-256-GCM. Activated by setting `ENCRYPTION_MASTER_KEY` env var.
+
+**Activation**: per-request via `x-amz-server-side-encryption: AES256` header, or per-bucket via `sse_enabled` column (defaults to TRUE for new buckets when SSE is available).
+
+**PUT flow** (s3_engine_adapter.go HandlePut):
+1. Check `shouldEncrypt`: sseService != nil AND (header present OR bucket sse_enabled) AND size > 0 AND size <= 256 MiB
+2. EnsureTenantKey (idempotent — creates ML-KEM-768 keypair if missing)
+3. ReadAll plaintext through TeeReader (computes ETag on plaintext)
+4. EncryptBytes → ciphertext (plaintext + 1117B overhead)
+5. engine.Put with ciphertext; object_head_cache stores plaintext size + encryption_algorithm
+
+**GET flow** (s3_engine_adapter.go HandleGet):
+1. Query encryption_algorithm from object_head_cache
+2. engine.Get → encrypted blob
+3. If encrypted: ReadAll + DecryptBytes → plaintext reader
+4. Serve plaintext (range requests work on decrypted data)
+
+**HEAD flow** (s3.go handleHeadObject):
+- Returns plaintext size from cache + `x-amz-server-side-encryption: AES256` header
+
+**Key files**: `internal/crypto/sse_s3.go` (service), `internal/crypto/CLAUDE.md` (crypto docs)
+
+**Tables**: `tenant_encryption_keys` (keypairs), `buckets.sse_enabled`, `object_head_cache.encryption_algorithm` (migration 037)
+
 ## Tenant Context
 
 Most handlers use `tenant.FromContext(r.Context())` to get the authenticated tenant. The `S3Request.TenantID` field is also set for convenience.

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -496,6 +496,7 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 // handleGetObject handles S3 GET requests
 func (s *Server) handleGetObject(w http.ResponseWriter, r *http.Request, req *S3Request) {
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
+	adapter.sseService = s.sseService
 
 	s.logger.Debug("S3 GET translating to engine",
 		zap.String("s3.bucket", req.Bucket),
@@ -527,12 +528,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	var updatedAt time.Time
 	var metadataJSON []byte
 	var backendName string
+	var encAlgo string
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, '')
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, '')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName, &encAlgo)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -569,6 +571,9 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	}
 	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(backendName))
 	w.Header().Set("x-amz-request-id", generateRequestID())
+	if encAlgo != "" {
+		w.Header().Set("x-amz-server-side-encryption", "AES256")
+	}
 	setS3MetadataHeaders(w, metadataJSON)
 	// HEAD must not write a body.
 	w.WriteHeader(http.StatusOK)
@@ -596,6 +601,7 @@ func (s *Server) handlePutObject(w http.ResponseWriter, r *http.Request, req *S3
 	}
 
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
+	adapter.sseService = s.sseService
 
 	s.logger.Debug("S3 PUT translating to engine",
 		zap.String("s3.bucket", req.Bucket),

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -154,11 +154,12 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.db != nil {
+		sseDefault := s.sseService != nil
 		_, dbErr := s.db.ExecContext(ctx, `
-			INSERT INTO buckets (tenant_id, name, visibility)
-			VALUES ($1, $2, 'private')
+			INSERT INTO buckets (tenant_id, name, visibility, sse_enabled)
+			VALUES ($1, $2, 'private', $3)
 			ON CONFLICT (tenant_id, name) DO NOTHING
-		`, tenantID, bucket)
+		`, tenantID, bucket, sseDefault)
 		if dbErr != nil {
 			s.logger.Error("failed to persist bucket",
 				zap.Error(dbErr), zap.String("bucket", bucket))

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
 	"database/sql"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"go.uber.org/zap"
@@ -21,10 +23,11 @@ import (
 
 // S3ToEngine adapts S3 requests to engine operations.
 type S3ToEngine struct {
-	engine    engine.Engine
-	db        *sql.DB
-	logger    *zap.Logger
-	notifySvc *NotificationDispatcher
+	engine     engine.Engine
+	db         *sql.DB
+	logger     *zap.Logger
+	notifySvc  *NotificationDispatcher
+	sseService *crypto.SSEService
 }
 
 // NewS3ToEngine creates a new adapter
@@ -207,13 +210,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedUpdatedAt time.Time
 	var cachedMetadata []byte
 	var cachedBackendName string
+	var cachedEncAlgo string
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, '')
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, '')
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo)
 		if err == nil {
 			cacheHit = true
 		}
@@ -258,6 +262,27 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 	defer func() { _ = reader.Close() }()
 
+	var dataReader io.Reader = reader
+	if a.sseService != nil && cachedEncAlgo != "" {
+		encBytes, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			a.logger.Error("failed to read encrypted object", zap.Error(readErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		plaintext, decErr := a.sseService.DecryptBytes(r.Context(), t.ID, encBytes)
+		if decErr != nil {
+			a.logger.Error("SSE-S3 decryption failed", zap.Error(decErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		dataReader = bytes.NewReader(plaintext)
+	}
+
+	if cachedEncAlgo != "" {
+		w.Header().Set("x-amz-server-side-encryption", "AES256")
+	}
+
 	rangeHeader := r.Header.Get("Range")
 	if rangeHeader != "" && cacheHit && cachedSize > 0 {
 		rng, parseErr := parseRangeHeader(rangeHeader, cachedSize)
@@ -269,7 +294,7 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		if w.Header().Get("x-amz-version-id") == "" {
 			w.Header().Set("x-amz-version-id", "null")
 		}
-		if err := serveRange(w, reader, rng, cachedSize, contentType); err != nil {
+		if err := serveRange(w, dataReader, rng, cachedSize, contentType); err != nil {
 			a.logger.Error("range serve failed",
 				zap.Error(err),
 				zap.String("container", container),
@@ -299,7 +324,7 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		setS3MetadataHeaders(w, cachedMetadata)
 	}
 
-	written, err := io.Copy(w, reader)
+	written, err := io.Copy(w, dataReader)
 	if err != nil {
 		a.logger.Error("failed to stream artifact",
 			zap.Error(err),
@@ -422,6 +447,38 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	hasher := md5.New() // #nosec G401 — S3 spec requires MD5 for ETags
 	hashingBody := io.TeeReader(body, hasher)
 
+	metadataSize := size
+	var encryptionAlgorithm string
+	shouldEncrypt := a.sseService != nil && size > 0 && size <= crypto.MaxEncryptableSize &&
+		(r.Header.Get("x-amz-server-side-encryption") == "AES256" ||
+			isBucketSSEEnabled(r.Context(), a.db, t.ID, bucket))
+
+	if shouldEncrypt {
+		if err := a.sseService.EnsureTenantKey(r.Context(), t.ID); err != nil {
+			a.logger.Error("failed to ensure tenant encryption key", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+
+		plaintext, readErr := io.ReadAll(hashingBody)
+		if readErr != nil {
+			a.logger.Error("failed to read plaintext for encryption", zap.Error(readErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+
+		ciphertext, encErr := a.sseService.EncryptBytes(r.Context(), t.ID, plaintext)
+		if encErr != nil {
+			a.logger.Error("SSE-S3 encryption failed", zap.Error(encErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+
+		hashingBody = bytes.NewReader(ciphertext)
+		size = int64(len(ciphertext))
+		encryptionAlgorithm = crypto.SSEAlgorithm
+	}
+
 	storageClass := r.Header.Get("x-amz-storage-class")
 	putOpts := []engine.PutOption{engine.WithContentLength(size)}
 	if storageClass != "" {
@@ -460,16 +517,17 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	if a.db != nil {
 		_, dbErr := a.db.ExecContext(r.Context(), `
 			INSERT INTO object_head_cache
-				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
 			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
-				size_bytes   = EXCLUDED.size_bytes,
-				etag         = EXCLUDED.etag,
-				content_type = EXCLUDED.content_type,
-				backend_name = EXCLUDED.backend_name,
-				metadata     = EXCLUDED.metadata,
-				updated_at   = NOW()
-		`, t.ID, bucket, artifact, size, etag, contentType, backendName, metaJSON)
+				size_bytes            = EXCLUDED.size_bytes,
+				etag                  = EXCLUDED.etag,
+				content_type          = EXCLUDED.content_type,
+				backend_name          = EXCLUDED.backend_name,
+				metadata              = EXCLUDED.metadata,
+				encryption_algorithm  = EXCLUDED.encryption_algorithm,
+				updated_at            = NOW()
+		`, t.ID, bucket, artifact, metadataSize, etag, contentType, backendName, metaJSON, encryptionAlgorithm)
 		if dbErr != nil {
 			a.logger.Error("failed to cache object metadata",
 				zap.Error(dbErr),
@@ -501,13 +559,16 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 				size_bytes = EXCLUDED.size_bytes, etag = EXCLUDED.etag,
 				content_type = EXCLUDED.content_type, is_latest = TRUE,
 				is_delete_marker = FALSE, backend_name = EXCLUDED.backend_name`,
-			t.ID, bucket, artifact, versionID, size, etag, contentType, backendName)
+			t.ID, bucket, artifact, versionID, metadataSize, etag, contentType, backendName)
 	}
 
 	applyObjectLockOnPut(r.Context(), a.db, t.ID, bucket, artifact, r)
 
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
 	w.Header().Set("x-amz-request-id", generateRequestID())
+	if encryptionAlgorithm != "" {
+		w.Header().Set("x-amz-server-side-encryption", "AES256")
+	}
 	if versionID != "" {
 		w.Header().Set("x-amz-version-id", versionID)
 	}
@@ -521,7 +582,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		zap.String("etag", etag),
 		zap.String("version_id", versionID),
 		zap.Bool("aws_chunked", chunked),
-		zap.Int64("size", size))
+		zap.Bool("encrypted", encryptionAlgorithm != ""),
+		zap.Int64("size", metadataSize))
 
 	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:Put", object, size, etag)
 	emitEvent(r.Context(), a.db, a.logger, "object.created", t.ID, map[string]interface{}{
@@ -643,6 +705,17 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 	emitEvent(r.Context(), a.db, a.logger, "object.deleted", t.ID, map[string]interface{}{
 		"bucket": bucket, "key": object,
 	})
+}
+
+func isBucketSSEEnabled(ctx context.Context, db *sql.DB, tenantID, bucket string) bool {
+	if db == nil {
+		return false
+	}
+	var enabled bool
+	err := db.QueryRowContext(ctx,
+		"SELECT sse_enabled FROM buckets WHERE tenant_id = $1 AND name = $2",
+		tenantID, bucket).Scan(&enabled)
+	return err == nil && enabled
 }
 
 // HandleList processes S3 LIST requests

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/billing"
 	"github.com/FairForge/vaultaire/internal/compliance"
 	"github.com/FairForge/vaultaire/internal/config"
+	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/dashboard"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/docs"
@@ -68,6 +69,7 @@ type Server struct {
 	githubOAuth      *oauth2.Config
 	mfaService       *auth.MFAService
 	mfaPendingStore  *dashboard.MFAPendingStore
+	sseService       *crypto.SSEService
 	cdnRateLimiter   *RateLimiter
 	cdnAnalytics     *CDNAnalyticsTracker
 	emailSender      email.Sender
@@ -152,6 +154,16 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	// MFA service for TOTP generation and validation.
 	s.mfaService = auth.NewMFAService("stored.ge")
 	s.mfaPendingStore = dashboard.NewMFAPendingStore()
+
+	if masterKey := os.Getenv("ENCRYPTION_MASTER_KEY"); masterKey != "" && s.db != nil {
+		sseSvc, sseErr := crypto.NewSSEService(s.db, masterKey)
+		if sseErr != nil {
+			logger.Error("failed to initialize SSE-S3 service", zap.Error(sseErr))
+		} else {
+			s.sseService = sseSvc
+			logger.Info("SSE-S3 encryption service initialized (ML-KEM-768+AES-256-GCM)")
+		}
+	}
 
 	s.auditLogger = auth.NewAuditLogger()
 	s.auth.SetAuditLogger(s.auditLogger)

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -1,0 +1,34 @@
+# internal/crypto
+
+Encryption, key management, and post-quantum cryptography for Vaultaire.
+
+## Key Files
+
+- **sse_s3.go** — SSE-S3 service: ML-KEM-768 key encapsulation + AES-256-GCM data encryption. Per-tenant keypairs in DB, per-object DEKs via KEM encapsulation
+- **encryption.go** — Core Encryptor interface: AES-256-GCM, ChaCha20-Poly1305, Noop implementations. Chunk-level encrypt/decrypt for pipeline
+- **keymanager.go** — Multi-tenant HKDF key derivation with version tracking and TTL cache
+- **postquantum.go** — ML-KEM-768 via cloudflare/circl (pipeline encryption). SSE-S3 uses Go stdlib crypto/mlkem instead
+- **compression.go** — LZ4/Zstd/Snappy compression with auto-detection
+- **chunker.go** — Content-defined chunking (FastCDC)
+- **pipeline.go** — Full encrypt+compress+chunk pipeline
+- **tls.go** — TLS configuration helpers
+- **gci.go** — Global content index for deduplication
+- **config.go** — Crypto configuration types
+
+## SSE-S3 Architecture (Phase 5.14.4)
+
+**SSEService** provides transparent server-side encryption at rest:
+
+- **Key hierarchy**: ENCRYPTION_MASTER_KEY (env, 32B hex) → encrypts tenant seeds → ML-KEM-768 keypairs per tenant → per-object shared keys via KEM encapsulation → HKDF-derived AES-256 DEKs
+- **Encrypted blob format**: `[version=0x01][KEM ciphertext (1088B)][nonce (12B)][AES-GCM ciphertext+tag]`
+- **Size overhead**: 1117 bytes per object (1 + 1088 + 12 + 16)
+- **Max encryptable size**: 256 MiB (whole-object GCM requires buffering)
+- **ETag**: computed on plaintext, not ciphertext (S3 compatibility)
+- **object_head_cache.size_bytes**: stores plaintext size (matches AWS SSE-S3 behavior)
+- **Tenant seed protection**: AES-256-GCM with masterKey, stored as nonce||ciphertext in DB
+
+**Activation**: set `ENCRYPTION_MASTER_KEY` env var (64 hex chars). When absent, SSE-S3 is disabled gracefully. Per-bucket via `sse_enabled` column, per-request via `x-amz-server-side-encryption: AES256` header.
+
+**Two ML-KEM implementations** coexist:
+- `postquantum.go` — cloudflare/circl (pipeline encryption, existing)
+- `sse_s3.go` — Go stdlib crypto/mlkem (SSE-S3, new)

--- a/internal/crypto/sse_s3.go
+++ b/internal/crypto/sse_s3.go
@@ -1,0 +1,267 @@
+package crypto
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/mlkem"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sync"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	SSEVersion         byte  = 0x01
+	SSEOverheadBytes         = 1 + mlkem.CiphertextSize768 + 12 + 16 // 1117
+	MaxEncryptableSize int64 = 256 << 20                             // 256 MiB
+	SSEAlgorithm             = "ML-KEM-768+AES-256-GCM"
+)
+
+type SSEService struct {
+	db        *sql.DB
+	masterKey []byte
+	ekCache   sync.Map
+	dkCache   sync.Map
+}
+
+func NewSSEService(db *sql.DB, masterKeyHex string) (*SSEService, error) {
+	key, err := hex.DecodeString(masterKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode master key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("master key must be 32 bytes, got %d", len(key))
+	}
+	return &SSEService{db: db, masterKey: key}, nil
+}
+
+func (s *SSEService) EnsureTenantKey(ctx context.Context, tenantID string) error {
+	if _, ok := s.ekCache.Load(tenantID); ok {
+		return nil
+	}
+
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM tenant_encryption_keys WHERE tenant_id = $1)",
+		tenantID).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("check tenant key: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	dk, err := mlkem.GenerateKey768()
+	if err != nil {
+		return fmt.Errorf("generate ML-KEM key: %w", err)
+	}
+
+	seed := dk.Bytes()
+	encryptedSeed, err := encryptSeed(s.masterKey, seed)
+	if err != nil {
+		return fmt.Errorf("encrypt seed: %w", err)
+	}
+
+	pubKey := dk.EncapsulationKey().Bytes()
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO tenant_encryption_keys (tenant_id, seed, public_key)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (tenant_id) DO NOTHING`,
+		tenantID, encryptedSeed, pubKey)
+	if err != nil {
+		return fmt.Errorf("store tenant key: %w", err)
+	}
+
+	s.ekCache.Store(tenantID, dk.EncapsulationKey())
+	return nil
+}
+
+func (s *SSEService) EncryptBytes(ctx context.Context, tenantID string, plaintext []byte) ([]byte, error) {
+	ek, err := s.loadEncapsulationKey(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	sharedKey, kemCiphertext := ek.Encapsulate()
+
+	aesKey, err := deriveSSEKey(sharedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	aesCiphertext := gcm.Seal(nil, nonce, plaintext, nil)
+
+	buf := make([]byte, 0, 1+len(kemCiphertext)+len(nonce)+len(aesCiphertext))
+	buf = append(buf, SSEVersion)
+	buf = append(buf, kemCiphertext...)
+	buf = append(buf, nonce...)
+	buf = append(buf, aesCiphertext...)
+
+	return buf, nil
+}
+
+func (s *SSEService) DecryptBytes(ctx context.Context, tenantID string, data []byte) ([]byte, error) {
+	minLen := 1 + mlkem.CiphertextSize768 + 12 + 16
+	if len(data) < minLen {
+		return nil, fmt.Errorf("encrypted data too short: %d bytes", len(data))
+	}
+
+	if data[0] != SSEVersion {
+		return nil, fmt.Errorf("unsupported SSE version: 0x%02x", data[0])
+	}
+
+	off := 1
+	kemCT := data[off : off+mlkem.CiphertextSize768]
+	off += mlkem.CiphertextSize768
+	nonce := data[off : off+12]
+	off += 12
+	aesCT := data[off:]
+
+	dk, err := s.loadDecapsulationKey(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	sharedKey, err := dk.Decapsulate(kemCT)
+	if err != nil {
+		return nil, fmt.Errorf("ML-KEM decapsulation failed: %w", err)
+	}
+
+	aesKey, err := deriveSSEKey(sharedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	plaintext, err := gcm.Open(nil, nonce, aesCT, nil)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decryption failed: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+func (s *SSEService) loadEncapsulationKey(ctx context.Context, tenantID string) (*mlkem.EncapsulationKey768, error) {
+	if cached, ok := s.ekCache.Load(tenantID); ok {
+		return cached.(*mlkem.EncapsulationKey768), nil
+	}
+
+	var pubKeyBytes []byte
+	err := s.db.QueryRowContext(ctx,
+		"SELECT public_key FROM tenant_encryption_keys WHERE tenant_id = $1",
+		tenantID).Scan(&pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load tenant public key: %w", err)
+	}
+
+	ek, err := mlkem.NewEncapsulationKey768(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse encapsulation key: %w", err)
+	}
+
+	s.ekCache.Store(tenantID, ek)
+	return ek, nil
+}
+
+func (s *SSEService) loadDecapsulationKey(ctx context.Context, tenantID string) (*mlkem.DecapsulationKey768, error) {
+	if cached, ok := s.dkCache.Load(tenantID); ok {
+		return cached.(*mlkem.DecapsulationKey768), nil
+	}
+
+	var encSeed []byte
+	err := s.db.QueryRowContext(ctx,
+		"SELECT seed FROM tenant_encryption_keys WHERE tenant_id = $1",
+		tenantID).Scan(&encSeed)
+	if err != nil {
+		return nil, fmt.Errorf("load tenant seed: %w", err)
+	}
+
+	seed, err := decryptSeed(s.masterKey, encSeed)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt tenant seed: %w", err)
+	}
+
+	dk, err := mlkem.NewDecapsulationKey768(seed)
+	if err != nil {
+		return nil, fmt.Errorf("reconstruct decapsulation key: %w", err)
+	}
+
+	s.dkCache.Store(tenantID, dk)
+	return dk, nil
+}
+
+func deriveSSEKey(sharedKey []byte) ([]byte, error) {
+	r := hkdf.New(sha256.New, sharedKey, nil, []byte("vaultaire-sse-s3"))
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(r, key); err != nil {
+		return nil, fmt.Errorf("HKDF key derivation: %w", err)
+	}
+	return key, nil
+}
+
+func encryptSeed(masterKey, seed []byte) ([]byte, error) {
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("create seed cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create seed GCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate seed nonce: %w", err)
+	}
+	ct := gcm.Seal(nil, nonce, seed, nil)
+	return append(nonce, ct...), nil
+}
+
+func decryptSeed(masterKey, data []byte) ([]byte, error) {
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("create seed cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create seed GCM: %w", err)
+	}
+	if len(data) < gcm.NonceSize()+16 {
+		return nil, fmt.Errorf("encrypted seed too short: %d bytes", len(data))
+	}
+	nonce := data[:gcm.NonceSize()]
+	ct := data[gcm.NonceSize():]
+	seed, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt seed: %w", err)
+	}
+	return seed, nil
+}

--- a/internal/crypto/sse_s3_test.go
+++ b/internal/crypto/sse_s3_test.go
@@ -1,0 +1,366 @@
+package crypto
+
+import (
+	"context"
+	"crypto/mlkem"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+)
+
+func testMasterKeyHex() string {
+	return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+
+func TestSSEService_NewSSEService(t *testing.T) {
+	t.Run("valid key", func(t *testing.T) {
+		svc, err := NewSSEService(nil, testMasterKeyHex())
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+	})
+
+	t.Run("invalid hex", func(t *testing.T) {
+		_, err := NewSSEService(nil, "not-hex")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode master key")
+	})
+
+	t.Run("wrong length", func(t *testing.T) {
+		_, err := NewSSEService(nil, "0123456789abcdef")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "32 bytes")
+	})
+}
+
+func TestSSEService_SeedEncryptDecrypt(t *testing.T) {
+	masterKey, _ := hex.DecodeString(testMasterKeyHex())
+
+	seed := make([]byte, mlkem.SeedSize)
+	_, err := rand.Read(seed)
+	require.NoError(t, err)
+
+	encrypted, err := encryptSeed(masterKey, seed)
+	require.NoError(t, err)
+	assert.Greater(t, len(encrypted), len(seed))
+
+	decrypted, err := decryptSeed(masterKey, encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, seed, decrypted)
+}
+
+func TestSSEService_SeedDecryptWrongKey(t *testing.T) {
+	masterKey, _ := hex.DecodeString(testMasterKeyHex())
+	wrongKey := make([]byte, 32)
+	_, _ = rand.Read(wrongKey)
+
+	seed := make([]byte, mlkem.SeedSize)
+	_, _ = rand.Read(seed)
+
+	encrypted, err := encryptSeed(masterKey, seed)
+	require.NoError(t, err)
+
+	_, err = decryptSeed(wrongKey, encrypted)
+	require.Error(t, err)
+}
+
+func TestSSEService_EncryptDecrypt_RoundTrip(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-test-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	err = svc.EnsureTenantKey(ctx, tenantID)
+	require.NoError(t, err)
+
+	plaintext := []byte("hello, post-quantum world!")
+	ciphertext, err := svc.EncryptBytes(ctx, tenantID, plaintext)
+	require.NoError(t, err)
+
+	decrypted, err := svc.DecryptBytes(ctx, tenantID, ciphertext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestSSEService_EncryptedFormat(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-fmt-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+
+	plaintext := []byte("format check")
+	ct, err := svc.EncryptBytes(ctx, tenantID, plaintext)
+	require.NoError(t, err)
+
+	assert.Equal(t, SSEVersion, ct[0])
+	assert.Equal(t, mlkem.CiphertextSize768, len(ct[1:1+mlkem.CiphertextSize768]))
+
+	nonceStart := 1 + mlkem.CiphertextSize768
+	nonce := ct[nonceStart : nonceStart+12]
+	assert.Len(t, nonce, 12)
+}
+
+func TestSSEService_EncryptedSizeOverhead(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-size-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+
+	for _, size := range []int{0, 1, 100, 4096, 65536} {
+		plaintext := make([]byte, size)
+		_, _ = rand.Read(plaintext)
+
+		ct, err := svc.EncryptBytes(ctx, tenantID, plaintext)
+		require.NoError(t, err)
+		assert.Equal(t, size+SSEOverheadBytes, len(ct),
+			"overhead mismatch for plaintext size %d", size)
+	}
+}
+
+func TestSSEService_DecryptWrongTenant(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenant1 := fmt.Sprintf("sse-t1-%d", os.Getpid())
+	tenant2 := fmt.Sprintf("sse-t2-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id IN ($1, $2)", tenant1, tenant2)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenant1))
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenant2))
+
+	ct, err := svc.EncryptBytes(ctx, tenant1, []byte("secret data"))
+	require.NoError(t, err)
+
+	_, err = svc.DecryptBytes(ctx, tenant2, ct)
+	require.Error(t, err)
+}
+
+func TestSSEService_DecryptCorruptedData(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-corrupt-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+
+	ct, err := svc.EncryptBytes(ctx, tenantID, []byte("original"))
+	require.NoError(t, err)
+
+	tampered := make([]byte, len(ct))
+	copy(tampered, ct)
+	tampered[len(tampered)-1] ^= 0xff
+
+	_, err = svc.DecryptBytes(ctx, tenantID, tampered)
+	require.Error(t, err)
+}
+
+func TestSSEService_DecryptBadVersion(t *testing.T) {
+	data := make([]byte, 1+mlkem.CiphertextSize768+12+32)
+	data[0] = 0xFF
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	tenantID := fmt.Sprintf("sse-ver-%d", os.Getpid())
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+	require.NoError(t, svc.EnsureTenantKey(context.Background(), tenantID))
+
+	_, err = svc.DecryptBytes(context.Background(), tenantID, data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported SSE version")
+}
+
+func TestSSEService_DecryptTooShort(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	tenantID := fmt.Sprintf("sse-short-%d", os.Getpid())
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+	require.NoError(t, svc.EnsureTenantKey(context.Background(), tenantID))
+
+	_, err = svc.DecryptBytes(context.Background(), tenantID, []byte("too short"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestSSEService_EnsureTenantKey_Idempotent(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-idem-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestSSEService_EmptyPlaintext(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	svc, err := NewSSEService(db, testMasterKeyHex())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("sse-empty-%d", os.Getpid())
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM tenant_encryption_keys WHERE tenant_id = $1", tenantID)
+	})
+
+	require.NoError(t, svc.EnsureTenantKey(ctx, tenantID))
+
+	ct, err := svc.EncryptBytes(ctx, tenantID, []byte{})
+	require.NoError(t, err)
+	assert.Equal(t, SSEOverheadBytes, len(ct))
+
+	pt, err := svc.DecryptBytes(ctx, tenantID, ct)
+	require.NoError(t, err)
+	assert.Empty(t, pt)
+}
+
+func TestSSEOverheadConstant(t *testing.T) {
+	assert.Equal(t, 1117, SSEOverheadBytes)
+}
+
+func TestDeriveSSEKey(t *testing.T) {
+	key1, err := deriveSSEKey(make([]byte, 32))
+	require.NoError(t, err)
+	assert.Len(t, key1, 32)
+
+	key2, err := deriveSSEKey(make([]byte, 32))
+	require.NoError(t, err)
+	assert.Equal(t, key1, key2, "same input should produce same output")
+
+	differentInput := make([]byte, 32)
+	differentInput[0] = 1
+	key3, err := deriveSSEKey(differentInput)
+	require.NoError(t, err)
+	assert.NotEqual(t, key1, key3)
+}

--- a/internal/database/migrations/037_sse_s3.sql
+++ b/internal/database/migrations/037_sse_s3.sql
@@ -1,0 +1,13 @@
+-- 037_sse_s3.sql: Server-side encryption with ML-KEM-768 + AES-256-GCM
+CREATE TABLE IF NOT EXISTS tenant_encryption_keys (
+    tenant_id    TEXT PRIMARY KEY,
+    algorithm    TEXT NOT NULL DEFAULT 'ML-KEM-768+AES-256-GCM',
+    seed         BYTEA NOT NULL,
+    public_key   BYTEA NOT NULL,
+    key_version  INTEGER NOT NULL DEFAULT 1,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rotated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS sse_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS encryption_algorithm TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

- **Post-quantum server-side encryption** using ML-KEM-768 (Go stdlib `crypto/mlkem`) for key encapsulation + AES-256-GCM for data encryption
- Per-tenant keypairs stored in `tenant_encryption_keys` table with master-key-encrypted seeds (defense in depth)
- Transparent encrypt on PUT, decrypt on GET — activated via `x-amz-server-side-encryption: AES256` header or bucket-level `sse_enabled` flag
- ETag computed on plaintext (S3 compatibility), `object_head_cache.size_bytes` stores original size
- Objects > 256 MiB skip encryption (chunked encryption deferred to Phase 10)

## What changed

| File | Change |
|------|--------|
| `internal/crypto/sse_s3.go` | SSEService: EnsureTenantKey, EncryptBytes, DecryptBytes, key caching, seed protection |
| `internal/crypto/sse_s3_test.go` | 13 tests: round-trip, format, overhead, wrong-tenant, corruption, idempotency |
| `internal/api/s3_engine_adapter.go` | HandlePut encryption, HandleGet decryption, `isBucketSSEEnabled` helper |
| `internal/api/server.go` | SSEService field + init from `ENCRYPTION_MASTER_KEY` env var |
| `internal/api/s3.go` | Pass sseService to adapter, HEAD returns `x-amz-server-side-encryption` header |
| `internal/api/s3_buckets.go` | CreateBucket defaults `sse_enabled = TRUE` when SSE available |
| `migrations/037_sse_s3.sql` | `tenant_encryption_keys` table, `buckets.sse_enabled`, `object_head_cache.encryption_algorithm` |

## Encrypted blob format

```
[0x01][ML-KEM-768 ciphertext (1088B)][nonce (12B)][AES-256-GCM ciphertext + tag (16B)]
```

Overhead: 1117 bytes per object.

## Test plan

- [x] Unit tests: SSEService constructor validation, seed encrypt/decrypt, HKDF determinism, overhead constant
- [x] Integration tests (DATABASE_URL): encrypt/decrypt round-trip, blob format verification, size overhead for multiple sizes, wrong-tenant decryption fails, corrupted data detection, bad version rejection, too-short data rejection, EnsureTenantKey idempotency, empty plaintext round-trip
- [x] Full test suite passes with `-race` (0 regressions)
- [x] golangci-lint: 0 issues
- [ ] CI: `build-and-test` workflow