### PR TITLE
feat(crypto): SSE-C customer-provided encryption keys [Phase 5.14.8]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -210,6 +210,39 @@ Transparent server-side encryption at rest using ML-KEM-768 (post-quantum key en
 
 **Tables**: `tenant_encryption_keys` (keypairs), `buckets.sse_enabled`, `object_head_cache.encryption_algorithm` (migration 037)
 
+## SSE-C Customer-Provided Encryption (Phase 5.14.8)
+
+Server-side encryption with customer-provided 256-bit AES keys. Stateless — key is never stored or logged.
+
+**S3 headers** (required on PUT, GET, HEAD for SSE-C objects):
+- `x-amz-server-side-encryption-customer-algorithm: AES256`
+- `x-amz-server-side-encryption-customer-key: <base64-encoded 32-byte key>`
+- `x-amz-server-side-encryption-customer-key-MD5: <base64-encoded MD5 of raw key>`
+
+**PUT flow** (s3_engine_adapter.go HandlePut):
+1. `HasSSECHeaders(r)` check runs BEFORE SSE-S3 check (mutually exclusive)
+2. `ParseSSECHeaders(r)` validates algorithm, decodes key, verifies MD5
+3. ReadAll plaintext through TeeReader (ETag on plaintext)
+4. `SSECEncrypt(key, plaintext)` → AES-256-GCM ciphertext (28B overhead)
+5. Key zeroed immediately after encryption
+6. `encryption_algorithm = "AES256-SSE-C"` stored in object_head_cache
+
+**GET flow** (s3_engine_adapter.go HandleGet):
+1. If `encryption_algorithm == "AES256-SSE-C"` and no SSE-C headers → 403
+2. Parse headers, decrypt with `SSECDecrypt`, key zeroed after
+3. Wrong key → 403 with "does not match" message
+4. Response header: `x-amz-server-side-encryption-customer-algorithm: AES256`
+
+**HEAD flow** (s3.go handleHeadObject):
+- If `encryption_algorithm == "AES256-SSE-C"` and no SSE-C headers → 403
+- With headers → 200 + `x-amz-server-side-encryption-customer-algorithm: AES256`
+
+**Multipart**: SSE-C headers on InitiateMultipartUpload → 501 NotImplemented
+
+**CopyObject**: SSE-C not handled — deferred to future phase
+
+**Key files**: `internal/crypto/ssec.go` (encrypt/decrypt/header parsing), `internal/crypto/CLAUDE.md`
+
 ## Per-Bucket Region Selection (Phase 5.14.7)
 
 Each bucket has a `region` column (default `us-west-1`). Region is immutable after creation.

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/FairForge/vaultaire/internal/auth"
 	"github.com/FairForge/vaultaire/internal/common"
+	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/events"
 	"github.com/FairForge/vaultaire/internal/tenant"
@@ -577,7 +578,14 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	}
 	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(backendName))
 	w.Header().Set("x-amz-request-id", generateRequestID())
-	if encAlgo != "" {
+	if encAlgo == crypto.SSECAlgorithm {
+		if !crypto.HasSSECHeaders(r) {
+			WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+				WithSuggestion("This object was encrypted with SSE-C. Provide the encryption key to access metadata."))
+			return
+		}
+		w.Header().Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	} else if encAlgo != "" {
 		w.Header().Set("x-amz-server-side-encryption", "AES256")
 	}
 	setS3MetadataHeaders(w, metadataJSON)

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -271,7 +271,42 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	defer func() { _ = reader.Close() }()
 
 	var dataReader io.Reader = reader
