### PR TITLE
feat(s3): server access logging and inventory reports [Phase 5.14.9]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -20,6 +20,9 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **presigned.go** — Management API endpoint for generating pre-signed URLs (`/api/v1/presigned`)
 - **sts_routes.go** — STS temporary credential endpoint (`POST /api/v1/sts/token`)
 - **cdn_analytics.go** — CDNAnalyticsTracker: buffered CDN access event writer (Record/Flush/CheckBudget) + hourly rollup
+- **access_log.go** — S3AccessLogTracker: buffered S3 access event writer (Record/Flush) + log delivery to target buckets
+- **s3_logging.go** — GET/PUT ?logging handlers for per-bucket server access logging config
+- **s3_inventory.go** — GET/PUT/DELETE ?inventory handlers + InventoryRunner background job for CSV reports
 - **management.go** — JSON response helpers: `writeJSON`, `writeListResponse`, `getRequestID` (Stripe-style envelope)
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
@@ -258,6 +261,44 @@ Each bucket has a `region` column (default `us-west-1`). Region is immutable aft
 **GET routing**: `HintBackend()` seeds the engine's `objectBackends` map from `cachedBackendName` so GET routes directly to the correct region driver without a failed failover attempt.
 
 **Table**: `buckets.region` (migration 039). **Error**: `ErrInvalidLocationConstraint` in s3_errors.go.
+
+## S3 Server Access Logging (Phase 5.14.9)
+
+Per-bucket server access logging with buffered writes and asynchronous log delivery to a target bucket.
+
+**Architecture**: Two-stage pipeline. All S3 requests are recorded to `s3_access_log` via `S3AccessLogTracker` (buffered, 5s flush interval, 100-event auto-flush). A delivery goroutine (every 5 min) queries logging-enabled buckets, formats records as S3-compatible access log lines, and writes them as objects to the target bucket via `engine.Put`. Delivered records are deleted from the table.
+
+**S3 API operations**:
+- `GET /{bucket}?logging` → `handleGetBucketLogging` — returns `<BucketLoggingStatus>` XML
+- `PUT /{bucket}?logging` → `handlePutBucketLogging` — sets logging target; rejects self-referential logging (same bucket → 400)
+
+**Access log format** (one line per request, space-separated):
+`{tenant_id} {bucket} [{time}] {source_ip} {operation} {key} {status} {error} {bytes_sent} {bytes_received} {request_id} "{user_agent}"`
+
+**Log object key**: `{prefix}{YYYY-MM-DD-HH-MM-SS}-{random6hex}`
+
+**Validation**: Target bucket must exist and belong to the same tenant. Source bucket cannot log to itself (prevents infinite loops).
+
+**Status code capture**: `countingResponseWriter` now captures HTTP status code via `WriteHeader` override (used by access log recording).
+
+**Tables**: `s3_access_log` (buffered records), `buckets.logging_enabled`, `buckets.logging_target_bucket`, `buckets.logging_prefix` (migration 040).
+
+## S3 Inventory Reports (Phase 5.14.9)
+
+Per-bucket inventory reports (daily/weekly CSV export of all objects to a destination bucket).
+
+**S3 API operations**:
+- `GET /{bucket}?inventory` → `handleGetBucketInventory` — returns `<InventoryConfiguration>` XML
+- `PUT /{bucket}?inventory` → `handlePutBucketInventory` — sets inventory config (schedule, target, format)
+- `DELETE /{bucket}?inventory` → `handleDeleteBucketInventory` — disables inventory (204)
+
+**InventoryRunner**: Background goroutine checks hourly; runs at midnight UTC. Daily schedules run every night; weekly schedules run only on Sunday. Reads from `object_head_cache` (not backend storage), so inventory generation is fast regardless of object count.
+
+**CSV columns**: Key, SizeBytes, ETag, ContentType, LastModified, EncryptionAlgorithm, BackendName
+
+**Inventory object key**: `{prefix}{source_bucket}/{YYYY-MM-DD}T00-00Z/manifest.csv`
+
+**Tables**: `buckets.inventory_enabled`, `buckets.inventory_schedule`, `buckets.inventory_target_bucket`, `buckets.inventory_prefix`, `buckets.inventory_format` (migration 040).
 
 ## Tenant Context
 

