### PR TITLE
feat(compliance): HIPAA readiness with BAA and breach workflow [Phase 5.14.5]

### DIFF
--- a/internal/api/admin_breach_test.go
+++ b/internal/api/admin_breach_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/FairForge/vaultaire/internal/compliance"
+	"github.com/FairForge/vaultaire/internal/config"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newAdminBreachTestServer(t *testing.T) (*Server, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	logger := zap.NewNop()
+
+	breachService := compliance.NewBreachService(nil, logger)
+	complianceHandler := compliance.NewAPIHandler(
+		nil, nil, nil, breachService, nil, nil, logger,
+	)
+
+	s := &Server{
+		logger: logger,
+		router: chi.NewRouter(),
+		db:     db,
+		config: &config.Config{Server: config.ServerConfig{Port: 8000}},
+	}
+
+	s.router.Route("/api/v1/admin", func(r chi.Router) {
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Request-Id", uuid.New().String())
+				ctx := context.WithValue(req.Context(), userIDKey, "admin-user")
+				ctx = context.WithValue(ctx, tenantIDKey, "admin-tenant")
+				next.ServeHTTP(w, req.WithContext(ctx))
+			})
+		})
+
+		r.Post("/breach", s.requireAdmin(complianceHandler.HandleReportBreach))
+		r.Get("/breaches", s.requireAdmin(complianceHandler.HandleListBreaches))
+	})
+
+	return s, mock, func() { _ = db.Close() }
+}
+
+func TestAdminBreachEndpoint_Create(t *testing.T) {
+	srv, mock, cleanup := newAdminBreachTestServer(t)
+	defer cleanup()
+
+	// requireAdmin checks role from DB
+	mock.ExpectQuery(`SELECT COALESCE\(role, ''\) FROM users WHERE id = \$1`).
+		WithArgs("admin-user").
+		WillReturnRows(sqlmock.NewRows([]string{"role"}).AddRow("admin"))
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"breach_type":     "data_leakage",
+		"description":     "test breach from admin",
+		"root_cause":      "test",
+		"data_categories": []string{"email"},
+	})
+
+	req := httptest.NewRequest("POST", "/api/v1/admin/breach", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&result))
+	assert.Equal(t, "data_leakage", result["BreachType"])
+}
+
+func TestAdminBreachEndpoint_RequiresAdmin(t *testing.T) {
+	srv, mock, cleanup := newAdminBreachTestServer(t)
+	defer cleanup()
+
+	// Non-admin user
+	mock.ExpectQuery(`SELECT COALESCE\(role, ''\) FROM users WHERE id = \$1`).
+		WithArgs("admin-user").
+		WillReturnRows(sqlmock.NewRows([]string{"role"}).AddRow("user"))
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"breach_type": "data_leakage",
+		"description": "should be rejected",
+	})
+
+	req := httptest.NewRequest("POST", "/api/v1/admin/breach", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "admin access required")
+}

--- a/internal/api/quota_management.go
+++ b/internal/api/quota_management.go
@@ -34,15 +34,23 @@ type QuotaResponse struct {
 	BandwidthUsed  int64  `json:"bandwidth_used,omitempty"`
 }
 
-// Middleware to check admin privileges
 func (s *Server) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		isAdmin, ok := r.Context().Value("is_admin").(bool)
