### PR TITLE
feat(s3): per-bucket region selection with iDrive multi-region [Phase 5.14.7]

### DIFF
--- a/cmd/vaultaire/main.go
+++ b/cmd/vaultaire/main.go
@@ -231,24 +231,39 @@ func main() {
 		}
 	}
 
-	// 6. Add iDrive if credentials available
+	// 6. Add iDrive if credentials available — register one driver per region
 	if accessKey := os.Getenv("IDRIVE_ACCESS_KEY"); accessKey != "" {
 		secretKey := os.Getenv("IDRIVE_SECRET_KEY")
-		endpoint := os.Getenv("IDRIVE_ENDPOINT")
-		if endpoint == "" {
-			endpoint = "https://e2-us-west-1.idrive.com"
+		defaultEndpoint := os.Getenv("IDRIVE_ENDPOINT")
+		if defaultEndpoint == "" {
+			defaultEndpoint = "https://e2-us-west-1.idrive.com"
 		}
-		region := os.Getenv("IDRIVE_REGION")
-		if region == "" {
-			region = "us-west-1"
+		defaultRegion := os.Getenv("IDRIVE_REGION")
+		if defaultRegion == "" {
+			defaultRegion = "us-west-1"
 		}
-		idriveDriver, err := drivers.NewIDriveDriver(accessKey, secretKey, endpoint, region, logger)
+
+		// Register default driver (backward compat alias).
+		idriveDriver, err := drivers.NewIDriveDriver(accessKey, secretKey, defaultEndpoint, defaultRegion, logger)
 		if err != nil {
 			logger.Warn("failed to add iDrive driver", zap.Error(err))
 		} else {
 			eng.AddDriver("idrive", idriveDriver)
-			logger.Info("iDrive driver added", zap.String("endpoint", endpoint), zap.String("region", region))
+			logger.Info("iDrive driver added", zap.String("endpoint", defaultEndpoint), zap.String("region", defaultRegion))
 		}
+
+		// Register per-region drivers for bucket-level region routing.
+		for region, endpoint := range drivers.IDriveRegions {
+			driverName := "idrive-" + region
+			drv, drvErr := drivers.NewIDriveDriver(accessKey, secretKey, endpoint, region, logger)
+			if drvErr != nil {
+				logger.Warn("failed to add region iDrive driver",
+					zap.String("region", region), zap.Error(drvErr))
+				continue
+			}
+			eng.AddDriver(driverName, drv)
+		}
+		logger.Info("iDrive per-region drivers registered", zap.Int("regions", len(drivers.IDriveRegions)))
 	}
 
 	// 7. Add OneDrive fleet if tenant credentials available

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -8,7 +8,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3.go** — Request parsing, auth, routing to operation handlers
 - **s3_errors.go** — Error codes, messages, and response writing
 - **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine
-- **s3_buckets.go** — CreateBucket, DeleteBucket, ListBuckets
+- **s3_buckets.go** — CreateBucket (with region), DeleteBucket, ListBuckets, GetBucketLocation, HeadBucket
 - **s3_versioning.go** — Bucket versioning enable/suspend
 - **s3_lock.go** — Object Lock, retention, legal hold
 - **s3_mfa_delete.go** — MFA Delete enforcement (`checkMFADelete` helper, `errMFARequired` sentinel)
@@ -209,6 +209,22 @@ Transparent server-side encryption at rest using ML-KEM-768 (post-quantum key en
 **Key files**: `internal/crypto/sse_s3.go` (service), `internal/crypto/CLAUDE.md` (crypto docs)
 
 **Tables**: `tenant_encryption_keys` (keypairs), `buckets.sse_enabled`, `object_head_cache.encryption_algorithm` (migration 037)
+
+## Per-Bucket Region Selection (Phase 5.14.7)
+
+Each bucket has a `region` column (default `us-west-1`). Region is immutable after creation.
+
+**CreateBucket** reads region from (in priority order): `X-Stored-Region` header, `x-amz-bucket-region` header, `<CreateBucketConfiguration><LocationConstraint>` XML body, or defaults to `us-west-1`. Validated against `drivers.IsValidRegion()`. Invalid region returns `InvalidLocationConstraint` (400). Response includes `x-amz-bucket-region` header.
+
+**GetBucketLocation** (`GET /{bucket}?location`): returns `<LocationConstraint>region</LocationConstraint>` XML + `x-amz-bucket-region` header.
+
+**HeadBucket** (`HEAD /{bucket}`): returns 200 + `x-amz-bucket-region` header.
+
+**PUT routing** (s3_engine_adapter.go): `bucketRegionDriver()` looks up bucket region from DB. If non-default and an `idrive-{region}` driver exists, PUT goes directly to that driver, bypassing the engine's normal routing. Backend name stored as `idrive-{region}` in `object_head_cache`.
+
+**GET routing**: `HintBackend()` seeds the engine's `objectBackends` map from `cachedBackendName` so GET routes directly to the correct region driver without a failed failover attempt.
+
+**Table**: `buckets.region` (migration 039). **Error**: `ErrInvalidLocationConstraint` in s3_errors.go.
 
 ## Tenant Context
 

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -110,6 +110,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 		case "GET":
 			if _, ok := req.Query["versioning"]; ok {
 				req.Operation = "GetBucketVersioning"
+			} else if _, ok := req.Query["location"]; ok {
+				req.Operation = "GetBucketLocation"
 			} else if _, ok := req.Query["notification"]; ok {
 				req.Operation = "GetBucketNotification"
 			} else if _, ok := req.Query["object-lock"]; ok {
@@ -461,6 +463,10 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleListParts(cw, r, s3Req.Bucket, s3Req.Object)
 	case "ListMultipartUploads":
 		s.handleListMultipartUploads(cw, r, s3Req.Bucket)
+	case "GetBucketLocation":
+		s.handleGetBucketLocation(cw, r, s3Req)
+	case "HeadBucket":
+		s.handleHeadBucket(cw, r, s3Req)
 	case "GetBucketVersioning":
 		s.handleGetBucketVersioning(cw, r, s3Req)
 	case "PutBucketVersioning":

--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/FairForge/vaultaire/internal/auth"
+	"github.com/FairForge/vaultaire/internal/drivers"
 	"github.com/FairForge/vaultaire/internal/tenant"
 	"github.com/FairForge/vaultaire/internal/usage"
 	"go.uber.org/zap"
@@ -149,6 +151,31 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Parse region: header takes precedence, then XML body, then default.
+	region := r.Header.Get("X-Stored-Region")
+	if region == "" {
+		region = r.Header.Get("x-amz-bucket-region")
+	}
+	if region == "" && r.ContentLength > 0 {
+		body, readErr := io.ReadAll(io.LimitReader(r.Body, 4096))
+		if readErr == nil && len(body) > 0 {
+			var cfg struct {
+				XMLName            xml.Name `xml:"CreateBucketConfiguration"`
+				LocationConstraint string   `xml:"LocationConstraint"`
+			}
+			if xml.Unmarshal(body, &cfg) == nil && cfg.LocationConstraint != "" {
+				region = cfg.LocationConstraint
+			}
+		}
+	}
+	if region == "" {
+		region = "us-west-1"
+	}
+	if !drivers.IsValidRegion(region) {
+		WriteS3Error(w, ErrInvalidLocationConstraint, r.URL.Path, generateRequestID())
+		return
+	}
+
 	// Create container directory
 	dirPath, safe := safeBucketPath("/tmp/vaultaire", tenantID, bucket)
 	if !safe {
@@ -164,10 +191,10 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 	if s.db != nil {
 		sseDefault := s.sseService != nil
 		_, dbErr := s.db.ExecContext(ctx, `
-			INSERT INTO buckets (tenant_id, name, visibility, sse_enabled)
-			VALUES ($1, $2, 'private', $3)
+			INSERT INTO buckets (tenant_id, name, visibility, sse_enabled, region)
+			VALUES ($1, $2, 'private', $3, $4)
 			ON CONFLICT (tenant_id, name) DO NOTHING
-		`, tenantID, bucket, sseDefault)
+		`, tenantID, bucket, sseDefault, region)
 		if dbErr != nil {
 			s.logger.Error("failed to persist bucket",
 				zap.Error(dbErr), zap.String("bucket", bucket))
@@ -176,9 +203,68 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		auth.EnsureTenantSlug(ctx, s.db, tenantID, s.logger)
 	}
 
+	w.Header().Set("x-amz-bucket-region", region)
 	emitEvent(ctx, s.db, s.logger, "bucket.created", tenantID, map[string]interface{}{
 		"bucket": bucket,
+		"region": region,
 	})
+	w.WriteHeader(http.StatusOK)
+}
+
+// LocationConstraintResponse is the S3 GetBucketLocation response.
+type LocationConstraintResponse struct {
+	XMLName  xml.Name `xml:"LocationConstraint"`
+	Location string   `xml:",chardata"`
+}
+
+// handleGetBucketLocation returns the region constraint for a bucket.
+func (s *Server) handleGetBucketLocation(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var region string
+	if s.db != nil {
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT region FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&region)
+		if err != nil {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+			return
+		}
+	} else {
+		region = "us-west-1"
+	}
+
+	resp := LocationConstraintResponse{Location: region}
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("x-amz-bucket-region", region)
+	if err := xml.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("encode location response", zap.Error(err))
+	}
+}
+
+// handleHeadBucket handles S3 HEAD bucket — returns 200 if bucket exists.
+func (s *Server) handleHeadBucket(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db != nil {
+		var region string
+		err := s.db.QueryRowContext(r.Context(),
+			`SELECT region FROM buckets WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket).Scan(&region)
+		if err != nil {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, generateRequestID())
+			return
+		}
+		w.Header().Set("x-amz-bucket-region", region)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/api/s3_buckets_test.go
+++ b/internal/api/s3_buckets_test.go
@@ -220,6 +220,144 @@ func TestCreateBucket_ValidNames(t *testing.T) {
 	}
 }
 
+func TestCreateBucket_WithRegionHeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testS3DB(t)
+	defer func() { _ = db.Close() }()
+	cleanupS3BucketData(t, db)
+	defer cleanupS3BucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ('test-s3-r1', 'Region Co', 'r1@test.com', 'VK-r1', 'SK-r1') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	s := s3ServerWithDB(t, db)
+	defer func() { _ = os.RemoveAll("/tmp/vaultaire/test-s3-r1") }()
+
+	req := httptest.NewRequest("PUT", "/eu-region-bucket", nil)
+	req.Header.Set("X-Stored-Region", "eu-west-1")
+	req = withTenantCtx(req, "test-s3-r1")
+	w := httptest.NewRecorder()
+
+	s.CreateBucket(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "eu-west-1", w.Header().Get("x-amz-bucket-region"))
+
+	var region string
+	err = db.QueryRow(`SELECT region FROM buckets WHERE tenant_id = 'test-s3-r1' AND name = 'eu-region-bucket'`).Scan(&region)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", region)
+}
+
+func TestCreateBucket_InvalidRegion(t *testing.T) {
+	s := &Server{logger: zap.NewNop(), db: nil}
+	defer func() { _ = os.RemoveAll("/tmp/vaultaire/default/bad-region-bucket") }()
+
+	req := httptest.NewRequest("PUT", "/bad-region-bucket", nil)
+	req.Header.Set("X-Stored-Region", "ap-southeast-1")
+	w := httptest.NewRecorder()
+
+	s.CreateBucket(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidLocationConstraint")
+}
+
+func TestCreateBucket_DefaultRegion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testS3DB(t)
+	defer func() { _ = db.Close() }()
+	cleanupS3BucketData(t, db)
+	defer cleanupS3BucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ('test-s3-r2', 'Default Co', 'r2@test.com', 'VK-r2', 'SK-r2') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	s := s3ServerWithDB(t, db)
+	defer func() { _ = os.RemoveAll("/tmp/vaultaire/test-s3-r2") }()
+
+	req := httptest.NewRequest("PUT", "/default-region-bucket", nil)
+	req = withTenantCtx(req, "test-s3-r2")
+	w := httptest.NewRecorder()
+
+	s.CreateBucket(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var region string
+	err = db.QueryRow(`SELECT region FROM buckets WHERE tenant_id = 'test-s3-r2' AND name = 'default-region-bucket'`).Scan(&region)
+	require.NoError(t, err)
+	assert.Equal(t, "us-west-1", region)
+}
+
+func TestCreateBucket_XMLLocationConstraint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testS3DB(t)
+	defer func() { _ = db.Close() }()
+	cleanupS3BucketData(t, db)
+	defer cleanupS3BucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ('test-s3-r3', 'XML Co', 'r3@test.com', 'VK-r3', 'SK-r3') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	s := s3ServerWithDB(t, db)
+	defer func() { _ = os.RemoveAll("/tmp/vaultaire/test-s3-r3") }()
+
+	body := `<CreateBucketConfiguration><LocationConstraint>eu-central-2</LocationConstraint></CreateBucketConfiguration>`
+	req := httptest.NewRequest("PUT", "/xml-region-bucket", strings.NewReader(body))
+	req.Header.Set("Content-Length", "100")
+	req = withTenantCtx(req, "test-s3-r3")
+	w := httptest.NewRecorder()
+
+	s.CreateBucket(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var region string
+	err = db.QueryRow(`SELECT region FROM buckets WHERE tenant_id = 'test-s3-r3' AND name = 'xml-region-bucket'`).Scan(&region)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-central-2", region)
+}
+
+func TestGetBucketLocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testS3DB(t)
+	defer func() { _ = db.Close() }()
+	cleanupS3BucketData(t, db)
+	defer cleanupS3BucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ('test-s3-r4', 'Loc Co', 'r4@test.com', 'VK-r4', 'SK-r4') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, region) VALUES ('test-s3-r4', 'located-bucket', 'eu-south-1') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	s := s3ServerWithDB(t, db)
+
+	req := httptest.NewRequest("GET", "/located-bucket?location", nil)
+	req = withTenantCtx(req, "test-s3-r4")
+	w := httptest.NewRecorder()
+
+	s3Req := &S3Request{Bucket: "located-bucket", Operation: "GetBucketLocation"}
+	s.handleGetBucketLocation(w, req, s3Req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/xml")
+	assert.Equal(t, "eu-south-1", w.Header().Get("x-amz-bucket-region"))
+
+	var resp LocationConstraintResponse
+	err = xml.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-south-1", resp.Location)
+}
+
 func TestListBuckets_NoDB_FallsBackToFilesystem(t *testing.T) {
 	s := &Server{logger: zap.NewNop(), db: nil}
 

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -223,6 +223,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 	}
 
+	// Seed the engine's in-memory routing map so GET goes directly to the
+	// correct backend instead of failing over from primary on restart.
+	if cacheHit && cachedBackendName != "" {
+		if ce, ok := a.engine.(*engine.CoreEngine); ok {
+			ce.HintBackend(container, artifact, cachedBackendName)
+		}
+	}
+
 	if cacheHit {
 		if code := evaluateConditionalGET(r, cachedETag, cachedUpdatedAt); code == http.StatusNotModified {
 			writeNotModified(w, cachedETag, cachedUpdatedAt, "private, no-cache")
@@ -485,7 +493,31 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		putOpts = append(putOpts, engine.WithStorageClass(storageClass))
 	}
 
-	backendName, err := a.engine.Put(r.Context(), container, artifact, hashingBody, putOpts...)
+	// Region-aware routing: if the bucket has a non-default region and
+	// a region-specific driver is registered, route directly to it.
+	var backendName string
+	regionDriver := bucketRegionDriver(r.Context(), a.db, a.engine, t.ID, bucket)
+	if regionDriver != "" {
+		if ce, ok := a.engine.(*engine.CoreEngine); ok {
+			if drv, exists := ce.GetDriver(regionDriver); exists {
+				putErr := drv.Put(r.Context(), container, artifact, hashingBody, putOpts...)
+				if putErr != nil {
+					a.logger.Error("region driver put failed",
+						zap.Error(putErr),
+						zap.String("driver", regionDriver))
+					WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+					return
+				}
+				backendName = regionDriver
+				ce.HintBackend(container, artifact, regionDriver)
+			}
+		}
+	}
+	if backendName == "" {
+		var putErr error
+		backendName, putErr = a.engine.Put(r.Context(), container, artifact, hashingBody, putOpts...)
+		err = putErr
+	}
 	if err != nil {
 		if errors.Is(err, engine.ErrAllBackendsUnavailable) {
 			w.Header().Set("Retry-After", "30")
@@ -705,6 +737,31 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 	emitEvent(r.Context(), a.db, a.logger, "object.deleted", t.ID, map[string]interface{}{
 		"bucket": bucket, "key": object,
 	})
+}
+
+// bucketRegionDriver returns the engine driver name for a bucket's region.
+// Returns "" if the bucket uses the default region or if no region-specific
+// driver is registered (non-iDrive backends).
+func bucketRegionDriver(ctx context.Context, db *sql.DB, eng engine.Engine, tenantID, bucket string) string {
+	if db == nil {
+		return ""
+	}
+	var region string
+	err := db.QueryRowContext(ctx,
+		"SELECT region FROM buckets WHERE tenant_id = $1 AND name = $2",
+		tenantID, bucket).Scan(&region)
+	if err != nil || region == "" || region == "us-west-1" {
+		return ""
+	}
+	driverName := "idrive-" + region
+	ce, ok := eng.(*engine.CoreEngine)
+	if !ok {
+		return ""
+	}
+	if _, exists := ce.GetDriver(driverName); exists {
+		return driverName
+	}
+	return ""
 }
 
 func isBucketSSEEnabled(ctx context.Context, db *sql.DB, tenantID, bucket string) bool {

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -55,6 +55,7 @@ const (
 	ErrQuotaExceeded                     = "QuotaExceeded"
 	ErrServiceUnavailable                = "ServiceUnavailable"
 	ErrInvalidBucketState                = "InvalidBucketState"
+	ErrInvalidLocationConstraint         = "InvalidLocationConstraint"
 )
 
 // Error messages
@@ -93,6 +94,7 @@ var errorMessages = map[string]string{
 	ErrQuotaExceeded:                     "Storage quota exceeded. Upgrade your plan for more storage.",
 	ErrServiceUnavailable:                "All storage backends are temporarily unavailable. Please retry.",
 	ErrInvalidBucketState:                "The request is not valid for the current state of the bucket.",
+	ErrInvalidLocationConstraint:         "The specified location constraint is not valid.",
 }
 
 // HTTP status codes for errors
@@ -131,6 +133,7 @@ var errorStatusCodes = map[string]int{
 	ErrQuotaExceeded:                     http.StatusForbidden,
 	ErrServiceUnavailable:                http.StatusServiceUnavailable,
 	ErrInvalidBucketState:                http.StatusConflict,
+	ErrInvalidLocationConstraint:         http.StatusBadRequest,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -17,7 +17,7 @@ Helper functions are in `context.go`: `formatBytes` (human-readable sizes), `rel
 
 Three handlers:
 - `HandleBuckets(tmpl, db, dataPath, logger)` — lists buckets from `buckets` table LEFT JOIN `object_head_cache` (includes empty buckets with count=0)
-- `HandleCreateBucket(tmpl, db, dataPath, logger)` — validates S3-compatible name, creates directory at `{dataPath}/{name}`, persists to `buckets` table
+- `HandleCreateBucket(tmpl, db, dataPath, logger)` — validates S3-compatible name and region (via `drivers.IsValidRegion`, default `us-west-1`), creates directory at `{dataPath}/{name}`, persists to `buckets` table with region
 - `HandleBucketObjects(tmpl, db, logger)` — lists objects in a bucket with prefix-based "folder" navigation (uses chi URL param `{name}`). Queries bucket visibility and tenant slug; for public-read buckets with a slug, sets `CDNBaseURL` and populates `ObjectRow.CDNURL` and `ObjectRow.PreviewType` fields for inline media previews and CDN copy buttons.
 
 `previewTypeFromContentType(ct)` maps content types to preview categories: `image/*` → "image", `video/*` → "video", `audio/*` → "audio", `text/*`/json/xml/js → "text", everything else → "".
@@ -29,8 +29,8 @@ Shared helpers in `context.go`: `sessionData(sd, page)` builds the base template
 ## Bucket Settings (`bucket_settings.go`)
 
 Two handlers:
-- `HandleBucketSettings(tmpl, db, logger)` — GET renders bucket settings page: visibility toggle (private/public-read), CDN URL card with tabbed code examples, cache TTL, CORS origins. Checks `CanEnablePublicRead(tier)` for archive-tier restriction.
-- `HandleUpdateBucketSettings(tmpl, db, logger)` — POST updates visibility, CORS origins, and cache_max_age_secs in `buckets` table. Validates visibility enum, clamps cache to 0–86400, enforces archive-tier restriction via `auth.CanEnablePublicRead()`. Uses flash messages for feedback.
+- `HandleBucketSettings(tmpl, db, logger)` — GET renders bucket settings page: visibility toggle (private/public-read), CDN URL card with tabbed code examples, cache TTL, CORS origins, **region** (read-only card showing region + display name + EU badge). Checks `CanEnablePublicRead(tier)` for archive-tier restriction. Region data: `Region`, `RegionDisplay`, `IsEURegion`.
+- `HandleUpdateBucketSettings(tmpl, db, logger)` — POST updates visibility, CORS origins, and cache_max_age_secs in `buckets` table. Validates visibility enum, clamps cache to 0–86400, enforces archive-tier restriction via `auth.CanEnablePublicRead()`. Uses flash messages for feedback. Region is NOT updatable.
 
 Template: `templates/customer/bucket_settings.html`. Routes: `GET/POST /dashboard/buckets/{name}/settings`.
 

--- a/internal/dashboard/handlers/bucket_settings.go
+++ b/internal/dashboard/handlers/bucket_settings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/FairForge/vaultaire/internal/auth"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
 	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"github.com/FairForge/vaultaire/internal/drivers"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 )
@@ -40,12 +41,13 @@ func HandleBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logge
 		corsOrigins := "*"
 		cacheMaxAge := 3600
 		slug := ""
+		region := "us-west-1"
 
 		if db != nil {
 			_ = db.QueryRowContext(r.Context(),
-				`SELECT visibility, cors_origins, cache_max_age_secs
+				`SELECT visibility, cors_origins, cache_max_age_secs, region
 				 FROM buckets WHERE tenant_id = $1 AND name = $2`,
-				sd.TenantID, bucketName).Scan(&vis, &corsOrigins, &cacheMaxAge)
+				sd.TenantID, bucketName).Scan(&vis, &corsOrigins, &cacheMaxAge, &region)
 
 			_ = db.QueryRowContext(r.Context(),
 				`SELECT COALESCE(slug, '') FROM tenants WHERE id = $1`,
@@ -67,6 +69,9 @@ func HandleBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logge
 		data["CORSOrigins"] = corsOrigins
 		data["CacheMaxAge"] = cacheMaxAge
 		data["Slug"] = slug
+		data["Region"] = region
+		data["RegionDisplay"] = drivers.RegionDisplayName(region)
+		data["IsEURegion"] = drivers.IsEURegion(region)
 
 		if vis == "public-read" && slug != "" {
 			data["CDNBaseURL"] = cdnBaseHost + slug + "/" + bucketName

--- a/internal/dashboard/handlers/buckets.go
+++ b/internal/dashboard/handlers/buckets.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/drivers"
 	"github.com/FairForge/vaultaire/internal/usage"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
@@ -126,6 +127,17 @@ func HandleCreateBucket(tmpl *template.Template, db *sql.DB, dataPath string, lo
 			}
 		}
 
+		// Validate region selection.
+		region := strings.TrimSpace(r.FormValue("region"))
+		if region == "" {
+			region = "us-west-1"
+		}
+		if !drivers.IsValidRegion(region) {
+			data["CreateError"] = "Invalid region."
+			renderBucketList(w, tmpl, db, sd, data, logger)
+			return
+		}
+
 		// Create the directory under the data path.
 		if dataPath != "" {
 			dirPath := filepath.Join(dataPath, name)
@@ -145,10 +157,10 @@ func HandleCreateBucket(tmpl *template.Template, db *sql.DB, dataPath string, lo
 
 		if db != nil {
 			_, dbErr := db.ExecContext(r.Context(), `
-				INSERT INTO buckets (tenant_id, name, visibility)
-				VALUES ($1, $2, 'private')
+				INSERT INTO buckets (tenant_id, name, visibility, region)
+				VALUES ($1, $2, 'private', $3)
 				ON CONFLICT (tenant_id, name) DO NOTHING
-			`, sd.TenantID, name)
+			`, sd.TenantID, name, region)
 			if dbErr != nil {
 				logger.Error("persist bucket to DB", zap.Error(dbErr))
 			}

--- a/internal/dashboard/handlers/buckets_test.go
+++ b/internal/dashboard/handlers/buckets_test.go
@@ -415,6 +415,53 @@ func TestDashboardJS_Exists(t *testing.T) {
 	assert.Contains(t, string(data), "btn-copy")
 }
 
+func TestHandleCreateBucket_WithRegion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ('test-dash-r1', 'Region Co', 'r1@test.com', 'VK-dr1', 'SK-dr1') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	tmpl := testBucketsTemplate(t)
+	handler := HandleCreateBucket(tmpl, db, tmpDir, zap.NewNop())
+
+	form := url.Values{"name": {"eu-dash-bucket"}, "region": {"eu-west-1"}}
+	req := injectSessionWithTenant(httptest.NewRequest("POST", "/dashboard/buckets",
+		strings.NewReader(form.Encode())), "test-dash-r1")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "eu-dash-bucket")
+
+	var region string
+	err = db.QueryRow(`SELECT region FROM buckets WHERE tenant_id = 'test-dash-r1' AND name = 'eu-dash-bucket'`).Scan(&region)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", region)
+}
+
+func TestHandleCreateBucket_InvalidRegion(t *testing.T) {
+	tmpl := testBucketsTemplate(t)
+	handler := HandleCreateBucket(tmpl, nil, t.TempDir(), zap.NewNop())
+
+	form := url.Values{"name": {"bad-region-bucket"}, "region": {"ap-southeast-1"}}
+	req := injectSession(httptest.NewRequest("POST", "/dashboard/buckets",
+		strings.NewReader(form.Encode())))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid region")
+}
+
 func TestListBuckets_Dashboard_IncludesEmptyBuckets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires database")

--- a/internal/dashboard/templates/customer/bucket_settings.html
+++ b/internal/dashboard/templates/customer/bucket_settings.html
@@ -17,6 +17,18 @@
 {{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
 {{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
 
+<div class="card">
+    <div class="card-title">Region</div>
+    <div style="display:flex;align-items:center;gap:0.5rem;">
+        <strong>{{.RegionDisplay}}</strong>
+        <span class="badge badge-default">{{.Region}}</span>
+        {{if .IsEURegion}}<span class="badge badge-success">EU Data Residency</span>{{end}}
+    </div>
+    <p class="text-muted" style="font-size: 0.8rem; margin-top: 0.5rem;">
+        Region is set at bucket creation and cannot be changed. All objects in this bucket are stored in this region.
+    </p>
+</div>
+
 <form method="POST" action="/dashboard/buckets/{{.BucketName}}/settings">
     <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 

--- a/internal/dashboard/templates/customer/buckets.html
+++ b/internal/dashboard/templates/customer/buckets.html
@@ -19,8 +19,28 @@
                 <input type="text" name="name" pattern="[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]" required
                        placeholder="my-bucket" title="Lowercase letters, numbers, hyphens, and dots. 3-63 characters.">
             </div>
+            <div class="form-group form-group-inline">
+                <label>Region</label>
+                <select name="region">
+                    <optgroup label="United States">
+                        <option value="us-west-1" selected>US West (San Jose)</option>
+                        <option value="us-west-2">US West (Dallas)</option>
+                        <option value="us-central-1">US Central (Chicago)</option>
+                        <option value="us-east-1">US East (Virginia)</option>
+                    </optgroup>
+                    <optgroup label="European Union">
+                        <option value="eu-west-1">EU West (Ireland)</option>
+                        <option value="eu-central-2">EU Central (Frankfurt)</option>
+                        <option value="eu-west-2">EU West (London)</option>
+                        <option value="eu-south-1">EU South (Milan)</option>
+                    </optgroup>
+                </select>
+            </div>
             <button type="submit" class="btn btn-primary">Create</button>
         </div>
+        <p class="text-muted" style="font-size: 0.8rem; margin-top: 0.25rem;">
+            Region cannot be changed after creation. EU regions ensure GDPR data residency.
+        </p>
         {{if .CreateError}}<div class="alert alert-error">{{.CreateError}}</div>{{end}}
         {{if .CreateSuccess}}<div class="alert alert-success">Bucket "{{.CreateSuccess}}" created.</div>{{end}}
     </form>

--- a/internal/database/migrations/039_bucket_region.sql
+++ b/internal/database/migrations/039_bucket_region.sql
@@ -1,0 +1,2 @@
+-- 039_bucket_region.sql: Per-bucket region selection for data residency.
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS region TEXT NOT NULL DEFAULT 'us-west-1';

--- a/internal/drivers/CLAUDE.md
+++ b/internal/drivers/CLAUDE.md
@@ -33,6 +33,12 @@ type Driver interface {
 | `IDriveDriver` | `idrive.go` | `NewIDriveDriver(accessKey, secretKey, endpoint, region, logger)` | iDrive E2 | Fixed-bucket + key-prefix pattern (like Geyser); `IDRIVE_BUCKET` env var (default `vaultaire`); materialize for Content-Length; ContentLength passthrough skips materialize when size known; `EgressTracker` field (not wired) |
 | `OneDriveDriver` | `onedrive.go` | `NewOneDriveFleetDriver(logger)` | Microsoft OneDrive (Graph API) | Multi-tenant fleet (TENANT_N_* env vars, N=1..15); raw HTTP + azidentity (no Graph SDK); dual transport (HTTP/2 API, HTTP/1.1 CDN); 60MB chunked uploads; streaming uploads (ContentLength passthrough); parallel byte-range downloads (adaptive 1/2/4/8 streams); fleet-wide TLS cache + DNS cache; token refresh mutex; RateLimit header tracking; pooled 1MB drain buffers |
 
+### iDrive Region Registry (Phase 5.14.7)
+
+`idrive_regions.go` — static map of iDrive e2 region identifiers to S3-compatible endpoints. Used by `cmd/vaultaire/main.go` to register one `IDriveDriver` per region (`idrive-{region}`), enabling per-bucket data residency.
+
+Helpers: `IsValidRegion(region)`, `IsEURegion(region)` (true for `eu-*`), `RegionDisplayName(region)`. Called from S3 API (`CreateBucket` validation), dashboard (`HandleCreateBucket`, `HandleBucketSettings`), and engine adapter (`bucketRegionDriver` routing).
+
 ### Not wired in main.go (scaffolds / future)
 
 | Driver | File | Constructor | Backend | Status |

--- a/internal/drivers/idrive_regions.go
+++ b/internal/drivers/idrive_regions.go
@@ -1,0 +1,43 @@
+package drivers
+
+// IDriveRegions maps iDrive e2 region identifiers to their S3-compatible endpoints.
+var IDriveRegions = map[string]string{
+	"us-west-1":    "https://e2-us-west-1.idrive.com",
+	"us-west-2":    "https://e2-us-west-2.idrive.com",
+	"us-central-1": "https://e2-us-central-1.idrive.com",
+	"us-east-1":    "https://e2-us-east-1.idrive.com",
+	"eu-west-1":    "https://e2-eu-west-1.idrive.com",
+	"eu-central-2": "https://e2-eu-central-2.idrive.com",
+	"eu-west-2":    "https://e2-eu-west-2.idrive.com",
+	"eu-south-1":   "https://e2-eu-south-1.idrive.com",
+}
+
+var regionDisplayNames = map[string]string{
+	"us-west-1":    "US West (San Jose)",
+	"us-west-2":    "US West (Dallas)",
+	"us-central-1": "US Central (Chicago)",
+	"us-east-1":    "US East (Virginia)",
+	"eu-west-1":    "EU West (Ireland)",
+	"eu-central-2": "EU Central (Frankfurt)",
+	"eu-west-2":    "EU West (London)",
+	"eu-south-1":   "EU South (Milan)",
+}
+
+func IsValidRegion(region string) bool {
+	_, ok := IDriveRegions[region]
+	return ok
+}
+
+func IsEURegion(region string) bool {
+	if len(region) < 3 {
+		return false
+	}
+	return region[:3] == "eu-"
+}
+
+func RegionDisplayName(region string) string {
+	if name, ok := regionDisplayNames[region]; ok {
+		return name
+	}
+	return region
+}

--- a/internal/drivers/idrive_regions_test.go
+++ b/internal/drivers/idrive_regions_test.go
@@ -1,0 +1,45 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidRegion(t *testing.T) {
+	valid := []string{"us-west-1", "us-east-1", "eu-west-1", "eu-central-2", "eu-south-1"}
+	for _, r := range valid {
+		assert.True(t, IsValidRegion(r), "expected %q to be valid", r)
+	}
+
+	invalid := []string{"", "us-north-1", "ap-southeast-1", "eu", "US-WEST-1"}
+	for _, r := range invalid {
+		assert.False(t, IsValidRegion(r), "expected %q to be invalid", r)
+	}
+}
+
+func TestIsEURegion(t *testing.T) {
+	eu := []string{"eu-west-1", "eu-central-2", "eu-west-2", "eu-south-1"}
+	for _, r := range eu {
+		assert.True(t, IsEURegion(r), "expected %q to be EU", r)
+	}
+
+	notEU := []string{"us-west-1", "us-east-1", "us-central-1", "", "e"}
+	for _, r := range notEU {
+		assert.False(t, IsEURegion(r), "expected %q to not be EU", r)
+	}
+}
+
+func TestRegionDisplayName(t *testing.T) {
+	assert.Equal(t, "US West (San Jose)", RegionDisplayName("us-west-1"))
+	assert.Equal(t, "EU Central (Frankfurt)", RegionDisplayName("eu-central-2"))
+	assert.Equal(t, "unknown-region", RegionDisplayName("unknown-region"))
+}
+
+func TestIDriveRegions_AllHaveEndpoints(t *testing.T) {
+	for region, endpoint := range IDriveRegions {
+		assert.NotEmpty(t, endpoint, "region %q has empty endpoint", region)
+		assert.Contains(t, endpoint, "idrive.com", "region %q endpoint should be idrive.com", region)
+	}
+	assert.True(t, len(IDriveRegions) >= 8, "expected at least 8 regions")
+}

--- a/internal/engine/CLAUDE.md
+++ b/internal/engine/CLAUDE.md
@@ -40,6 +40,12 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 | `failover.go` | `FailoverManager`, `BackendCircuitBreaker` | Per-backend circuit breaker (5 failures/60s → open, 30s → half-open → probe) + ordered failover execution |
 | `storage_class.go` | `ResolveStorageClass`, `BackendToStorageClass` | S3 storage class ↔ backend name mapping (STANDARD→idrive, GLACIER→geyser, etc.) |
 
+## Per-Bucket Region Routing (Phase 5.14.7)
+
+`GetDriver(name string) (Driver, bool)` — returns a named driver from the registry. Used by the S3 adapter to route PUT operations directly to a region-specific iDrive driver (e.g., `idrive-eu-west-1`) when a bucket has a non-default region.
+
+`HintBackend(container, artifact, backend string)` — seeds `objectBackends` so GET routes to the correct backend without a failed failover attempt. The S3 adapter calls this with `backend_name` from `object_head_cache` on every GET to ensure correct routing after restart.
+
 ## Circuit Breaker (Phase 5.12.4)
 
 Each registered backend gets an independent `BackendCircuitBreaker`:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -616,6 +616,23 @@ func (e *CoreEngine) buildCandidateList(preferred string) []string {
 	return candidates
 }
 
+// GetDriver returns a named driver if it is registered.
+func (e *CoreEngine) GetDriver(name string) (Driver, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	d, ok := e.drivers[name]
+	return d, ok
+}
+
+// HintBackend seeds the objectBackends map so Get routes to the correct
+// backend without a failed attempt against the primary. The S3 adapter
+// calls this with the backend_name read from object_head_cache on GET.
+func (e *CoreEngine) HintBackend(container, artifact, backend string) {
+	if backend != "" {
+		e.objectBackends.Store(objectKey(container, artifact), backend)
+	}
+}
+
 // GetFailoverStatus returns circuit breaker states for all backends.
 func (e *CoreEngine) GetFailoverStatus() map[string]string {
 	return e.failover.GetAllStatuses()

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,7 +1,9 @@
 package engine
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"testing"
 
 	"go.uber.org/zap"
@@ -23,5 +25,82 @@ func TestCoreEngine_ImplementsInterface(t *testing.T) {
 	err := engine.HealthCheck(context.Background())
 	if err != nil {
 		t.Errorf("HealthCheck failed: %v", err)
+	}
+}
+
+type stubDriver struct {
+	name    string
+	data    map[string][]byte
+	healthy bool
+}
+
+func (d *stubDriver) Name() string { return d.name }
+func (d *stubDriver) Get(ctx context.Context, container, artifact string) (io.ReadCloser, error) {
+	key := container + "/" + artifact
+	if b, ok := d.data[key]; ok {
+		return io.NopCloser(bytes.NewReader(b)), nil
+	}
+	return nil, &NotFoundError{Container: container, Artifact: artifact}
+}
+func (d *stubDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...PutOption) error {
+	key := container + "/" + artifact
+	b, _ := io.ReadAll(data)
+	d.data[key] = b
+	return nil
+}
+func (d *stubDriver) Delete(ctx context.Context, container, artifact string) error { return nil }
+func (d *stubDriver) List(ctx context.Context, container, prefix string) ([]string, error) {
+	return nil, nil
+}
+func (d *stubDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return false, nil
+}
+func (d *stubDriver) HealthCheck(ctx context.Context) error {
+	if !d.healthy {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func TestGetDriver(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, nil)
+
+	drv := &stubDriver{name: "test-driver", data: make(map[string][]byte), healthy: true}
+	eng.AddDriver("idrive-eu-west-1", drv)
+
+	got, ok := eng.GetDriver("idrive-eu-west-1")
+	if !ok {
+		t.Fatal("GetDriver should find registered driver")
+	}
+	if got.Name() != "test-driver" {
+		t.Errorf("expected Name() = %q, got %q", "test-driver", got.Name())
+	}
+
+	_, ok = eng.GetDriver("nonexistent")
+	if ok {
+		t.Error("GetDriver should return false for unregistered driver")
+	}
+}
+
+func TestHintBackend(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, nil)
+
+	drv := &stubDriver{name: "region-drv", data: make(map[string][]byte), healthy: true}
+	drv.data["bucket/key"] = []byte("hello")
+	eng.AddDriver("idrive-eu-west-1", drv)
+
+	eng.HintBackend("bucket", "key", "idrive-eu-west-1")
+
+	reader, err := eng.Get(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Get after HintBackend failed: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	b, _ := io.ReadAll(reader)
+	if string(b) != "hello" {
+		t.Errorf("expected %q, got %q", "hello", string(b))
 	}
 }


### PR DESCRIPTION
## Summary

- Adds per-bucket region selection for GDPR data residency compliance
- 8 iDrive e2 regions (4 US, 4 EU) with automatic multi-region driver registration
- Region is set at bucket creation via S3 API header, XML body, or dashboard dropdown; immutable after creation
- PUT operations route directly to region-specific iDrive driver; GET uses backend hint for correct routing after restart

## Changes

**Migration**: `039_bucket_region.sql` — `ALTER TABLE buckets ADD COLUMN region TEXT NOT NULL DEFAULT 'us-west-1'`

**New file**: `internal/drivers/idrive_regions.go` — region registry with `IsValidRegion`, `IsEURegion`, `RegionDisplayName` helpers

**S3 API** (`s3_buckets.go`, `s3.go`, `s3_errors.go`):
- `CreateBucket`: parses region from `X-Stored-Region` header, `x-amz-bucket-region` header, or `<CreateBucketConfiguration>` XML body
- `GetBucketLocation` (`GET /{bucket}?location`): returns region as XML
- `HeadBucket` (`HEAD /{bucket}`): returns `x-amz-bucket-region` header
- New error: `InvalidLocationConstraint` (400)

**Engine** (`engine.go`):
- `GetDriver(name)`: returns a named driver for direct region-specific routing
- `HintBackend(container, artifact, backend)`: seeds in-memory routing map from DB on GET

**Engine adapter** (`s3_engine_adapter.go`):
- `bucketRegionDriver()`: resolves bucket region to `idrive-{region}` driver name
- PUT routes directly to region driver when available
- GET seeds backend hint from `object_head_cache.backend_name`

**main.go**: registers one iDrive driver per region when `IDRIVE_ACCESS_KEY` is set

**Dashboard**:
- Region dropdown on bucket creation form (8 options, grouped US/EU)
- Read-only region card on bucket settings page with EU data residency badge

## Test plan

- [x] `TestIsValidRegion` — valid and invalid region strings
- [x] `TestIsEURegion` — eu-* returns true, us-* returns false
- [x] `TestRegionDisplayName` — display name lookup
- [x] `TestIDriveRegions_AllHaveEndpoints` — all 8 regions have valid endpoints
- [x] `TestCreateBucket_WithRegionHeader` — X-Stored-Region header persisted to DB
- [x] `TestCreateBucket_InvalidRegion` — returns InvalidLocationConstraint
- [x] `TestCreateBucket_DefaultRegion` — no header defaults to us-west-1
- [x] `TestCreateBucket_XMLLocationConstraint` — XML body region parsed
- [x] `TestGetBucketLocation` — returns correct region XML
- [x] `TestGetDriver` / `TestHintBackend` — engine routing methods
- [x] `TestHandleCreateBucket_WithRegion` / `InvalidRegion` — dashboard region form
- [x] Full test suite: `go test -short -race ./...` passes
- [x] Lint: `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)