--- a/internal/api/access_log.go
+++ b/internal/api/access_log.go
@@ -1,0 +1,291 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/engine"
+	"go.uber.org/zap"
+)
+
+type s3AccessEvent struct {
+	tenantID      string
+	bucket        string
+	objectKey     string
+	operation     string
+	statusCode    int
+	bytesSent     int64
+	bytesReceived int64
+	sourceIP      string
+	userAgent     string
+	requestID     string
+	errorCode     string
+	loggedAt      time.Time
+}
+
+// S3AccessLogTracker buffers S3 access events and flushes them to the
+// s3_access_log table periodically. A separate delivery goroutine writes
+// accumulated log records as objects to the configured target bucket.
+type S3AccessLogTracker struct {
+	db     *sql.DB
+	mu     sync.Mutex
+	buffer []s3AccessEvent
+	logger *zap.Logger
+}
+
+func NewS3AccessLogTracker(db *sql.DB) *S3AccessLogTracker {
+	return &S3AccessLogTracker{
+		db:     db,
+		buffer: make([]s3AccessEvent, 0, 128),
+	}
+}
+
+func (at *S3AccessLogTracker) SetLogger(logger *zap.Logger) {
+	at.logger = logger
+}
+
+// Record appends an S3 access event to the buffer. Auto-flushes at 100 events.
+func (at *S3AccessLogTracker) Record(_ context.Context, event s3AccessEvent) {
+	if event.tenantID == "" || event.bucket == "" {
+		return
+	}
+	if event.loggedAt.IsZero() {
+		event.loggedAt = time.Now()
+	}
+
+	at.mu.Lock()
+	at.buffer = append(at.buffer, event)
+	needsFlush := len(at.buffer) >= 100
+	at.mu.Unlock()
+
+	if needsFlush {
+		at.Flush()
+	}
+}
+
+// StartFlusher runs a background goroutine that flushes the buffer every interval.
+func (at *S3AccessLogTracker) StartFlusher(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				at.Flush()
+				return
+			case <-ticker.C:
+				at.Flush()
+			}
+		}
+	}()
+}
+
+// Flush writes all buffered events to the s3_access_log table.
+func (at *S3AccessLogTracker) Flush() {
+	at.mu.Lock()
+	if len(at.buffer) == 0 {
+		at.mu.Unlock()
+		return
+	}
+	events := at.buffer
+	at.buffer = make([]s3AccessEvent, 0, 128)
+	at.mu.Unlock()
+
+	if at.db == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, e := range events {
+		_, err := at.db.ExecContext(ctx, `
+			INSERT INTO s3_access_log (tenant_id, bucket, object_key, operation, status_code,
+				bytes_sent, bytes_received, source_ip, user_agent, request_id, error_code, logged_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		`, e.tenantID, e.bucket, e.objectKey, e.operation, e.statusCode,
+			e.bytesSent, e.bytesReceived, e.sourceIP, e.userAgent, e.requestID, e.errorCode, e.loggedAt)
+		if err != nil && at.logger != nil {
+			at.logger.Error("flush s3 access log",
+				zap.String("tenant_id", e.tenantID), zap.Error(err))
+		}
+	}
+}
+
+// formatAccessLogLine formats a single access log record in S3 server access log format.
+func formatAccessLogLine(e s3AccessEvent) string {
+	ts := e.loggedAt.UTC().Format("02/Jan/2006:15:04:05 -0700")
+	key := e.objectKey
+	if key == "" {
+		key = "-"
+	}
+	errCode := e.errorCode
+	if errCode == "" {
+		errCode = "-"
+	}
+	ua := e.userAgent
+	if ua == "" {
+		ua = "-"
+	}
+	return fmt.Sprintf("%s %s [%s] %s %s %s %d %s %d %d %s \"%s\"",
+		e.tenantID, e.bucket, ts, e.sourceIP, e.operation, key,
+		e.statusCode, errCode, e.bytesSent, e.bytesReceived, e.requestID, ua)
+}
+
+func randomHex6() string {
+	b := make([]byte, 3)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// writeAccessLogObject formats records as S3 access log lines and writes them
+// as an object to the target bucket via engine.Put.
+func (at *S3AccessLogTracker) writeAccessLogObject(ctx context.Context, eng *engine.CoreEngine, tenantID, targetBucket, prefix string, records []s3AccessEvent) error {
+	if eng == nil || len(records) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for _, r := range records {
+		buf.WriteString(formatAccessLogLine(r))
+		buf.WriteByte('\n')
+	}
+
+	now := time.Now().UTC()
+	objectKey := fmt.Sprintf("%s%s-%s", prefix, now.Format("2006-01-02-15-04-05"), randomHex6())
+
+	container := fmt.Sprintf("tenant/%s/%s", tenantID, targetBucket)
+	_, err := eng.Put(ctx, container, objectKey, strings.NewReader(buf.String()))
+	return err
+}
+
+// StartLogDelivery runs a background goroutine that delivers accumulated access
+// log records from the s3_access_log table to the configured target buckets as
+// log objects every 5 minutes.
+func (at *S3AccessLogTracker) StartLogDelivery(ctx context.Context, eng *engine.CoreEngine) {
+	if at.db == nil || eng == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				at.deliverLogs(ctx, eng)
+			}
+		}
+	}()
+}
+
+func (at *S3AccessLogTracker) deliverLogs(ctx context.Context, eng *engine.CoreEngine) {
+	deliverCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	// Find all buckets with logging enabled.
+	rows, err := at.db.QueryContext(deliverCtx, `
+		SELECT DISTINCT b.tenant_id, b.name, b.logging_target_bucket, b.logging_prefix
+		FROM buckets b
+		INNER JOIN s3_access_log l ON l.tenant_id = b.tenant_id AND l.bucket = b.name
+		WHERE b.logging_enabled = TRUE AND b.logging_target_bucket IS NOT NULL
+	`)
+	if err != nil {
+		if at.logger != nil {
+			at.logger.Error("query logging-enabled buckets", zap.Error(err))
+		}
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type bucketConfig struct {
+		tenantID     string
+		bucket       string
+		targetBucket string
+		prefix       string
+	}
+	var configs []bucketConfig
+	for rows.Next() {
+		var c bucketConfig
+		if err := rows.Scan(&c.tenantID, &c.bucket, &c.targetBucket, &c.prefix); err != nil {
+			if at.logger != nil {
+				at.logger.Error("scan logging bucket config", zap.Error(err))
+			}
+			continue
+		}
+		configs = append(configs, c)
+	}
+
+	for _, c := range configs {
+		at.deliverBucketLogs(deliverCtx, eng, c.tenantID, c.bucket, c.targetBucket, c.prefix)
+	}
+}
+
+func (at *S3AccessLogTracker) deliverBucketLogs(ctx context.Context, eng *engine.CoreEngine, tenantID, bucket, targetBucket, prefix string) {
+	rows, err := at.db.QueryContext(ctx, `
+		SELECT id, tenant_id, bucket, object_key, operation, status_code,
+			bytes_sent, bytes_received, source_ip, user_agent, request_id, error_code, logged_at
+		FROM s3_access_log
+		WHERE tenant_id = $1 AND bucket = $2
+		ORDER BY logged_at ASC
+		LIMIT 1000
+	`, tenantID, bucket)
+	if err != nil {
+		if at.logger != nil {
+			at.logger.Error("query access log records", zap.Error(err))
+		}
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []int64
+	var records []s3AccessEvent
+	for rows.Next() {
+		var id int64
+		var e s3AccessEvent
+		if err := rows.Scan(&id, &e.tenantID, &e.bucket, &e.objectKey, &e.operation, &e.statusCode,
+			&e.bytesSent, &e.bytesReceived, &e.sourceIP, &e.userAgent, &e.requestID, &e.errorCode, &e.loggedAt); err != nil {
+			if at.logger != nil {
+				at.logger.Error("scan access log row", zap.Error(err))
+			}
+			continue
+		}
+		ids = append(ids, id)
+		records = append(records, e)
+	}
+
+	if len(records) == 0 {
+		return
+	}
+
+	if err := at.writeAccessLogObject(ctx, eng, tenantID, targetBucket, prefix, records); err != nil {
+		if at.logger != nil {
+			at.logger.Error("write access log object",
+				zap.String("tenant_id", tenantID),
+				zap.String("target_bucket", targetBucket),
+				zap.Error(err))
+		}
+		return
+	}
+
+	// Delete delivered records.
+	for _, id := range ids {
+		_, _ = at.db.ExecContext(ctx, `DELETE FROM s3_access_log WHERE id = $1`, id)
+	}
+
+	if at.logger != nil {
+		at.logger.Info("delivered access log records",
+			zap.String("tenant_id", tenantID),
+			zap.String("bucket", bucket),
+			zap.String("target_bucket", targetBucket),
+			zap.Int("records", len(records)))
+	}
+}

--- a/internal/api/access_log_test.go
+++ b/internal/api/access_log_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3AccessLogTracker_Record(t *testing.T) {
+	// Arrange
+	at := NewS3AccessLogTracker(nil)
+
+	// Act
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:   "t1",
+		bucket:     "my-bucket",
+		objectKey:  "photo.jpg",
+		operation:  "GetObject",
+		statusCode: 200,
+		bytesSent:  1024,
+	})
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:      "t1",
+		bucket:        "my-bucket",
+		objectKey:     "doc.pdf",
+		operation:     "PutObject",
+		statusCode:    200,
+		bytesReceived: 5000,
+	})
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:   "t2",
+		bucket:     "other",
+		operation:  "ListObjects",
+		statusCode: 200,
+	})
+
+	// Assert
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	require.Len(t, at.buffer, 3)
+	assert.Equal(t, "t1", at.buffer[0].tenantID)
+	assert.Equal(t, "my-bucket", at.buffer[0].bucket)
+	assert.Equal(t, "photo.jpg", at.buffer[0].objectKey)
+	assert.Equal(t, "GetObject", at.buffer[0].operation)
+	assert.Equal(t, 200, at.buffer[0].statusCode)
+	assert.Equal(t, int64(1024), at.buffer[0].bytesSent)
+}
+
+func TestS3AccessLogTracker_AutoFlushAt100(t *testing.T) {
+	// Arrange
+	at := NewS3AccessLogTracker(nil)
+
+	// Act — record 100 events to trigger auto-flush
+	for i := 0; i < 100; i++ {
+		at.Record(context.Background(), s3AccessEvent{
+			tenantID:   "t1",
+			bucket:     "b1",
+			operation:  "GetObject",
+			statusCode: 200,
+		})
+	}
+
+	// Assert — buffer should be empty after auto-flush (nil DB drains silently)
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	assert.Empty(t, at.buffer)
+}
+
+func TestS3AccessLogTracker_Flush(t *testing.T) {
+	// Arrange
+	at := NewS3AccessLogTracker(nil)
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:   "t1",
+		bucket:     "b1",
+		operation:  "GetObject",
+		statusCode: 200,
+		bytesSent:  100,
+	})
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:   "t1",
+		bucket:     "b1",
+		operation:  "PutObject",
+		statusCode: 200,
+	})
+
+	// Act
+	at.Flush()
+
+	// Assert
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	assert.Empty(t, at.buffer)
+}
+
+func TestS3AccessLogTracker_NilDB(t *testing.T) {
+	// Arrange
+	at := NewS3AccessLogTracker(nil)
+
+	// Act — should not panic with nil DB
+	at.Record(context.Background(), s3AccessEvent{
+		tenantID:   "t1",
+		bucket:     "b1",
+		operation:  "GetObject",
+		statusCode: 200,
+	})
+	at.Flush()
+
+	// Assert — no panic = pass
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	assert.Empty(t, at.buffer)
+}
+
+func TestS3AccessLogTracker_SkipsEmptyTenantOrBucket(t *testing.T) {
+	at := NewS3AccessLogTracker(nil)
+
+	at.Record(context.Background(), s3AccessEvent{tenantID: "", bucket: "b", operation: "Get", statusCode: 200})
+	at.Record(context.Background(), s3AccessEvent{tenantID: "t", bucket: "", operation: "Get", statusCode: 200})
+
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	assert.Empty(t, at.buffer)
+}
+
+func TestAccessLogFormat(t *testing.T) {
+	// Arrange
+	ts := time.Date(2026, 5, 27, 14, 30, 45, 0, time.UTC)
+	event := s3AccessEvent{
+		tenantID:      "tenant-abc",
+		bucket:        "my-bucket",
+		objectKey:     "photos/sunset.jpg",
+		operation:     "GetObject",
+		statusCode:    200,
+		bytesSent:     4096,
+		bytesReceived: 0,
+		sourceIP:      "192.168.1.1",
+		userAgent:     "aws-cli/2.0",
+		requestID:     "req-12345",
+		errorCode:     "",
+		loggedAt:      ts,
+	}
+
+	// Act
+	line := formatAccessLogLine(event)
+
+	// Assert
+	assert.Contains(t, line, "tenant-abc")
+	assert.Contains(t, line, "my-bucket")
+	assert.Contains(t, line, "[27/May/2026:14:30:45 +0000]")
+	assert.Contains(t, line, "192.168.1.1")
+	assert.Contains(t, line, "GetObject")
+	assert.Contains(t, line, "photos/sunset.jpg")
+	assert.Contains(t, line, "200")
+	assert.Contains(t, line, "4096")
+	assert.Contains(t, line, "req-12345")
+	assert.Contains(t, line, `"aws-cli/2.0"`)
+	// Error code should be "-" when empty
+	assert.Contains(t, line, " - ")
+}
+
+func TestAccessLogFormat_EmptyFields(t *testing.T) {
+	event := s3AccessEvent{
+		tenantID:   "t1",
+		bucket:     "b1",
+		operation:  "ListObjects",
+		statusCode: 200,
+		loggedAt:   time.Now(),
+	}
+
+	line := formatAccessLogLine(event)
+
+	// Empty objectKey should be "-"
+	assert.Contains(t, line, "ListObjects -")
+	// Empty user agent should be "-" (quoted)
+	assert.Contains(t, line, `"-"`)
+}