-		if !ok || !isAdmin {
-			http.Error(w, "admin access required", http.StatusForbidden)
+		if isAdmin, ok := r.Context().Value("is_admin").(bool); ok && isAdmin {
+			next(w, r)
 			return
 		}
-		next(w, r)
+		userID, _ := r.Context().Value(userIDKey).(string)
+		if userID != "" && s.db != nil {
+			var role string
+			if err := s.db.QueryRowContext(r.Context(),
+				"SELECT COALESCE(role, '') FROM users WHERE id = $1", userID,
+			).Scan(&role); err == nil && role == "admin" {
+				next(w, r)
+				return
+			}
+		}
+		http.Error(w, "admin access required", http.StatusForbidden)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -482,11 +482,17 @@ func (s *Server) setupRoutes() {
 }
 
 func (s *Server) registerComplianceRoutes() {
+	var breachDB compliance.BreachDatabase
+	if s.db != nil {
+		breachDB = compliance.NewBreachPgStore(s.db)
+	}
+	breachService := compliance.NewBreachService(breachDB, s.logger)
+
 	complianceHandler := compliance.NewAPIHandler(
 		compliance.NewGDPRService(nil, s.logger),
 		compliance.NewPortabilityService(nil, nil, s.logger),
 		compliance.NewConsentService(nil, s.logger),
-		compliance.NewBreachService(nil, s.logger),
+		breachService,
 		compliance.NewROPAService(nil, s.logger),
 		compliance.NewPrivacyService(nil),
 		s.logger,
@@ -533,6 +539,14 @@ func (s *Server) registerComplianceRoutes() {
 		r.Post("/privacy/minimize", complianceHandler.HandleMinimizeData)
 		r.Get("/privacy/purpose/{dataId}/{purpose}", complianceHandler.HandleCheckPurpose)
 		r.Post("/privacy/pseudonymize", complianceHandler.HandlePseudonymize)
+	})
+
+	s.router.Route("/api/v1/admin", func(r chi.Router) {
+		r.Use(s.requireJWT)
+
+		r.Post("/breach", s.requireAdmin(complianceHandler.HandleReportBreach))
+		r.Get("/breaches", s.requireAdmin(complianceHandler.HandleListBreaches))
+		r.Patch("/breach/{id}", s.requireAdmin(complianceHandler.HandleUpdateBreach))
 	})
 }
 

--- a/internal/compliance/breach_pg.go
+++ b/internal/compliance/breach_pg.go
@@ -1,0 +1,353 @@
+package compliance
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BreachPgStore implements BreachDatabase using PostgreSQL.
+type BreachPgStore struct {
+	db *sql.DB
+}
+
+// NewBreachPgStore returns a PostgreSQL-backed BreachDatabase.
+func NewBreachPgStore(db *sql.DB) *BreachPgStore {
+	return &BreachPgStore{db: db}
+}
+
+func (s *BreachPgStore) CreateBreach(ctx context.Context, breach *BreachRecord) error {
+	categories, err := json.Marshal(breach.DataCategories)
+	if err != nil {
+		return fmt.Errorf("marshal data_categories: %w", err)
+	}
+
+	var metadata []byte
+	if breach.Metadata != nil {
+		metadata, err = json.Marshal(breach.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO breach_records (
+			id, breach_type, severity, status, detected_at, reported_at,
+			affected_user_count, affected_record_count, data_categories,
+			description, root_cause, consequences, mitigation,
+			notified_authority, notified_subjects, authority_notified_at,
+			subjects_notified_at, deadline_at, metadata, created_at, updated_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			$7, $8, $9,
+			$10, $11, $12, $13,
+			$14, $15, $16,
+			$17, $18, $19, $20, $21
+		)`,
+		breach.ID, breach.BreachType, breach.Severity, breach.Status, breach.DetectedAt, breach.ReportedAt,
+		breach.AffectedUserCount, breach.AffectedRecordCount, categories,
+		breach.Description, breach.RootCause, breach.Consequences, breach.Mitigation,
+		breach.NotifiedAuthority, breach.NotifiedSubjects, breach.AuthorityNotifiedAt,
+		breach.SubjectsNotifiedAt, breach.DeadlineAt, metadata, breach.CreatedAt, breach.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert breach_records: %w", err)
+	}
+	return nil
+}
+
+func (s *BreachPgStore) GetBreach(ctx context.Context, breachID uuid.UUID) (*BreachRecord, error) {
+	var b BreachRecord
+	var categories, metadata []byte
+
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, breach_type, severity, status, detected_at, reported_at,
+			affected_user_count, affected_record_count, data_categories,
+			description, root_cause, consequences, mitigation,
+			notified_authority, notified_subjects, authority_notified_at,
+			subjects_notified_at, deadline_at, metadata, created_at, updated_at
+		FROM breach_records WHERE id = $1`, breachID).Scan(
+		&b.ID, &b.BreachType, &b.Severity, &b.Status, &b.DetectedAt, &b.ReportedAt,
+		&b.AffectedUserCount, &b.AffectedRecordCount, &categories,
+		&b.Description, &b.RootCause, &b.Consequences, &b.Mitigation,
+		&b.NotifiedAuthority, &b.NotifiedSubjects, &b.AuthorityNotifiedAt,
+		&b.SubjectsNotifiedAt, &b.DeadlineAt, &metadata, &b.CreatedAt, &b.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query breach_records: %w", err)
+	}
+
+	if categories != nil {
+		_ = json.Unmarshal(categories, &b.DataCategories)
+	}
+	if metadata != nil {
+		_ = json.Unmarshal(metadata, &b.Metadata)
+	}
+
+	return &b, nil
+}
+
+func (s *BreachPgStore) UpdateBreach(ctx context.Context, breach *BreachRecord) error {
+	categories, err := json.Marshal(breach.DataCategories)
+	if err != nil {
+		return fmt.Errorf("marshal data_categories: %w", err)
+	}
+
+	var metadata []byte
+	if breach.Metadata != nil {
+		metadata, err = json.Marshal(breach.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE breach_records SET
+			breach_type = $2, severity = $3, status = $4,
+			reported_at = $5, affected_user_count = $6, affected_record_count = $7,
+			data_categories = $8, description = $9, root_cause = $10,
+			consequences = $11, mitigation = $12,
+			notified_authority = $13, notified_subjects = $14,
+			authority_notified_at = $15, subjects_notified_at = $16,
+			metadata = $17, updated_at = $18
+		WHERE id = $1`,
+		breach.ID, breach.BreachType, breach.Severity, breach.Status,
+		breach.ReportedAt, breach.AffectedUserCount, breach.AffectedRecordCount,
+		categories, breach.Description, breach.RootCause,
+		breach.Consequences, breach.Mitigation,
+		breach.NotifiedAuthority, breach.NotifiedSubjects,
+		breach.AuthorityNotifiedAt, breach.SubjectsNotifiedAt,
+		metadata, breach.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("update breach_records: %w", err)
+	}
+	return nil
+}
+
+func (s *BreachPgStore) ListBreaches(ctx context.Context, filters map[string]interface{}) ([]*BreachRecord, error) {
+	query := `SELECT id, breach_type, severity, status, detected_at, reported_at,
+		affected_user_count, affected_record_count, data_categories,
+		description, root_cause, consequences, mitigation,
+		notified_authority, notified_subjects, authority_notified_at,
+		subjects_notified_at, deadline_at, metadata, created_at, updated_at
+		FROM breach_records WHERE 1=1`
+
+	var args []interface{}
+	argIdx := 1
+
+	if severity, ok := filters["severity"].(string); ok && severity != "" {
+		query += fmt.Sprintf(" AND severity = $%d", argIdx)
+		args = append(args, severity)
+		argIdx++
+	}
+	if status, ok := filters["status"].(string); ok && status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, status)
+	}
+
+	query += " ORDER BY detected_at DESC LIMIT 100"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query breach_records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var breaches []*BreachRecord
+	for rows.Next() {
+		var b BreachRecord
+		var categories, metadata []byte
+		if err := rows.Scan(
+			&b.ID, &b.BreachType, &b.Severity, &b.Status, &b.DetectedAt, &b.ReportedAt,
+			&b.AffectedUserCount, &b.AffectedRecordCount, &categories,
+			&b.Description, &b.RootCause, &b.Consequences, &b.Mitigation,
+			&b.NotifiedAuthority, &b.NotifiedSubjects, &b.AuthorityNotifiedAt,
+			&b.SubjectsNotifiedAt, &b.DeadlineAt, &metadata, &b.CreatedAt, &b.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan breach_records: %w", err)
+		}
+		if categories != nil {
+			_ = json.Unmarshal(categories, &b.DataCategories)
+		}
+		if metadata != nil {
+			_ = json.Unmarshal(metadata, &b.Metadata)
+		}
+		breaches = append(breaches, &b)
+	}
+
+	return breaches, nil
+}
+
+func (s *BreachPgStore) AddAffectedUsers(ctx context.Context, breachID uuid.UUID, userIDs []uuid.UUID) error {
+	for _, uid := range userIDs {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO breach_affected_users (id, breach_id, user_id, created_at)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (breach_id, user_id) DO NOTHING`,
+			uuid.New(), breachID, uid, time.Now(),
+		)
+		if err != nil {
+			return fmt.Errorf("insert breach_affected_users: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *BreachPgStore) GetAffectedUsers(ctx context.Context, breachID uuid.UUID) ([]*BreachAffectedUser, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, breach_id, user_id, notified, notified_at, method, created_at
+		FROM breach_affected_users WHERE breach_id = $1`, breachID)
+	if err != nil {
+		return nil, fmt.Errorf("query breach_affected_users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var users []*BreachAffectedUser
+	for rows.Next() {
+		var u BreachAffectedUser
+		if err := rows.Scan(&u.ID, &u.BreachID, &u.UserID, &u.Notified, &u.NotifiedAt, &u.Method, &u.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan breach_affected_users: %w", err)
+		}
+		users = append(users, &u)
+	}
+
+	return users, nil
+}
+
+func (s *BreachPgStore) UpdateAffectedUser(ctx context.Context, affected *BreachAffectedUser) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE breach_affected_users SET notified = $2, notified_at = $3, method = $4
+		WHERE id = $1`,
+		affected.ID, affected.Notified, affected.NotifiedAt, affected.Method,
+	)
+	if err != nil {
+		return fmt.Errorf("update breach_affected_users: %w", err)
+	}
+	return nil
+}
+
+func (s *BreachPgStore) CreateNotification(ctx context.Context, notification *BreachNotification) error {
+	var metadata []byte
+	var err error
+	if notification.Metadata != nil {
+		metadata, err = json.Marshal(notification.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO breach_notifications (
+			id, breach_id, notification_type, recipient, sent_at,
+			method, status, content, metadata, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		notification.ID, notification.BreachID, notification.NotificationType,
+		notification.Recipient, notification.SentAt,
+		notification.Method, notification.Status, notification.Content,
+		metadata, notification.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert breach_notifications: %w", err)
+	}
+	return nil
+}
+
+func (s *BreachPgStore) GetNotifications(ctx context.Context, breachID uuid.UUID) ([]*BreachNotification, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, breach_id, notification_type, recipient, sent_at,
+			method, status, content, metadata, created_at
+		FROM breach_notifications WHERE breach_id = $1 ORDER BY created_at DESC`, breachID)
+	if err != nil {
+		return nil, fmt.Errorf("query breach_notifications: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notifications []*BreachNotification
+	for rows.Next() {
+		var n BreachNotification
+		var metadata []byte
+		if err := rows.Scan(
+			&n.ID, &n.BreachID, &n.NotificationType, &n.Recipient, &n.SentAt,
+			&n.Method, &n.Status, &n.Content, &metadata, &n.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan breach_notifications: %w", err)
+		}
+		if metadata != nil {
+			_ = json.Unmarshal(metadata, &n.Metadata)
+		}
+		notifications = append(notifications, &n)
+	}
+
+	return notifications, nil
+}
+
+func (s *BreachPgStore) GetBreachStats(ctx context.Context) (*BreachStats, error) {
+	stats := &BreachStats{
+		BreachesByType:     make(map[string]int),
+		BreachesBySeverity: make(map[string]int),
+		BreachesByStatus:   make(map[string]int),
+	}
+
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM breach_records`).Scan(&stats.TotalBreaches)
+	if err != nil {
+		return nil, fmt.Errorf("count breach_records: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT breach_type, COUNT(*) FROM breach_records GROUP BY breach_type`)
+	if err != nil {
+		return nil, fmt.Errorf("query by type: %w", err)
+	}
+	for rows.Next() {
+		var t string
+		var c int
+		if err := rows.Scan(&t, &c); err == nil {
+			stats.BreachesByType[t] = c
+		}
+	}
+	_ = rows.Close()
+
+	rows, err = s.db.QueryContext(ctx, `SELECT severity, COUNT(*) FROM breach_records GROUP BY severity`)
+	if err != nil {
+		return nil, fmt.Errorf("query by severity: %w", err)
+	}
+	for rows.Next() {
+		var t string
+		var c int
+		if err := rows.Scan(&t, &c); err == nil {
+			stats.BreachesBySeverity[t] = c
+		}
+	}
+	_ = rows.Close()
+
+	rows, err = s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM breach_records GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("query by status: %w", err)
+	}
+	for rows.Next() {
+		var t string
+		var c int
+		if err := rows.Scan(&t, &c); err == nil {
+			stats.BreachesByStatus[t] = c
+		}
+	}
+	_ = rows.Close()
+
+	_ = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM breach_records WHERE deadline_at > NOW() AND notified_authority = false`).Scan(&stats.WithinDeadline)
+	_ = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM breach_records WHERE deadline_at <= NOW() AND notified_authority = false`).Scan(&stats.MissedDeadline)
+
+	var avgSeconds sql.NullFloat64
+	_ = s.db.QueryRowContext(ctx, `SELECT AVG(EXTRACT(EPOCH FROM (COALESCE(reported_at, NOW()) - detected_at))) FROM breach_records`).Scan(&avgSeconds)
+	if avgSeconds.Valid {
+		stats.AverageResponseTime = time.Duration(avgSeconds.Float64) * time.Second
+	}
+
+	return stats, nil
+}

--- a/internal/compliance/breach_pg_test.go
+++ b/internal/compliance/breach_pg_test.go
@@ -1,0 +1,198 @@
+package compliance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreachPgStore_CreateAndGet(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewBreachPgStore(db)
+	ctx := context.Background()
+
+	breach := &BreachRecord{
+		ID:                uuid.New(),
+		BreachType:        BreachTypeDataLeakage,
+		Severity:          BreachSeverityHigh,
+		Status:            BreachStatusDetected,
+		DetectedAt:        time.Now(),
+		AffectedUserCount: 42,
+		DataCategories:    []string{"email", "health"},
+		Description:       "test breach",
+		RootCause:         "misconfiguration",
+		DeadlineAt:        time.Now().Add(72 * time.Hour),
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	// Expect INSERT
+	mock.ExpectExec(`INSERT INTO breach_records`).
+		WithArgs(
+			breach.ID, breach.BreachType, breach.Severity, breach.Status,
+			breach.DetectedAt, breach.ReportedAt,
+			breach.AffectedUserCount, breach.AffectedRecordCount,
+			sqlmock.AnyArg(), // categories JSON
+			breach.Description, breach.RootCause, breach.Consequences, breach.Mitigation,
+			breach.NotifiedAuthority, breach.NotifiedSubjects,
+			breach.AuthorityNotifiedAt, breach.SubjectsNotifiedAt,
+			breach.DeadlineAt, sqlmock.AnyArg(), // metadata
+			breach.CreatedAt, breach.UpdatedAt,
+		).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.CreateBreach(ctx, breach)
+	require.NoError(t, err)
+
+	// Expect SELECT
+	rows := sqlmock.NewRows([]string{
+		"id", "breach_type", "severity", "status", "detected_at", "reported_at",
+		"affected_user_count", "affected_record_count", "data_categories",
+		"description", "root_cause", "consequences", "mitigation",
+		"notified_authority", "notified_subjects", "authority_notified_at",
+		"subjects_notified_at", "deadline_at", "metadata", "created_at", "updated_at",
+	}).AddRow(
+		breach.ID, breach.BreachType, breach.Severity, breach.Status,
+		breach.DetectedAt, breach.ReportedAt,
+		breach.AffectedUserCount, breach.AffectedRecordCount,
+		[]byte(`["email","health"]`),
+		breach.Description, breach.RootCause, breach.Consequences, breach.Mitigation,
+		breach.NotifiedAuthority, breach.NotifiedSubjects,
+		breach.AuthorityNotifiedAt, breach.SubjectsNotifiedAt,
+		breach.DeadlineAt, nil, breach.CreatedAt, breach.UpdatedAt,
+	)
+	mock.ExpectQuery(`SELECT .+ FROM breach_records WHERE id = \$1`).
+		WithArgs(breach.ID).WillReturnRows(rows)
+
+	got, err := store.GetBreach(ctx, breach.ID)
+	require.NoError(t, err)
+	assert.Equal(t, breach.ID, got.ID)
+	assert.Equal(t, BreachTypeDataLeakage, got.BreachType)
+	assert.Equal(t, BreachSeverityHigh, got.Severity)
+	assert.Equal(t, 42, got.AffectedUserCount)
+	assert.Equal(t, []string{"email", "health"}, got.DataCategories)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBreachPgStore_AddAffectedUsers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewBreachPgStore(db)
+	ctx := context.Background()
+
+	breachID := uuid.New()
+	userIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+
+	for range userIDs {
+		mock.ExpectExec(`INSERT INTO breach_affected_users`).
+			WithArgs(sqlmock.AnyArg(), breachID, sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+
+	err = store.AddAffectedUsers(ctx, breachID, userIDs)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBreachPgStore_ListBreaches(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewBreachPgStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	id1 := uuid.New()
+	id2 := uuid.New()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "breach_type", "severity", "status", "detected_at", "reported_at",
+		"affected_user_count", "affected_record_count", "data_categories",
+		"description", "root_cause", "consequences", "mitigation",
+		"notified_authority", "notified_subjects", "authority_notified_at",
+		"subjects_notified_at", "deadline_at", "metadata", "created_at", "updated_at",
+	}).
+		AddRow(id1, "data_leakage", "high", "detected", now, nil,
+			10, 100, []byte(`["email"]`), "desc1", "", "", "",
+			false, false, nil, nil, now.Add(72*time.Hour), nil, now, now).
+		AddRow(id2, "phishing", "medium", "detected", now, nil,
+			5, 50, []byte(`[]`), "desc2", "", "", "",
+			false, false, nil, nil, now.Add(72*time.Hour), nil, now, now)
+
+	mock.ExpectQuery(`SELECT .+ FROM breach_records WHERE 1=1 AND status = \$1`).
+		WithArgs("detected").WillReturnRows(rows)
+
+	breaches, err := store.ListBreaches(ctx, map[string]interface{}{"status": "detected"})
+	require.NoError(t, err)
+	assert.Len(t, breaches, 2)
+	assert.Equal(t, id1, breaches[0].ID)
+	assert.Equal(t, id2, breaches[1].ID)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBreachPgStore_UpdateStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewBreachPgStore(db)
+	ctx := context.Background()
+
+	breach := &BreachRecord{
+		ID:             uuid.New(),
+		BreachType:     BreachTypeRansomware,
+		Severity:       BreachSeverityCritical,
+		Status:         BreachStatusMitigated,
+		DetectedAt:     time.Now(),
+		DataCategories: []string{"financial"},
+		Description:    "ransomware attack",
+		DeadlineAt:     time.Now().Add(72 * time.Hour),
+		UpdatedAt:      time.Now(),
+	}
+
+	mock.ExpectExec(`UPDATE breach_records SET`).
+		WithArgs(
+			breach.ID, breach.BreachType, breach.Severity, breach.Status,
+			breach.ReportedAt, breach.AffectedUserCount, breach.AffectedRecordCount,
+			sqlmock.AnyArg(), // categories
+			breach.Description, breach.RootCause,
+			breach.Consequences, breach.Mitigation,
+			breach.NotifiedAuthority, breach.NotifiedSubjects,
+			breach.AuthorityNotifiedAt, breach.SubjectsNotifiedAt,
+			sqlmock.AnyArg(), // metadata
+			breach.UpdatedAt,
+		).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.UpdateBreach(ctx, breach)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBreachPgStore_GetNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewBreachPgStore(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT .+ FROM breach_records WHERE id = \$1`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows(nil))
+
+	_, err = store.GetBreach(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/dashboard/handlers/legal_test.go
+++ b/internal/dashboard/handlers/legal_test.go
@@ -137,3 +137,27 @@ func TestLegalAUP_ContainsProhibited(t *testing.T) {
 	assert.Contains(t, body, "Prohibited Content")
 	assert.Contains(t, body, "Enforcement")
 }
+
+func TestHandleLegalPage_BAA(t *testing.T) {
+	// Arrange
+	tmpl := legalTmpl(t, `{{define "content"}}`+
+		`<h1>Business Associate Agreement</h1>`+
+		`<h2 id="definitions">1. Definitions</h2>`+
+		`<h2 id="safeguards">3. Safeguards</h2>`+
+		`<h2 id="breach-notification">4. Breach Notification</h2>`+
+		`{{end}}`)
+	handler := handlers.HandleLegalPage(tmpl)
+	req := httptest.NewRequest(http.MethodGet, "/legal/baa", nil)
+	rec := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(rec, req)
+
+	// Assert
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Business Associate")
+	assert.Contains(t, body, "Definitions")
+	assert.Contains(t, body, "Safeguards")
+	assert.Contains(t, body, "Breach Notification")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -99,6 +99,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"dpa":     "templates/legal/dpa.html",
 		"cookies": "templates/legal/cookies.html",
 		"aup":     "templates/legal/aup.html",
+		"baa":     "templates/legal/baa.html",
 	}
 	for slug, tmplPath := range legalPages {
 		pageTmpl := template.Must(baseTmpl.Clone())

--- a/internal/dashboard/templates/legal/baa.html
+++ b/internal/dashboard/templates/legal/baa.html
@@ -1,0 +1,113 @@
+{{define "title"}}Business Associate Agreement — stored.ge{{end}}
+{{define "content"}}
+<div class="card">
+    <p class="text-muted">Last updated: June 1, 2026</p>
+    <h1>Business Associate Agreement</h1>
+    <p>This Business Associate Agreement ("BAA") is entered into between you, the Covered Entity or Business Associate ("Covered Entity"), and FairForge LLC, operating as stored.ge ("Business Associate"), and supplements the <a href="/legal/terms">Terms of Service</a> and <a href="/legal/dpa">Data Processing Agreement</a>.</p>
+    <p>This BAA is required under the Health Insurance Portability and Accountability Act of 1996 ("HIPAA"), the Health Information Technology for Economic and Clinical Health Act ("HITECH"), and their implementing regulations at 45 CFR Parts 160 and 164 (collectively, "HIPAA Rules").</p>
+
+    <h2 id="contents">Contents</h2>
+    <ul>
+        <li><a href="#definitions">Definitions</a></li>
+        <li><a href="#permitted-uses">Permitted Uses and Disclosures of PHI</a></li>
+        <li><a href="#safeguards">Safeguards</a></li>
+        <li><a href="#breach-notification">Breach Notification</a></li>
+        <li><a href="#subcontractors">Subcontractors</a></li>
+        <li><a href="#access-records">Access to Records</a></li>
+        <li><a href="#return-destruction">Return or Destruction of PHI</a></li>
+        <li><a href="#term-termination">Term and Termination</a></li>
+        <li><a href="#contact">Contact</a></li>
+    </ul>
+
+    <h2 id="definitions">1. Definitions</h2>
+    <p>Capitalized terms used but not defined in this BAA have the meanings assigned to them in the HIPAA Rules. For purposes of this BAA:</p>
+    <ul>
+        <li><strong>Covered Entity</strong> means the customer who is subject to HIPAA and enters into this BAA in connection with the use of stored.ge services.</li>
+        <li><strong>Business Associate</strong> means FairForge LLC, operating as stored.ge, which creates, receives, maintains, or transmits Protected Health Information on behalf of the Covered Entity.</li>
+        <li><strong>Protected Health Information (PHI)</strong> means individually identifiable health information as defined in 45 CFR §160.103, including electronic PHI (ePHI).</li>
+        <li><strong>Electronic Protected Health Information (ePHI)</strong> means PHI that is transmitted by or maintained in electronic media, as defined in 45 CFR §160.103.</li>
+        <li><strong>Breach</strong> means the acquisition, access, use, or disclosure of PHI in a manner not permitted under the HIPAA Privacy Rule which compromises the security or privacy of the PHI, as defined in 45 CFR §164.402.</li>
+        <li><strong>Security Incident</strong> means the attempted or successful unauthorized access, use, disclosure, modification, or destruction of information or interference with system operations in an information system, as defined in 45 CFR §164.304.</li>
+    </ul>
+
+    <h2 id="permitted-uses">2. Permitted Uses and Disclosures of PHI</h2>
+    <p>Business Associate may use or disclose PHI only as follows:</p>
+    <ul>
+        <li><strong>Service performance:</strong> As necessary to perform obligations under the Terms of Service, including storage, retrieval, and delivery of objects via the S3-compatible API.</li>
+        <li><strong>Management and administration:</strong> For Business Associate's proper management and administration, or to carry out legal responsibilities, provided that any disclosure is required by law or Business Associate obtains reasonable assurances from the recipient that the information will be held confidentially.</li>
+        <li><strong>As required by law:</strong> As required by applicable federal, state, or local law, provided that Business Associate will notify Covered Entity of such requirement where permitted.</li>
+    </ul>
+    <p>Business Associate shall not use or disclose PHI in any manner that would violate the HIPAA Rules if done by Covered Entity, except as permitted above.</p>
+
+    <h2 id="safeguards">3. Safeguards</h2>
+    <p>Business Associate shall implement administrative, physical, and technical safeguards that reasonably and appropriately protect the confidentiality, integrity, and availability of ePHI, as required by 45 CFR §164.306 and §164.312. stored.ge provides the following safeguards:</p>
+
+    <h3>3.1 Encryption at Rest</h3>
+    <p>All stored objects are encrypted at rest using server-side encryption (SSE-S3) with AES-256-GCM. Key encapsulation uses ML-KEM-768, a post-quantum key encapsulation mechanism. Per-tenant encryption keys are derived and managed automatically.</p>
+
+    <h3>3.2 Encryption in Transit</h3>
+    <p>All data in transit is encrypted via TLS 1.2 or higher. HSTS headers are enforced on all connections. API endpoints are accessible only over HTTPS.</p>
+
+    <h3>3.3 Access Controls</h3>
+    <ul>
+        <li><strong>Unique user identification:</strong> Each tenant receives unique access credentials. Scoped API keys provide granular, per-bucket, per-operation access control.</li>
+        <li><strong>Two-factor authentication:</strong> TOTP-based two-factor authentication is available for all accounts and enforced for administrative access.</li>
+        <li><strong>Automatic logoff:</strong> Dashboard sessions expire after 24 hours of inactivity, with hourly session cleanup.</li>
+        <li><strong>Emergency access:</strong> Administrators can reset two-factor authentication and manage account status for emergency access procedures.</li>
+    </ul>
+
+    <h3>3.4 Integrity Controls</h3>
+    <ul>
+        <li>ETag (MD5) verification computed on every upload to ensure data integrity.</li>
+        <li>Object Lock (WORM) support for immutable retention of records.</li>
+        <li>MFA Delete enforcement prevents unauthorized deletion of versioned objects.</li>
+    </ul>
+
+    <h3>3.5 Audit Controls</h3>
+    <p>stored.ge maintains audit logs for account access, API operations, and administrative actions. Event logging and webhook notifications are available for real-time monitoring of object operations.</p>
+
+    <h2 id="breach-notification">4. Breach Notification</h2>
+    <p>Business Associate shall comply with the breach notification requirements of 45 CFR §§164.400–414:</p>
+    <ul>
+        <li><strong>Discovery and notification:</strong> Business Associate shall report to Covered Entity any Breach of Unsecured PHI without unreasonable delay, and in no case later than <strong>72 hours</strong> after discovery of the Breach.</li>
+        <li><strong>Content of notification:</strong> Notification shall include, to the extent available: (a) identification of each individual whose PHI has been or is reasonably believed to have been affected; (b) a description of the type of PHI involved; (c) a description of what Business Associate is doing to investigate, mitigate, and prevent recurrence; (d) contact information for questions.</li>
+        <li><strong>Cooperation:</strong> Business Associate shall cooperate with Covered Entity in meeting Covered Entity's obligations to notify affected individuals and the Secretary of the U.S. Department of Health and Human Services ("HHS").</li>
+        <li><strong>Security incidents:</strong> Business Associate shall report to Covered Entity any Security Incident of which it becomes aware. Reports of unsuccessful Security Incidents (e.g., pings, port scans, failed login attempts) may be provided in summary or aggregate form.</li>
+    </ul>
+
+    <h2 id="subcontractors">5. Subcontractors</h2>
+    <p>Business Associate shall ensure that any subcontractors that create, receive, maintain, or transmit PHI on behalf of Business Associate agree to the same restrictions, conditions, and requirements that apply to Business Associate under this BAA, in accordance with 45 CFR §164.502(e)(1)(ii) and §164.308(b)(2).</p>
+
+    <h2 id="access-records">6. Access to Records</h2>
+    <ul>
+        <li><strong>Individual access:</strong> Business Associate shall make PHI maintained in Designated Record Sets available to Covered Entity as necessary to satisfy Covered Entity's obligations under 45 CFR §164.524. stored.ge's S3-compatible API provides direct access to all stored objects.</li>
+        <li><strong>Amendment:</strong> Business Associate shall make PHI available for amendment and incorporate any amendments to PHI as directed by Covered Entity, pursuant to 45 CFR §164.526.</li>
+        <li><strong>Accounting of disclosures:</strong> Business Associate shall make information available to Covered Entity as required to provide an accounting of disclosures under 45 CFR §164.528.</li>
+        <li><strong>HHS access:</strong> Business Associate shall make its internal practices, books, and records relating to the use and disclosure of PHI available to the Secretary of HHS for purposes of determining Covered Entity's compliance with the HIPAA Rules.</li>
+    </ul>
+
+    <h2 id="return-destruction">7. Return or Destruction of PHI</h2>
+    <p>Upon termination of this BAA or the underlying Terms of Service, Business Associate shall:</p>
+    <ul>
+        <li>Return or destroy all PHI received from Covered Entity, or created or received by Business Associate on behalf of Covered Entity, if feasible.</li>
+        <li>If return or destruction is not feasible, extend the protections of this BAA to the PHI retained and limit further uses and disclosures to those purposes that make return or destruction infeasible.</li>
+        <li>Account deletion follows the process described in our <a href="/legal/terms">Terms of Service</a>: a 30-day grace period followed by permanent data destruction.</li>
+    </ul>
+
+    <h2 id="term-termination">8. Term and Termination</h2>
+    <ul>
+        <li><strong>Term:</strong> This BAA is effective upon execution by both parties and remains in effect for the duration of the underlying Terms of Service, unless terminated earlier as provided herein.</li>
+        <li><strong>Termination for cause:</strong> Either party may terminate this BAA if the other party materially breaches any provision and fails to cure the breach within 30 days of written notice.</li>
+        <li><strong>Effect of termination:</strong> The obligations of Business Associate under Section 7 (Return or Destruction of PHI) shall survive termination.</li>
+        <li><strong>Regulatory changes:</strong> The parties agree to negotiate in good faith any amendments to this BAA necessary to comply with changes to the HIPAA Rules or other applicable law.</li>
+    </ul>
+
+    <h2 id="contact">Contact</h2>
+    <p>For questions about this Business Associate Agreement or to execute a BAA for your organization:</p>
+    <ul>
+        <li><strong>Email:</strong> compliance@stored.ge</li>
+        <li><strong>Entity:</strong> FairForge LLC</li>
+        <li><strong>Jurisdiction:</strong> State of Utah, United States</li>
+    </ul>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

- **BAA legal page** at `/legal/baa` — HIPAA-compliant Business Associate Agreement covering definitions, permitted uses, safeguards (SSE-S3, TLS, 2FA, scoped keys), 72-hour breach notification, PHI return/destruction, and termination
- **Breach PostgreSQL store** (`breach_pg.go`) — full `BreachDatabase` interface implementation against existing migration 014 tables (`breach_records`, `breach_affected_users`, `breach_notifications`), wired into `server.go` replacing the nil placeholder
- **Admin breach API** — `POST/GET/PATCH /api/v1/admin/breach` endpoints behind JWT + admin role check; `requireAdmin` middleware upgraded to fall back to DB role lookup
- **HIPAA checklist** (`.private/HIPAA_CHECKLIST.md`, gitignored) — maps all §164.312 technical safeguards to shipped Vaultaire features with pre-BAA signing checklist

## Test plan

- [x] `TestHandleLegalPage_BAA` — GET /legal/baa returns 200 with BAA content
- [x] `TestBreachPgStore_CreateAndGet` — insert breach, retrieve by ID, verify fields
- [x] `TestBreachPgStore_AddAffectedUsers` — batch insert affected users
- [x] `TestBreachPgStore_ListBreaches` — list with status filter
- [x] `TestBreachPgStore_UpdateStatus` — update breach to mitigated
- [x] `TestBreachPgStore_GetNotFound` — returns ErrNotFound for missing ID
- [x] `TestAdminBreachEndpoint_Create` — POST /api/v1/admin/breach returns 201 for admin
- [x] `TestAdminBreachEndpoint_RequiresAdmin` — non-admin gets 403
- [x] Full test suite passes (`go test ./... -short` — zero failures)
- [x] Lint clean (`golangci-lint run` — zero issues)