-	if a.sseService != nil && cachedEncAlgo != "" {
+	if cachedEncAlgo == crypto.SSECAlgorithm {
+		if !crypto.HasSSECHeaders(r) {
+			WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+				WithSuggestion("This object was encrypted with SSE-C. Provide the encryption key."))
+			return
+		}
+		ssecKey, parseErr := crypto.ParseSSECHeaders(r)
+		if parseErr != nil {
+			WriteS3ErrorWithContext(w, ErrInvalidRequest, r.URL.Path, generateRequestID(),
+				WithSuggestion(parseErr.Error()))
+			return
+		}
+
+		encBytes, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			a.logger.Error("failed to read SSE-C encrypted object", zap.Error(readErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		plaintext, decErr := crypto.SSECDecrypt(ssecKey, encBytes)
+		for i := range ssecKey {
+			ssecKey[i] = 0
+		}
+		if decErr != nil {
+			if errors.Is(decErr, crypto.ErrSSECKeyMismatch) {
+				WriteS3ErrorWithContext(w, ErrAccessDenied, r.URL.Path, generateRequestID(),
+					WithSuggestion("The provided encryption key does not match."))
+				return
+			}
+			a.logger.Error("SSE-C decryption failed", zap.Error(decErr))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		dataReader = bytes.NewReader(plaintext)
+		w.Header().Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	} else if cachedEncAlgo != "" && a.sseService != nil {
 		encBytes, readErr := io.ReadAll(reader)
 		if readErr != nil {
 			a.logger.Error("failed to read encrypted object", zap.Error(readErr))
@@ -285,9 +320,6 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 			return
 		}
 		dataReader = bytes.NewReader(plaintext)
-	}
-
-	if cachedEncAlgo != "" {
 		w.Header().Set("x-amz-server-side-encryption", "AES256")
 	}
 
@@ -457,34 +489,76 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 
 	metadataSize := size
 	var encryptionAlgorithm string
-	shouldEncrypt := a.sseService != nil && size > 0 && size <= crypto.MaxEncryptableSize &&
-		(r.Header.Get("x-amz-server-side-encryption") == "AES256" ||
-			isBucketSSEEnabled(r.Context(), a.db, t.ID, bucket))
 
-	if shouldEncrypt {
-		if err := a.sseService.EnsureTenantKey(r.Context(), t.ID); err != nil {
-			a.logger.Error("failed to ensure tenant encryption key", zap.Error(err))
-			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+	if crypto.HasSSECHeaders(r) {
+		if r.Header.Get("x-amz-server-side-encryption") != "" {
+			WriteS3ErrorWithContext(w, ErrInvalidRequest, r.URL.Path, generateRequestID(),
+				WithSuggestion("Cannot use SSE-S3 and SSE-C simultaneously."))
+			return
+		}
+		if size <= 0 || size > crypto.MaxEncryptableSize {
+			WriteS3Error(w, ErrEntityTooLarge, r.URL.Path, generateRequestID())
+			return
+		}
+
+		ssecKey, parseErr := crypto.ParseSSECHeaders(r)
+		if parseErr != nil {
+			WriteS3ErrorWithContext(w, ErrInvalidRequest, r.URL.Path, generateRequestID(),
+				WithSuggestion(parseErr.Error()))
 			return
 		}
 
 		plaintext, readErr := io.ReadAll(hashingBody)
 		if readErr != nil {
-			a.logger.Error("failed to read plaintext for encryption", zap.Error(readErr))
+			a.logger.Error("failed to read plaintext for SSE-C encryption", zap.Error(readErr))
 			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 			return
 		}
 
-		ciphertext, encErr := a.sseService.EncryptBytes(r.Context(), t.ID, plaintext)
+		ciphertext, encErr := crypto.SSECEncrypt(ssecKey, plaintext)
 		if encErr != nil {
-			a.logger.Error("SSE-S3 encryption failed", zap.Error(encErr))
+			a.logger.Error("SSE-C encryption failed", zap.Error(encErr))
 			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 			return
+		}
+
+		for i := range ssecKey {
+			ssecKey[i] = 0
 		}
 
 		hashingBody = bytes.NewReader(ciphertext)
 		size = int64(len(ciphertext))
-		encryptionAlgorithm = crypto.SSEAlgorithm
+		encryptionAlgorithm = crypto.SSECAlgorithm
+	} else {
+		shouldEncrypt := a.sseService != nil && size > 0 && size <= crypto.MaxEncryptableSize &&
+			(r.Header.Get("x-amz-server-side-encryption") == "AES256" ||
+				isBucketSSEEnabled(r.Context(), a.db, t.ID, bucket))
+
+		if shouldEncrypt {
+			if err := a.sseService.EnsureTenantKey(r.Context(), t.ID); err != nil {
+				a.logger.Error("failed to ensure tenant encryption key", zap.Error(err))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
+			}
+
+			plaintext, readErr := io.ReadAll(hashingBody)
+			if readErr != nil {
+				a.logger.Error("failed to read plaintext for encryption", zap.Error(readErr))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
+			}
+
+			ciphertext, encErr := a.sseService.EncryptBytes(r.Context(), t.ID, plaintext)
+			if encErr != nil {
+				a.logger.Error("SSE-S3 encryption failed", zap.Error(encErr))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
+			}
+
+			hashingBody = bytes.NewReader(ciphertext)
+			size = int64(len(ciphertext))
+			encryptionAlgorithm = crypto.SSEAlgorithm
+		}
 	}
 
 	storageClass := r.Header.Get("x-amz-storage-class")
@@ -598,7 +672,9 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
 	w.Header().Set("x-amz-request-id", generateRequestID())
-	if encryptionAlgorithm != "" {
+	if encryptionAlgorithm == crypto.SSECAlgorithm {
+		w.Header().Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	} else if encryptionAlgorithm != "" {
 		w.Header().Set("x-amz-server-side-encryption", "AES256")
 	}
 	if versionID != "" {

--- a/internal/api/s3_engine_adapter_test.go
+++ b/internal/api/s3_engine_adapter_test.go
@@ -3,7 +3,10 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/md5" // #nosec G401 — S3 spec requires MD5
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +14,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/drivers"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/tenant"
@@ -239,4 +243,206 @@ func TestHandleGet_ContentLengthSetFromCache(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "23", w.Header().Get("Content-Length"))
+}
+
+func generateSSECKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return key
+}
+
+func setSSECHeaders(t *testing.T, req *http.Request, key []byte) {
+	t.Helper()
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	req.Header.Set("x-amz-server-side-encryption-customer-key", base64.StdEncoding.EncodeToString(key))
+	digest := md5.Sum(key) // #nosec G401
+	req.Header.Set("x-amz-server-side-encryption-customer-key-MD5", base64.StdEncoding.EncodeToString(digest[:]))
+}
+
+func TestPutObject_SSEC_Encrypts(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+	content := []byte("SSE-C encrypted content for testing")
+
+	req := httptest.NewRequest("PUT", "/test-bucket/ssec-obj.txt", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	req.Header.Set("Content-Type", "text/plain")
+	setSSECHeaders(t, req, key)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "ssec-obj.txt")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "AES256", w.Header().Get("x-amz-server-side-encryption-customer-algorithm"))
+	assert.Empty(t, w.Header().Get("x-amz-server-side-encryption"))
+
+	var encAlgo string
+	err := f.db.QueryRow(`
+		SELECT COALESCE(encryption_algorithm, '')
+		FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "ssec-obj.txt").Scan(&encAlgo)
+	require.NoError(t, err)
+	assert.Equal(t, crypto.SSECAlgorithm, encAlgo)
+
+	var storedSize int64
+	err = f.db.QueryRow(`
+		SELECT size_bytes FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "ssec-obj.txt").Scan(&storedSize)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), storedSize, "cache stores plaintext size")
+}
+
+func TestGetObject_SSEC_RequiresKey(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+	content := []byte("requires key to read")
+
+	putReq := httptest.NewRequest("PUT", "/test-bucket/ssec-need-key.txt", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	setSSECHeaders(t, putReq, key)
+	ctx := tenant.WithTenant(putReq.Context(), f.tenant)
+	putReq = putReq.WithContext(ctx)
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "ssec-need-key.txt")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/ssec-need-key.txt", nil)
+	ctx = tenant.WithTenant(getReq.Context(), f.tenant)
+	getReq = getReq.WithContext(ctx)
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "ssec-need-key.txt")
+
+	assert.Equal(t, http.StatusForbidden, gw.Code)
+	assert.Contains(t, gw.Body.String(), "SSE-C")
+}
+
+func TestGetObject_SSEC_WrongKey(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+	wrongKey := generateSSECKey(t)
+	content := []byte("wrong key test data")
+
+	putReq := httptest.NewRequest("PUT", "/test-bucket/ssec-wrong.txt", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	setSSECHeaders(t, putReq, key)
+	ctx := tenant.WithTenant(putReq.Context(), f.tenant)
+	putReq = putReq.WithContext(ctx)
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "ssec-wrong.txt")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/ssec-wrong.txt", nil)
+	setSSECHeaders(t, getReq, wrongKey)
+	ctx = tenant.WithTenant(getReq.Context(), f.tenant)
+	getReq = getReq.WithContext(ctx)
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "ssec-wrong.txt")
+
+	assert.Equal(t, http.StatusForbidden, gw.Code)
+	assert.Contains(t, gw.Body.String(), "does not match")
+}
+
+func TestGetObject_SSEC_CorrectKey(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+	content := []byte("round-trip SSE-C data — should come back identical")
+
+	putReq := httptest.NewRequest("PUT", "/test-bucket/ssec-roundtrip.txt", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	putReq.Header.Set("Content-Type", "text/plain")
+	setSSECHeaders(t, putReq, key)
+	ctx := tenant.WithTenant(putReq.Context(), f.tenant)
+	putReq = putReq.WithContext(ctx)
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "ssec-roundtrip.txt")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/ssec-roundtrip.txt", nil)
+	setSSECHeaders(t, getReq, key)
+	ctx = tenant.WithTenant(getReq.Context(), f.tenant)
+	getReq = getReq.WithContext(ctx)
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "ssec-roundtrip.txt")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content, body)
+	assert.Equal(t, "AES256", gw.Header().Get("x-amz-server-side-encryption-customer-algorithm"))
+}
+
+func TestHeadObject_SSEC_RequiresKey(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	_, err := f.db.Exec(`
+		INSERT INTO object_head_cache
+			(tenant_id, bucket, object_key, size_bytes, etag, content_type, encryption_algorithm)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			encryption_algorithm = $7
+	`, f.tenantID, "test-bucket", "ssec-head.txt", 100, "abc123", "text/plain", crypto.SSECAlgorithm)
+	require.NoError(t, err)
+
+	srv := &Server{db: f.db, logger: zap.NewNop()}
+	req := httptest.NewRequest("HEAD", "/test-bucket/ssec-head.txt", nil)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	s3Req := &S3Request{Bucket: "test-bucket", Object: "ssec-head.txt"}
+
+	w := httptest.NewRecorder()
+	srv.handleHeadObject(w, req, s3Req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHeadObject_SSEC_WithKey(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+
+	_, err := f.db.Exec(`
+		INSERT INTO object_head_cache
+			(tenant_id, bucket, object_key, size_bytes, etag, content_type, encryption_algorithm)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			encryption_algorithm = $7
+	`, f.tenantID, "test-bucket", "ssec-head-ok.txt", 100, "def456", "text/plain", crypto.SSECAlgorithm)
+	require.NoError(t, err)
+
+	srv := &Server{db: f.db, logger: zap.NewNop()}
+	req := httptest.NewRequest("HEAD", "/test-bucket/ssec-head-ok.txt", nil)
+	setSSECHeaders(t, req, key)
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+	s3Req := &S3Request{Bucket: "test-bucket", Object: "ssec-head-ok.txt"}
+
+	w := httptest.NewRecorder()
+	srv.handleHeadObject(w, req, s3Req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "AES256", w.Header().Get("x-amz-server-side-encryption-customer-algorithm"))
+	assert.Empty(t, w.Header().Get("x-amz-server-side-encryption"))
+}
+
+func TestPutObject_SSEC_And_SSES3_MutuallyExclusive(t *testing.T) {
+	f := setupAdapterFixture(t)
+	key := generateSSECKey(t)
+	content := []byte("conflict test")
+
+	req := httptest.NewRequest("PUT", "/test-bucket/conflict.txt", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	setSSECHeaders(t, req, key)
+	req.Header.Set("x-amz-server-side-encryption", "AES256")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "conflict.txt")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "simultaneously")
 }

--- a/internal/api/s3_multipart.go
+++ b/internal/api/s3_multipart.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/tenant"
 
@@ -61,6 +62,12 @@ func (s *Server) handleInitiateMultipartUpload(w http.ResponseWriter, r *http.Re
 	t, err := tenant.FromContext(r.Context())
 	if err != nil || t == nil {
 		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if crypto.HasSSECHeaders(r) {
+		WriteS3ErrorWithContext(w, ErrNotImplemented, r.URL.Path, generateRequestID(),
+			WithSuggestion("SSE-C is not yet supported for multipart uploads."))
 		return
 	}
 

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -4,6 +4,7 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 
 ## Key Files
 
+- **ssec.go** — SSE-C (customer-provided keys): stateless AES-256-GCM encrypt/decrypt with customer's 32-byte key. S3 header parsing (algorithm, key, MD5 validation). No DB, no key storage
 - **sse_s3.go** — SSE-S3 service: ML-KEM-768 key encapsulation + AES-256-GCM data encryption. Per-tenant keypairs in DB, per-object DEKs via KEM encapsulation
 - **encryption.go** — Core Encryptor interface: AES-256-GCM, ChaCha20-Poly1305, Noop implementations. Chunk-level encrypt/decrypt for pipeline
 - **keymanager.go** — Multi-tenant HKDF key derivation with version tracking and TTL cache
@@ -32,3 +33,18 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 **Two ML-KEM implementations** coexist:
 - `postquantum.go` — cloudflare/circl (pipeline encryption, existing)
 - `sse_s3.go` — Go stdlib crypto/mlkem (SSE-S3, new)
+
+## SSE-C Architecture (Phase 5.14.8)
+
+**Stateless** customer-provided key encryption. No DB, no key management — the customer sends a raw 256-bit AES key with each PUT/GET/HEAD request.
+
+- **Encrypted blob format**: `[nonce (12B)][AES-GCM ciphertext+tag]`
+- **Size overhead**: 28 bytes per object (12 nonce + 16 GCM tag)
+- **Max encryptable size**: same 256 MiB limit as SSE-S3
+- **ETag**: computed on plaintext (before encryption)
+- **Key never stored**: only the algorithm indicator `AES256-SSE-C` in `object_head_cache.encryption_algorithm`
+- **Mutually exclusive** with SSE-S3 per object
+- **S3 headers**: `x-amz-server-side-encryption-customer-algorithm: AES256`, `x-amz-server-side-encryption-customer-key: <base64>`, `x-amz-server-side-encryption-customer-key-MD5: <base64>`
+- **GET/HEAD without key**: returns 403 AccessDenied
+- **Multipart uploads**: not yet supported (returns NotImplemented)
+- **CopyObject**: not yet supported for SSE-C objects

--- a/internal/crypto/ssec.go
+++ b/internal/crypto/ssec.go
@@ -1,0 +1,128 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5" // #nosec G401 — S3 spec requires MD5 for SSE-C key validation
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	SSECAlgorithm = "AES256-SSE-C"
+	SSECOverhead  = 28 // 12 nonce + 16 GCM tag
+)
+
+var ErrSSECKeyMismatch = errors.New("ssec: decryption failed — wrong key")
+
+func SSECEncrypt(key, plaintext []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("ssec: key must be 32 bytes, got %d", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("ssec: generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+
+	buf := make([]byte, 0, len(nonce)+len(ciphertext))
+	buf = append(buf, nonce...)
+	buf = append(buf, ciphertext...)
+	return buf, nil
+}
+
+func SSECDecrypt(key, data []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("ssec: key must be 32 bytes, got %d", len(key))
+	}
+	if len(data) < SSECOverhead {
+		return nil, fmt.Errorf("ssec: data too short: %d bytes (minimum %d)", len(data), SSECOverhead)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: create GCM: %w", err)
+	}
+
+	nonce := data[:gcm.NonceSize()]
+	ciphertext := data[gcm.NonceSize():]
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, ErrSSECKeyMismatch
+	}
+	return plaintext, nil
+}
+
+func HasSSECHeaders(r *http.Request) bool {
+	return r.Header.Get("x-amz-server-side-encryption-customer-algorithm") != ""
+}
+
+func ParseSSECHeaders(r *http.Request) ([]byte, error) {
+	algo := r.Header.Get("x-amz-server-side-encryption-customer-algorithm")
+	keyB64 := r.Header.Get("x-amz-server-side-encryption-customer-key")
+	md5B64 := r.Header.Get("x-amz-server-side-encryption-customer-key-MD5")
+
+	if algo == "" && keyB64 == "" && md5B64 == "" {
+		return nil, nil
+	}
+
+	if algo == "" || keyB64 == "" || md5B64 == "" {
+		return nil, fmt.Errorf("ssec: incomplete SSE-C headers — all three are required")
+	}
+
+	if algo != "AES256" {
+		return nil, fmt.Errorf("ssec: unsupported algorithm %q, expected AES256", algo)
+	}
+
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: invalid base64 key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("ssec: key must be 32 bytes, got %d", len(key))
+	}
+
+	expectedMD5, err := base64.StdEncoding.DecodeString(md5B64)
+	if err != nil {
+		return nil, fmt.Errorf("ssec: invalid base64 MD5: %w", err)
+	}
+
+	actualMD5 := md5.Sum(key) // #nosec G401 — S3 spec requires MD5 for key validation
+	if !equal(actualMD5[:], expectedMD5) {
+		return nil, fmt.Errorf("ssec: key MD5 mismatch")
+	}
+
+	return key, nil
+}
+
+func equal(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/crypto/ssec_test.go
+++ b/internal/crypto/ssec_test.go
@@ -1,0 +1,194 @@
+package crypto
+
+import (
+	"crypto/md5" // #nosec G401 — S3 spec requires MD5
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSSECKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return key
+}
+
+func TestSSECEncryptDecrypt(t *testing.T) {
+	key := testSSECKey(t)
+	plaintext := []byte("hello, SSE-C world!")
+
+	ciphertext, err := SSECEncrypt(key, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, len(plaintext)+SSECOverhead, len(ciphertext))
+
+	decrypted, err := SSECDecrypt(key, ciphertext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestSSECEncryptDecrypt_EmptyPlaintext(t *testing.T) {
+	key := testSSECKey(t)
+
+	ciphertext, err := SSECEncrypt(key, []byte{})
+	require.NoError(t, err)
+	assert.Equal(t, SSECOverhead, len(ciphertext))
+
+	decrypted, err := SSECDecrypt(key, ciphertext)
+	require.NoError(t, err)
+	assert.Empty(t, decrypted)
+}
+
+func TestSSECDecrypt_WrongKey(t *testing.T) {
+	key := testSSECKey(t)
+	wrongKey := testSSECKey(t)
+
+	ciphertext, err := SSECEncrypt(key, []byte("secret data"))
+	require.NoError(t, err)
+
+	_, err = SSECDecrypt(wrongKey, ciphertext)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSSECKeyMismatch)
+}
+
+func TestSSECEncrypt_InvalidKeyLength(t *testing.T) {
+	_, err := SSECEncrypt(make([]byte, 16), []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+func TestSSECDecrypt_InvalidKeyLength(t *testing.T) {
+	_, err := SSECDecrypt(make([]byte, 16), make([]byte, SSECOverhead))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+func TestSSECDecrypt_DataTooShort(t *testing.T) {
+	key := testSSECKey(t)
+	_, err := SSECDecrypt(key, []byte("short"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestSSECEncrypt_DifferentCiphertexts(t *testing.T) {
+	key := testSSECKey(t)
+	plaintext := []byte("same data")
+
+	ct1, err := SSECEncrypt(key, plaintext)
+	require.NoError(t, err)
+	ct2, err := SSECEncrypt(key, plaintext)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ct1, ct2, "different nonces should produce different ciphertexts")
+}
+
+func ssecHeaders(t *testing.T, key []byte) http.Header {
+	t.Helper()
+	h := http.Header{}
+	h.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	h.Set("x-amz-server-side-encryption-customer-key", base64.StdEncoding.EncodeToString(key))
+	digest := md5.Sum(key) // #nosec G401
+	h.Set("x-amz-server-side-encryption-customer-key-MD5", base64.StdEncoding.EncodeToString(digest[:]))
+	return h
+}
+
+func TestParseSSECHeaders_Valid(t *testing.T) {
+	key := testSSECKey(t)
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	for k, v := range ssecHeaders(t, key) {
+		req.Header[k] = v
+	}
+
+	parsed, err := ParseSSECHeaders(req)
+	require.NoError(t, err)
+	assert.Equal(t, key, parsed)
+}
+
+func TestParseSSECHeaders_Missing(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	parsed, err := ParseSSECHeaders(req)
+	require.NoError(t, err)
+	assert.Nil(t, parsed)
+}
+
+func TestParseSSECHeaders_MD5Mismatch(t *testing.T) {
+	key := testSSECKey(t)
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	req.Header.Set("x-amz-server-side-encryption-customer-key", base64.StdEncoding.EncodeToString(key))
+	req.Header.Set("x-amz-server-side-encryption-customer-key-MD5", base64.StdEncoding.EncodeToString([]byte("wrongmd5wrongmd5")))
+
+	_, err := ParseSSECHeaders(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MD5 mismatch")
+}
+
+func TestParseSSECHeaders_PartialHeaders(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+
+	_, err := ParseSSECHeaders(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete")
+}
+
+func TestParseSSECHeaders_WrongAlgorithm(t *testing.T) {
+	key := testSSECKey(t)
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES128")
+	req.Header.Set("x-amz-server-side-encryption-customer-key", base64.StdEncoding.EncodeToString(key))
+	digest := md5.Sum(key) // #nosec G401
+	req.Header.Set("x-amz-server-side-encryption-customer-key-MD5", base64.StdEncoding.EncodeToString(digest[:]))
+
+	_, err := ParseSSECHeaders(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported algorithm")
+}
+
+func TestParseSSECHeaders_InvalidBase64Key(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	req.Header.Set("x-amz-server-side-encryption-customer-key", "not-valid-base64!!!")
+	req.Header.Set("x-amz-server-side-encryption-customer-key-MD5", "also-bad")
+
+	_, err := ParseSSECHeaders(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base64")
+}
+
+func TestParseSSECHeaders_WrongKeyLength(t *testing.T) {
+	shortKey := make([]byte, 16)
+	_, _ = rand.Read(shortKey)
+	req := httptest.NewRequest("PUT", "/bucket/key", nil)
+	req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+	req.Header.Set("x-amz-server-side-encryption-customer-key", base64.StdEncoding.EncodeToString(shortKey))
+	digest := md5.Sum(shortKey) // #nosec G401
+	req.Header.Set("x-amz-server-side-encryption-customer-key-MD5", base64.StdEncoding.EncodeToString(digest[:]))
+
+	_, err := ParseSSECHeaders(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+func TestHasSSECHeaders(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		req.Header.Set("x-amz-server-side-encryption-customer-algorithm", "AES256")
+		assert.True(t, HasSSECHeaders(req))
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		req := httptest.NewRequest("PUT", "/", nil)
+		assert.False(t, HasSSECHeaders(req))
+	})
+}
+
+func TestSSECOverheadConstant(t *testing.T) {
+	assert.Equal(t, 28, SSECOverhead)
+}


### PR DESCRIPTION
## Summary
- Add SSE-C (Server-Side Encryption with Customer-provided Keys) — customers supply a 256-bit AES key per request via standard S3 headers (`x-amz-server-side-encryption-customer-algorithm`, `x-amz-server-side-encryption-customer-key`, `x-amz-server-side-encryption-customer-key-MD5`)
- New `internal/crypto/ssec.go`: stateless AES-256-GCM encrypt/decrypt with customer key, S3 header parsing with MD5 validation, 28-byte overhead per object
- HandlePut encrypts with customer key (mutually exclusive with SSE-S3), HandleGet/HEAD require the same key or return 403
- Customer key is never stored or logged — only the indicator `AES256-SSE-C` in `object_head_cache.encryption_algorithm`
- Multipart uploads with SSE-C return 501 NotImplemented (deferred)

## Test plan
- [x] `TestSSECEncryptDecrypt` — round-trip encrypt/decrypt returns original plaintext
- [x] `TestSSECDecrypt_WrongKey` — wrong key returns `ErrSSECKeyMismatch`
- [x] `TestSSECEncrypt_InvalidKeyLength` — 16-byte key rejected
- [x] `TestParseSSECHeaders_Valid` — all three headers present and correct
- [x] `TestParseSSECHeaders_Missing` — no SSE-C headers returns (nil, nil)
- [x] `TestParseSSECHeaders_MD5Mismatch` — wrong MD5 returns error
- [x] `TestParseSSECHeaders_PartialHeaders` — only algorithm header returns error
- [x] `TestPutObject_SSEC_Encrypts` — PUT with SSE-C stores `AES256-SSE-C` in DB, plaintext size in cache
- [x] `TestGetObject_SSEC_RequiresKey` — GET without key returns 403
- [x] `TestGetObject_SSEC_WrongKey` — GET with wrong key returns 403
- [x] `TestGetObject_SSEC_CorrectKey` — full round-trip PUT→GET returns original data
- [x] `TestHeadObject_SSEC_RequiresKey` — HEAD without key returns 403
- [x] `TestHeadObject_SSEC_WithKey` — HEAD with key returns 200 + correct header
- [x] `TestPutObject_SSEC_And_SSES3_MutuallyExclusive` — both headers = 400