--- a/internal/api/bandwidth.go
+++ b/internal/api/bandwidth.go
@@ -10,13 +10,28 @@ import (
 	"go.uber.org/zap"
 )
 
-// countingResponseWriter wraps http.ResponseWriter to count bytes written.
+// countingResponseWriter wraps http.ResponseWriter to count bytes written
+// and capture the HTTP status code for access logging.
 type countingResponseWriter struct {
 	http.ResponseWriter
 	bytesWritten int64
+	statusCode   int
+	wroteHeader  bool
+}
+
+func (cw *countingResponseWriter) WriteHeader(code int) {
+	if !cw.wroteHeader {
+		cw.statusCode = code
+		cw.wroteHeader = true
+	}
+	cw.ResponseWriter.WriteHeader(code)
 }
 
 func (cw *countingResponseWriter) Write(b []byte) (int, error) {
+	if !cw.wroteHeader {
+		cw.statusCode = http.StatusOK
+		cw.wroteHeader = true
+	}
 	n, err := cw.ResponseWriter.Write(b)
 	cw.bytesWritten += int64(n)
 	return n, err

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -117,6 +117,10 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 				req.Operation = "GetBucketNotification"
 			} else if _, ok := req.Query["object-lock"]; ok {
 				req.Operation = "GetObjectLockConfiguration"
+			} else if _, ok := req.Query["logging"]; ok {
+				req.Operation = "GetBucketLogging"
+			} else if _, ok := req.Query["inventory"]; ok {
+				req.Operation = "GetBucketInventory"
 			} else if _, ok := req.Query["uploads"]; ok {
 				req.Operation = "ListMultipartUploads"
 			} else {
@@ -129,11 +133,19 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 				req.Operation = "PutBucketNotification"
 			} else if _, ok := req.Query["object-lock"]; ok {
 				req.Operation = "PutObjectLockConfiguration"
+			} else if _, ok := req.Query["logging"]; ok {
+				req.Operation = "PutBucketLogging"
+			} else if _, ok := req.Query["inventory"]; ok {
+				req.Operation = "PutBucketInventory"
 			} else {
 				req.Operation = "CreateBucket"
 			}
 		case "DELETE":
-			req.Operation = "DeleteBucket"
+			if _, ok := req.Query["inventory"]; ok {
+				req.Operation = "DeleteBucketInventory"
+			} else {
+				req.Operation = "DeleteBucket"
+			}
 		case "HEAD":
 			req.Operation = "HeadBucket"
 		case "POST":
@@ -488,10 +500,41 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handleGetObjectLegalHold(cw, r, s3Req)
 	case "PutObjectLegalHold":
 		s.handlePutObjectLegalHold(cw, r, s3Req)
+	case "GetBucketLogging":
+		s.handleGetBucketLogging(cw, r, s3Req)
+	case "PutBucketLogging":
+		s.handlePutBucketLogging(cw, r, s3Req)
+	case "GetBucketInventory":
+		s.handleGetBucketInventory(cw, r, s3Req)
+	case "PutBucketInventory":
+		s.handlePutBucketInventory(cw, r, s3Req)
+	case "DeleteBucketInventory":
+		s.handleDeleteBucketInventory(cw, r, s3Req)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))
 		WriteS3Error(cw, ErrNotImplemented, r.URL.Path, generateRequestID())
+	}
+
+	// Record S3 access log for authenticated requests.
+	if tenantID != "" && tenantID != "default" && s.accessLogTracker != nil {
+		statusCode := cw.statusCode
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		s.accessLogTracker.Record(r.Context(), s3AccessEvent{
+			tenantID:      tenantID,
+			bucket:        s3Req.Bucket,
+			objectKey:     s3Req.Object,
+			operation:     s3Req.Operation,
+			statusCode:    statusCode,
+			bytesSent:     cw.bytesWritten,
+			bytesReceived: ingressBytes,
+			sourceIP:      extractClientIP(r),
+			userAgent:     r.UserAgent(),
+			requestID:     r.Header.Get("X-Request-Id"),
+			loggedAt:      time.Now(),
+		})
 	}
 
 	// Record bandwidth for authenticated requests.

--- a/internal/api/s3_inventory.go
+++ b/internal/api/s3_inventory.go
@@ -1,0 +1,409 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const maxInventoryBodyBytes = 4096
+
+// InventoryConfiguration is the S3 XML type for inventory config.
+type InventoryConfiguration struct {
+	XMLName     xml.Name              `xml:"InventoryConfiguration"`
+	Xmlns       string                `xml:"xmlns,attr,omitempty"`
+	ID          string                `xml:"Id,omitempty"`
+	IsEnabled   bool                  `xml:"IsEnabled"`
+	Schedule    *InventorySchedule    `xml:"Schedule,omitempty"`
+	Destination *InventoryDestination `xml:"Destination,omitempty"`
+	Format      string                `xml:"Format,omitempty"`
+}
+
+type InventorySchedule struct {
+	Frequency string `xml:"Frequency"`
+}
+
+type InventoryDestination struct {
+	S3BucketDestination *S3BucketDestination `xml:"S3BucketDestination,omitempty"`
+}
+
+type S3BucketDestination struct {
+	Bucket string `xml:"Bucket"`
+	Prefix string `xml:"Prefix,omitempty"`
+	Format string `xml:"Format,omitempty"`
+}
+
+func (s *Server) handleGetBucketInventory(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(xml.Header))
+		_, _ = w.Write([]byte(`<InventoryConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><IsEnabled>false</IsEnabled></InventoryConfiguration>`))
+		return
+	}
+
+	var enabled bool
+	var schedule string
+	var targetBucket, prefix, format sql.NullString
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT inventory_enabled, inventory_schedule, inventory_target_bucket, inventory_prefix, inventory_format
+		 FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		t.ID, req.Bucket).Scan(&enabled, &schedule, &targetBucket, &prefix, &format)
+	if err == sql.ErrNoRows {
+		reqID := generateRequestID()
+		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+		}
+		return
+	}
+	if err != nil {
+		s.logger.Error("query bucket inventory config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	resp := InventoryConfiguration{
+		Xmlns:     "http://s3.amazonaws.com/doc/2006-03-01/",
+		ID:        req.Bucket,
+		IsEnabled: enabled,
+	}
+	if enabled && targetBucket.Valid && targetBucket.String != "" {
+		resp.Schedule = &InventorySchedule{Frequency: schedule}
+		resp.Format = format.String
+		resp.Destination = &InventoryDestination{
+			S3BucketDestination: &S3BucketDestination{
+				Bucket: targetBucket.String,
+				Prefix: prefix.String,
+				Format: format.String,
+			},
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutBucketInventory(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxInventoryBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config InventoryConfiguration
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	// Verify source bucket exists.
+	var exists bool
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT EXISTS(SELECT 1 FROM buckets WHERE tenant_id = $1 AND name = $2)`,
+		t.ID, req.Bucket).Scan(&exists)
+	if err != nil || !exists {
+		reqID := generateRequestID()
+		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+		}
+		return
+	}
+
+	if !config.IsEnabled || config.Destination == nil || config.Destination.S3BucketDestination == nil {
+		// Disable inventory.
+		_, err = s.db.ExecContext(r.Context(),
+			`UPDATE buckets SET inventory_enabled = FALSE, inventory_target_bucket = NULL, inventory_prefix = '', updated_at = NOW()
+			 WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket)
+		if err != nil {
+			s.logger.Error("disable bucket inventory", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	dest := config.Destination.S3BucketDestination
+	targetBucket := dest.Bucket
+
+	// Validate target bucket exists and belongs to same tenant.
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT EXISTS(SELECT 1 FROM buckets WHERE tenant_id = $1 AND name = $2)`,
+		t.ID, targetBucket).Scan(&exists)
+	if err != nil || !exists {
+		WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, generateRequestID(),
+			WithSuggestion("Target bucket does not exist or belongs to a different account."))
+		return
+	}
+
+	schedule := "daily"
+	if config.Schedule != nil && config.Schedule.Frequency != "" {
+		freq := strings.ToLower(config.Schedule.Frequency)
+		if freq == "daily" || freq == "weekly" {
+			schedule = freq
+		}
+	}
+
+	inventoryFormat := "csv"
+	if dest.Format != "" {
+		f := strings.ToLower(dest.Format)
+		if f == "csv" || f == "orc" || f == "parquet" {
+			inventoryFormat = f
+		}
+	}
+
+	_, err = s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET inventory_enabled = TRUE, inventory_schedule = $3,
+			inventory_target_bucket = $4, inventory_prefix = $5, inventory_format = $6, updated_at = NOW()
+		 WHERE tenant_id = $1 AND name = $2`,
+		t.ID, req.Bucket, schedule, targetBucket, dest.Prefix, inventoryFormat)
+	if err != nil {
+		s.logger.Error("enable bucket inventory", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("bucket inventory enabled",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.String("target_bucket", targetBucket),
+		zap.String("schedule", schedule),
+		zap.String("format", inventoryFormat))
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleDeleteBucketInventory(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	result, err := s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET inventory_enabled = FALSE, inventory_target_bucket = NULL,
+			inventory_prefix = '', updated_at = NOW()
+		 WHERE tenant_id = $1 AND name = $2`,
+		t.ID, req.Bucket)
+	if err != nil {
+		s.logger.Error("delete bucket inventory", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		reqID := generateRequestID()
+		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+		}
+		return
+	}
+
+	s.logger.Info("bucket inventory deleted",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket))
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// InventoryRunner generates inventory reports for buckets that have inventory enabled.
+type InventoryRunner struct {
+	db     *sql.DB
+	eng    *engine.CoreEngine
+	logger *zap.Logger
+}
+
+func NewInventoryRunner(db *sql.DB, eng *engine.CoreEngine, logger *zap.Logger) *InventoryRunner {
+	if db == nil || eng == nil {
+		return nil
+	}
+	return &InventoryRunner{db: db, eng: eng, logger: logger}
+}
+
+// StartInventoryJob runs a background goroutine that generates inventory reports.
+// Checks once per hour whether any inventory reports are due.
+func (ir *InventoryRunner) StartInventoryJob(ctx context.Context) {
+	if ir == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ir.runInventory(ctx)
+			}
+		}
+	}()
+}
+
+func (ir *InventoryRunner) runInventory(ctx context.Context) {
+	now := time.Now().UTC()
+
+	// Only run at midnight UTC (hour 0).
+	if now.Hour() != 0 {
+		return
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	rows, err := ir.db.QueryContext(runCtx, `
+		SELECT tenant_id, name, inventory_schedule, inventory_target_bucket,
+			inventory_prefix, inventory_format
+		FROM buckets
+		WHERE inventory_enabled = TRUE AND inventory_target_bucket IS NOT NULL
+	`)
+	if err != nil {
+		ir.logger.Error("query inventory-enabled buckets", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type invConfig struct {
+		tenantID     string
+		bucket       string
+		schedule     string
+		targetBucket string
+		prefix       string
+		format       string
+	}
+	var configs []invConfig
+	for rows.Next() {
+		var c invConfig
+		if err := rows.Scan(&c.tenantID, &c.bucket, &c.schedule, &c.targetBucket, &c.prefix, &c.format); err != nil {
+			ir.logger.Error("scan inventory config", zap.Error(err))
+			continue
+		}
+		configs = append(configs, c)
+	}
+
+	for _, c := range configs {
+		// Weekly runs only on Sunday.
+		if c.schedule == "weekly" && now.Weekday() != time.Sunday {
+			continue
+		}
+		ir.generateReport(runCtx, c.tenantID, c.bucket, c.targetBucket, c.prefix, c.format)
+	}
+}
+
+func (ir *InventoryRunner) generateReport(ctx context.Context, tenantID, bucket, targetBucket, prefix, format string) {
+	rows, err := ir.db.QueryContext(ctx, `
+		SELECT object_key, size_bytes, etag, content_type, updated_at,
+			COALESCE(encryption_algorithm, ''), COALESCE(backend_name, '')
+		FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2
+		ORDER BY object_key ASC
+	`, tenantID, bucket)
+	if err != nil {
+		ir.logger.Error("query objects for inventory",
+			zap.String("bucket", bucket), zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+
+	_ = w.Write([]string{"Key", "SizeBytes", "ETag", "ContentType", "LastModified", "EncryptionAlgorithm", "BackendName"})
+
+	var count int
+	for rows.Next() {
+		var key, etag, contentType, encAlgo, backendName string
+		var sizeBytes int64
+		var updatedAt time.Time
+		if err := rows.Scan(&key, &sizeBytes, &etag, &contentType, &updatedAt, &encAlgo, &backendName); err != nil {
+			ir.logger.Error("scan inventory row", zap.Error(err))
+			continue
+		}
+		_ = w.Write([]string{
+			key,
+			fmt.Sprintf("%d", sizeBytes),
+			etag,
+			contentType,
+			updatedAt.UTC().Format(time.RFC3339),
+			encAlgo,
+			backendName,
+		})
+		count++
+	}
+	w.Flush()
+
+	if count == 0 {
+		return
+	}
+
+	now := time.Now().UTC()
+	objectKey := fmt.Sprintf("%s%s/%sT00-00Z/manifest.csv",
+		prefix, bucket, now.Format("2006-01-02"))
+
+	container := fmt.Sprintf("tenant/%s/%s", tenantID, targetBucket)
+
+	if _, err := ir.eng.Put(ctx, container, objectKey, strings.NewReader(buf.String())); err != nil {
+		ir.logger.Error("write inventory report",
+			zap.String("tenant_id", tenantID),
+			zap.String("target", targetBucket+"/"+objectKey),
+			zap.Error(err))
+		return
+	}
+
+	ir.logger.Info("inventory report generated",
+		zap.String("tenant_id", tenantID),
+		zap.String("bucket", bucket),
+		zap.String("target", targetBucket+"/"+objectKey),
+		zap.Int("objects", count))
+}
+
+// GenerateReportNow is exposed for testing — generates a report immediately.
+func (ir *InventoryRunner) GenerateReportNow(ctx context.Context, tenantID, bucket, targetBucket, prefix, format string) {
+	if ir == nil {
+		return
+	}
+	ir.generateReport(ctx, tenantID, bucket, targetBucket, prefix, format)
+}

--- a/internal/api/s3_inventory_test.go
+++ b/internal/api/s3_inventory_test.go
@@ -1,0 +1,331 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type inventoryFixture struct {
+	server    *Server
+	db        *sql.DB
+	eng       *engine.CoreEngine
+	tenantID  string
+	tenant    *tenant.Tenant
+	tempDir   string
+	bucket    string
+	invBucket string
+}
+
+func setupInventoryFixture(t *testing.T) *inventoryFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-inv-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("inv-%d", os.Getpid())
+	bucket := "data-bucket"
+	invBucket := "inventory-bucket"
+	email := fmt.Sprintf("inv-%d@test.local", os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Inventory Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	for _, b := range []string{bucket, invBucket} {
+		_, err = db.Exec(`
+			INSERT INTO buckets (tenant_id, name, visibility)
+			VALUES ($1, $2, 'private')
+			ON CONFLICT (tenant_id, name) DO NOTHING
+		`, tenantID, b)
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	for _, b := range []string{bucket, invBucket} {
+		container := tn.NamespaceContainer(b)
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+	}
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+
+	return &inventoryFixture{
+		server:    srv,
+		db:        db,
+		eng:       eng,
+		tenantID:  tenantID,
+		tenant:    tn,
+		tempDir:   tempDir,
+		bucket:    bucket,
+		invBucket: invBucket,
+	}
+}
+
+func TestPutBucketInventory_Enable(t *testing.T) {
+	f := setupInventoryFixture(t)
+
+	configXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<InventoryConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <IsEnabled>true</IsEnabled>
+  <Schedule><Frequency>Daily</Frequency></Schedule>
+  <Destination>
+    <S3BucketDestination>
+      <Bucket>%s</Bucket>
+      <Prefix>reports/</Prefix>
+      <Format>CSV</Format>
+    </S3BucketDestination>
+  </Destination>
+</InventoryConfiguration>`, f.invBucket)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"?inventory", bytes.NewReader([]byte(configXML))).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	f.server.handlePutBucketInventory(w, r, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET should return the config
+	r2 := httptest.NewRequest("GET", "/"+f.bucket+"?inventory", nil).WithContext(ctx)
+	w2 := httptest.NewRecorder()
+	f.server.handleGetBucketInventory(w2, r2, s3Req)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+	var resp InventoryConfiguration
+	err := xml.Unmarshal(w2.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.True(t, resp.IsEnabled)
+	require.NotNil(t, resp.Destination)
+	require.NotNil(t, resp.Destination.S3BucketDestination)
+	assert.Equal(t, f.invBucket, resp.Destination.S3BucketDestination.Bucket)
+	assert.Equal(t, "reports/", resp.Destination.S3BucketDestination.Prefix)
+}
+
+func TestDeleteBucketInventory(t *testing.T) {
+	f := setupInventoryFixture(t)
+
+	// First enable inventory
+	configXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<InventoryConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <IsEnabled>true</IsEnabled>
+  <Schedule><Frequency>Daily</Frequency></Schedule>
+  <Destination>
+    <S3BucketDestination>
+      <Bucket>%s</Bucket>
+      <Format>CSV</Format>
+    </S3BucketDestination>
+  </Destination>
+</InventoryConfiguration>`, f.invBucket)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"?inventory", bytes.NewReader([]byte(configXML))).WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutBucketInventory(w, r, s3Req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// DELETE inventory
+	r2 := httptest.NewRequest("DELETE", "/"+f.bucket+"?inventory", nil).WithContext(ctx)
+	w2 := httptest.NewRecorder()
+	f.server.handleDeleteBucketInventory(w2, r2, s3Req)
+	assert.Equal(t, http.StatusNoContent, w2.Code)
+
+	// GET should return disabled
+	r3 := httptest.NewRequest("GET", "/"+f.bucket+"?inventory", nil).WithContext(ctx)
+	w3 := httptest.NewRecorder()
+	f.server.handleGetBucketInventory(w3, r3, s3Req)
+
+	var resp InventoryConfiguration
+	err := xml.Unmarshal(w3.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.False(t, resp.IsEnabled)
+}
+
+func TestInventoryCSV_Format(t *testing.T) {
+	f := setupInventoryFixture(t)
+
+	// Insert some objects into object_head_cache
+	for i, key := range []string{"file-a.txt", "file-b.jpg", "folder/file-c.pdf"} {
+		_, err := f.db.Exec(`
+			INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (tenant_id, bucket, object_key) DO NOTHING
+		`, f.tenantID, f.bucket, key, (i+1)*1024, fmt.Sprintf("etag-%d", i), "application/octet-stream", "local")
+		require.NoError(t, err)
+	}
+
+	// Run inventory report
+	logger := zap.NewNop()
+	runner := NewInventoryRunner(f.db, f.eng, logger)
+	require.NotNil(t, runner)
+
+	runner.GenerateReportNow(context.Background(), f.tenantID, f.bucket, f.invBucket, "inv/", "csv")
+
+	// Read the generated inventory object from the local filesystem
+	container := fmt.Sprintf("tenant/%s/%s", f.tenantID, f.invBucket)
+	containerPath := filepath.Join(f.tempDir, container)
+
+	// Find the CSV file under inv/
+	var csvPath string
+	err := filepath.Walk(containerPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.Contains(path, "manifest.csv") {
+			csvPath = path
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, csvPath, "inventory CSV file not found")
+
+	data, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(bytes.NewReader(data))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 3 data rows
+	require.Len(t, records, 4)
+
+	// Verify header
+	assert.Equal(t, []string{"Key", "SizeBytes", "ETag", "ContentType", "LastModified", "EncryptionAlgorithm", "BackendName"}, records[0])
+
+	// Verify data rows are sorted by key
+	assert.Equal(t, "file-a.txt", records[1][0])
+	assert.Equal(t, "1024", records[1][1])
+	assert.Equal(t, "file-b.jpg", records[2][0])
+	assert.Equal(t, "2048", records[2][1])
+	assert.Equal(t, "folder/file-c.pdf", records[3][0])
+	assert.Equal(t, "3072", records[3][1])
+}
+
+func TestCountingResponseWriter_CapturesStatusCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	cw := &countingResponseWriter{ResponseWriter: w}
+
+	// Act — write header
+	cw.WriteHeader(http.StatusNotFound)
+
+	// Assert
+	assert.Equal(t, http.StatusNotFound, cw.statusCode)
+	assert.True(t, cw.wroteHeader)
+
+	// Second WriteHeader should not change status
+	cw.WriteHeader(http.StatusOK)
+	assert.Equal(t, http.StatusNotFound, cw.statusCode)
+}
+
+func TestCountingResponseWriter_ImplicitOK(t *testing.T) {
+	w := httptest.NewRecorder()
+	cw := &countingResponseWriter{ResponseWriter: w}
+
+	// Act — Write without explicit WriteHeader
+	_, err := cw.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	// Assert — implicit 200
+	assert.Equal(t, http.StatusOK, cw.statusCode)
+	assert.Equal(t, int64(5), cw.bytesWritten)
+}
+
+func TestDetermineOperation_LoggingAndInventory(t *testing.T) {
+	logger := zap.NewNop()
+	parser := NewS3Parser(logger)
+
+	tests := []struct {
+		method string
+		query  map[string]string
+		wantOp string
+	}{
+		{"GET", map[string]string{"logging": ""}, "GetBucketLogging"},
+		{"PUT", map[string]string{"logging": ""}, "PutBucketLogging"},
+		{"GET", map[string]string{"inventory": ""}, "GetBucketInventory"},
+		{"PUT", map[string]string{"inventory": ""}, "PutBucketInventory"},
+		{"DELETE", map[string]string{"inventory": ""}, "DeleteBucketInventory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantOp, func(t *testing.T) {
+			req := &S3Request{
+				Bucket: "test-bucket",
+				Query:  tt.query,
+			}
+			parser.determineOperation(req, tt.method)
+			assert.Equal(t, tt.wantOp, req.Operation)
+		})
+	}
+}
+
+func TestGetBucketInventory_Disabled(t *testing.T) {
+	f := setupInventoryFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("GET", "/"+f.bucket+"?inventory", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	f.server.handleGetBucketInventory(w, r, s3Req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp InventoryConfiguration
+	err := xml.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.False(t, resp.IsEnabled)
+}

--- a/internal/api/s3_logging.go
+++ b/internal/api/s3_logging.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/xml"
+	"io"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const maxLoggingBodyBytes = 4096
+
+// BucketLoggingStatus is the S3 XML response for GET ?logging.
+type BucketLoggingStatus struct {
+	XMLName        xml.Name        `xml:"BucketLoggingStatus"`
+	Xmlns          string          `xml:"xmlns,attr,omitempty"`
+	LoggingEnabled *LoggingEnabled `xml:"LoggingEnabled,omitempty"`
+}
+
+type LoggingEnabled struct {
+	TargetBucket string `xml:"TargetBucket"`
+	TargetPrefix string `xml:"TargetPrefix,omitempty"`
+}
+
+func (s *Server) handleGetBucketLogging(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(xml.Header))
+		_, _ = w.Write([]byte(`<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>`))
+		return
+	}
+
+	var enabled bool
+	var targetBucket, prefix sql.NullString
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT logging_enabled, logging_target_bucket, logging_prefix
+		 FROM buckets WHERE tenant_id = $1 AND name = $2`,
+		t.ID, req.Bucket).Scan(&enabled, &targetBucket, &prefix)
+	if err == sql.ErrNoRows {
+		reqID := generateRequestID()
+		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+		}
+		return
+	}
+	if err != nil {
+		s.logger.Error("query bucket logging config", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	resp := BucketLoggingStatus{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+	}
+	if enabled && targetBucket.Valid && targetBucket.String != "" {
+		resp.LoggingEnabled = &LoggingEnabled{
+			TargetBucket: targetBucket.String,
+			TargetPrefix: prefix.String,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePutBucketLogging(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLoggingBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var config BucketLoggingStatus
+	if err := xml.Unmarshal(body, &config); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	// Verify the source bucket exists.
+	var exists bool
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT EXISTS(SELECT 1 FROM buckets WHERE tenant_id = $1 AND name = $2)`,
+		t.ID, req.Bucket).Scan(&exists)
+	if err != nil || !exists {
+		reqID := generateRequestID()
+		if suggestion := bucketSuggestion(r.Context(), s.db, t.ID, req.Bucket); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchBucket, r.URL.Path, reqID)
+		}
+		return
+	}
+
+	// If LoggingEnabled is nil or empty target, disable logging.
+	if config.LoggingEnabled == nil || config.LoggingEnabled.TargetBucket == "" {
+		_, err = s.db.ExecContext(r.Context(),
+			`UPDATE buckets SET logging_enabled = FALSE, logging_target_bucket = NULL, logging_prefix = '', updated_at = NOW()
+			 WHERE tenant_id = $1 AND name = $2`,
+			t.ID, req.Bucket)
+		if err != nil {
+			s.logger.Error("disable bucket logging", zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+			return
+		}
+		s.logger.Info("bucket logging disabled",
+			zap.String("tenant_id", t.ID),
+			zap.String("bucket", req.Bucket))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	targetBucket := config.LoggingEnabled.TargetBucket
+	targetPrefix := config.LoggingEnabled.TargetPrefix
+
+	// Reject self-referential logging (prevents infinite loops).
+	if targetBucket == req.Bucket {
+		WriteS3ErrorWithContext(w, ErrInvalidRequest, r.URL.Path, generateRequestID(),
+			WithSuggestion("Target bucket must be different from the source bucket to prevent logging loops."))
+		return
+	}
+
+	// Verify target bucket exists and belongs to the same tenant.
+	err = s.db.QueryRowContext(r.Context(),
+		`SELECT EXISTS(SELECT 1 FROM buckets WHERE tenant_id = $1 AND name = $2)`,
+		t.ID, targetBucket).Scan(&exists)
+	if err != nil || !exists {
+		WriteS3ErrorWithContext(w, ErrNoSuchBucket, r.URL.Path, generateRequestID(),
+			WithSuggestion("Target bucket does not exist or belongs to a different account."))
+		return
+	}
+
+	_, err = s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET logging_enabled = TRUE, logging_target_bucket = $3, logging_prefix = $4, updated_at = NOW()
+		 WHERE tenant_id = $1 AND name = $2`,
+		t.ID, req.Bucket, targetBucket, targetPrefix)
+	if err != nil {
+		s.logger.Error("enable bucket logging", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	s.logger.Info("bucket logging enabled",
+		zap.String("tenant_id", t.ID),
+		zap.String("bucket", req.Bucket),
+		zap.String("target_bucket", targetBucket),
+		zap.String("prefix", targetPrefix))
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/api/s3_logging_test.go
+++ b/internal/api/s3_logging_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type loggingFixture struct {
+	server    *Server
+	db        *sql.DB
+	eng       *engine.CoreEngine
+	tenantID  string
+	tenant    *tenant.Tenant
+	tempDir   string
+	bucket    string
+	logBucket string
+}
+
+func setupLoggingFixture(t *testing.T) *loggingFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+
+	tempDir, err := os.MkdirTemp("", "vaultaire-logging-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	eng := engine.NewEngine(nil, logger, nil)
+	driver := drivers.NewLocalDriver(tempDir, logger)
+	eng.AddDriver("local", driver)
+	eng.SetPrimary("local")
+
+	tenantID := fmt.Sprintf("log-%d", os.Getpid())
+	bucket := "source-bucket"
+	logBucket := "log-bucket"
+	email := fmt.Sprintf("log-%d@test.local", os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Logging Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, $2, 'private')
+		ON CONFLICT (tenant_id, name) DO NOTHING
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, $2, 'private')
+		ON CONFLICT (tenant_id, name) DO NOTHING
+	`, tenantID, logBucket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM s3_access_log WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	for _, b := range []string{bucket, logBucket} {
+		container := tn.NamespaceContainer(b)
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, container), 0755))
+	}
+
+	srv := &Server{
+		logger:           logger,
+		router:           chi.NewRouter(),
+		engine:           eng,
+		db:               db,
+		testMode:         true,
+		accessLogTracker: NewS3AccessLogTracker(db),
+	}
+
+	return &loggingFixture{
+		server:    srv,
+		db:        db,
+		eng:       eng,
+		tenantID:  tenantID,
+		tenant:    tn,
+		tempDir:   tempDir,
+		bucket:    bucket,
+		logBucket: logBucket,
+	}
+}
+
+func TestGetBucketLogging_Disabled(t *testing.T) {
+	f := setupLoggingFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("GET", "/"+f.bucket+"?logging", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	f.server.handleGetBucketLogging(w, r, s3Req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/xml")
+
+	var resp BucketLoggingStatus
+	err := xml.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Nil(t, resp.LoggingEnabled)
+}
+
+func TestPutBucketLogging_Enable(t *testing.T) {
+	f := setupLoggingFixture(t)
+
+	// PUT logging config
+	configXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <LoggingEnabled>
+    <TargetBucket>%s</TargetBucket>
+    <TargetPrefix>logs/</TargetPrefix>
+  </LoggingEnabled>
+</BucketLoggingStatus>`, f.logBucket)
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"?logging", bytes.NewReader([]byte(configXML))).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	f.server.handlePutBucketLogging(w, r, s3Req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET should now return the config
+	r2 := httptest.NewRequest("GET", "/"+f.bucket+"?logging", nil).WithContext(ctx)
+	w2 := httptest.NewRecorder()
+	f.server.handleGetBucketLogging(w2, r2, s3Req)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+	var resp BucketLoggingStatus
+	err := xml.Unmarshal(w2.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp.LoggingEnabled)
+	assert.Equal(t, f.logBucket, resp.LoggingEnabled.TargetBucket)
+	assert.Equal(t, "logs/", resp.LoggingEnabled.TargetPrefix)
+}
+
+func TestPutBucketLogging_SameBucket(t *testing.T) {
+	f := setupLoggingFixture(t)
+
+	configXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <LoggingEnabled>
+    <TargetBucket>%s</TargetBucket>
+  </LoggingEnabled>
+</BucketLoggingStatus>`, f.bucket) // self-referential
+
+	s3Req := &S3Request{Bucket: f.bucket, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"?logging", bytes.NewReader([]byte(configXML))).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	f.server.handlePutBucketLogging(w, r, s3Req)
+
+	// Should reject self-referential logging
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -72,6 +72,8 @@ type Server struct {
 	sseService       *crypto.SSEService
 	cdnRateLimiter   *RateLimiter
 	cdnAnalytics     *CDNAnalyticsTracker
+	accessLogTracker *S3AccessLogTracker
+	inventoryRunner  *InventoryRunner
 	emailSender      email.Sender
 	baseURL          string
 	startTime        time.Time
@@ -186,6 +188,16 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	s.cdnAnalytics.SetLogger(logger)
 	s.cdnAnalytics.StartFlusher(context.Background(), 5*time.Second)
 	s.cdnAnalytics.StartRollup(context.Background())
+
+	// S3 access log tracker — buffers access events, delivers log objects to target buckets.
+	s.accessLogTracker = NewS3AccessLogTracker(s.db)
+	s.accessLogTracker.SetLogger(logger)
+	s.accessLogTracker.StartFlusher(context.Background(), 5*time.Second)
+	s.accessLogTracker.StartLogDelivery(context.Background(), s.engine)
+
+	// Inventory report runner — generates CSV inventory reports on schedule.
+	s.inventoryRunner = NewInventoryRunner(s.db, s.engine, logger)
+	s.inventoryRunner.StartInventoryJob(context.Background())
 
 	// Stripe billing service. Only active when STRIPE_SECRET_KEY is set.
 	if stripeKey := os.Getenv("STRIPE_SECRET_KEY"); stripeKey != "" {

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -29,6 +29,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 035 | CDN analytics: `cdn_access_log` (per-request log), `cdn_stats_daily` (tenant+bucket+date rollup) |
 | 036 | MFA Delete: `mfa_delete_enabled` BOOLEAN on `buckets` (default FALSE) |
 | 038 | Account deletion: `deletion_scheduled_at` + `deletion_reason` on users, `account_exports` table |
+| 040 | S3 access logging + inventory: `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format` on `buckets`; `s3_access_log` table |
 
 ## Key Tables
 
@@ -39,7 +40,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`
 - **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT)
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
@@ -54,6 +55,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **cdn_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `bytes_sent`, `country`, `referer`, `accessed_at` — raw CDN access events
 - **cdn_stats_daily** — `(tenant_id, bucket, date) PK`, `requests`, `bytes_sent`, `unique_objects` — daily CDN rollup
 - **account_exports** — `id (UUID PK)`, `user_id → users`, `tenant_id`, `status` (pending/processing/completed/failed), `format`, `file_path`, `file_size_bytes`, `error_message`, `created_at`, `completed_at`, `expires_at` — GDPR data export tracking
+- **s3_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `operation`, `status_code`, `bytes_sent`, `bytes_received`, `source_ip`, `user_agent`, `request_id`, `error_code`, `logged_at` — buffered S3 access events, delivered as log objects to target buckets
 
 ## Connection
 

--- a/internal/database/migrations/040_access_logging.sql
+++ b/internal/database/migrations/040_access_logging.sql
@@ -1,0 +1,33 @@
+-- 040_access_logging.sql: S3 server access logging and inventory report configuration.
+
+-- Per-bucket logging configuration.
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS logging_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS logging_target_bucket TEXT;
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS logging_prefix TEXT NOT NULL DEFAULT '';
+
+-- Per-bucket inventory report configuration.
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS inventory_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS inventory_schedule TEXT NOT NULL DEFAULT 'daily';
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS inventory_target_bucket TEXT;
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS inventory_prefix TEXT NOT NULL DEFAULT '';
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS inventory_format TEXT NOT NULL DEFAULT 'csv';
+
+-- S3 access log table: buffered writes from S3AccessLogTracker, delivered as
+-- log objects to the target bucket by the log delivery goroutine.
+CREATE TABLE IF NOT EXISTS s3_access_log (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    object_key TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    bytes_received BIGINT NOT NULL DEFAULT 0,
+    source_ip TEXT NOT NULL DEFAULT '',
+    user_agent TEXT NOT NULL DEFAULT '',
+    request_id TEXT NOT NULL DEFAULT '',
+    error_code TEXT NOT NULL DEFAULT '',
+    logged_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_s3_access_log_tenant_bucket ON s3_access_log (tenant_id, bucket, logged_at);


### PR DESCRIPTION
## Summary

- **S3 Server Access Logging**: Per-bucket access logging with buffered writes to `s3_access_log` table and async delivery to a configurable target bucket as S3-format log objects. Includes self-referential logging rejection and same-tenant validation.
- **S3 Inventory Reports**: Per-bucket inventory reports (daily/weekly) that export all objects from `object_head_cache` as CSV to a target bucket. `InventoryRunner` background job runs at midnight UTC.
- **Migration 040**: Adds logging and inventory columns to `buckets` table, creates `s3_access_log` table with tenant/bucket/time index.
- **countingResponseWriter**: Now captures HTTP status code via `WriteHeader` override for access log recording.
- S3 API operations: `GET/PUT ?logging`, `GET/PUT/DELETE ?inventory` wired into `determineOperation` and the handler switch.

## Architecture

- Two-stage access log pipeline: buffered Record → DB table → delivery goroutine writes log objects to target bucket
- Inventory reads from `object_head_cache` (PostgreSQL) — instant regardless of backend object count
- SOC 2 evidence (CC7.1) and enterprise migration requirements

## Test plan

- [x] `TestS3AccessLogTracker_Record` — buffer fills correctly
- [x] `TestS3AccessLogTracker_AutoFlushAt100` — auto-flush at 100 events
- [x] `TestS3AccessLogTracker_Flush` — events cleared from buffer
- [x] `TestS3AccessLogTracker_NilDB` — no panic on nil DB
- [x] `TestS3AccessLogTracker_SkipsEmptyTenantOrBucket` — empty tenant/bucket skipped
- [x] `TestAccessLogFormat` — log line format matches S3 spec
- [x] `TestAccessLogFormat_EmptyFields` — empty fields render as "-"
- [x] `TestGetBucketLogging_Disabled` — returns empty XML when disabled
- [x] `TestPutBucketLogging_Enable` — sets logging config, GET returns it
- [x] `TestPutBucketLogging_SameBucket` — rejects self-referential logging (400)
- [x] `TestPutBucketInventory_Enable` — sets inventory config, GET returns it
- [x] `TestDeleteBucketInventory` — disables inventory, GET returns disabled
- [x] `TestInventoryCSV_Format` — CSV has correct columns, data sorted by key
- [x] `TestCountingResponseWriter_CapturesStatusCode` — WriteHeader captures status
- [x] `TestCountingResponseWriter_ImplicitOK` — Write without WriteHeader = 200
- [x] `TestDetermineOperation_LoggingAndInventory` — 5 new operations route correctly
- [x] Full test suite passes with race detector, zero lint issues