### PR TITLE
feat(dashboard): customer compliance dashboard [Phase 5.14.10]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -87,6 +87,8 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/dashboard/billing` | GET | session | Billing: plan, upgrade, value stack, cost comparison |
 | `/dashboard/billing/upgrade` | POST | session | Redirect to Stripe Checkout for chosen plan |
 | `/dashboard/billing/portal` | POST | session | Redirect to Stripe Billing Portal |
+| `/dashboard/compliance` | GET | session | Compliance dashboard: per-bucket security posture, score |
+| `/dashboard/compliance/export` | GET | session | Download compliance report as JSON |
 | `/dashboard/settings/export` | POST | session | Download all user data as JSON (GDPR Article 20) |
 | `/dashboard/settings/delete-account` | POST | session | Schedule account deletion with 30-day grace (GDPR Article 17) |
 | `/dashboard/settings/cancel-deletion` | POST | session | Cancel pending account deletion |

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -115,6 +115,14 @@ Three handlers for GDPR compliance (Phase 5.14.1):
 
 `populateDeletionStatus(ctx, db, userID, data)` in `settings.go` queries `deletion_scheduled_at` from users and populates `DeletionScheduled` + `DeletionDate` template data.
 
+## Compliance Dashboard (`compliance.go`)
+
+Two handlers:
+- `HandleCompliance(tmpl, db, logger)` — GET `/dashboard/compliance`. Queries all buckets for the tenant with compliance-relevant columns (SSE, Object Lock, versioning, logging, inventory, MFA delete). Computes per-bucket `IsFullyCompliant` (SSE + logging + versioning) and overall `ComplianceScore` (percentage of compliant buckets). Degrades to empty state when DB is nil.
+- `HandleComplianceExport(db, logger)` — GET `/dashboard/compliance/export`. Same data as above, serialized as JSON with `Content-Disposition: attachment` header. Filename: `compliance-report-{date}.json`.
+
+Shared `queryComplianceData(r, db, tenantID)` helper queries buckets table + `object_head_cache` for encryption percentages. Template: `templates/customer/compliance.html`.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/compliance.go
+++ b/internal/dashboard/handlers/compliance.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/drivers"
+	"go.uber.org/zap"
+)
+
+type BucketCompliance struct {
+	Name              string `json:"name"`
+	Region            string `json:"region"`
+	RegionDisplay     string `json:"region_display"`
+	IsEURegion        bool   `json:"is_eu_region"`
+	SSEEnabled        bool   `json:"sse_enabled"`
+	ObjectLockEnabled bool   `json:"object_lock_enabled"`
+	RetentionMode     string `json:"retention_mode,omitempty"`
+	RetentionDays     int    `json:"retention_days,omitempty"`
+	VersioningEnabled bool   `json:"versioning_enabled"`
+	LoggingEnabled    bool   `json:"logging_enabled"`
+	InventoryEnabled  bool   `json:"inventory_enabled"`
+	MFADeleteEnabled  bool   `json:"mfa_delete_enabled"`
+	EncryptedObjects  int64  `json:"encrypted_objects"`
+	TotalObjects      int64  `json:"total_objects"`
+	EncryptionPct     int    `json:"encryption_pct"`
+	IsFullyCompliant  bool   `json:"is_fully_compliant"`
+}
+
+type complianceReport struct {
+	GeneratedAt      string             `json:"generated_at"`
+	ComplianceScore  int                `json:"compliance_score"`
+	TotalBuckets     int                `json:"total_buckets"`
+	CompliantBuckets int                `json:"compliant_buckets"`
+	Buckets          []BucketCompliance `json:"buckets"`
+}
+
+func HandleCompliance(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "compliance")
+		buckets, score, compliant := queryComplianceData(r, db, sd.TenantID)
+
+		data["Buckets"] = buckets
+		data["ComplianceScore"] = score
+		data["TotalBuckets"] = len(buckets)
+		data["CompliantBuckets"] = compliant
+		data["HasBuckets"] = len(buckets) > 0
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", data); err != nil {
+			logger.Error("render compliance", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func HandleComplianceExport(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		buckets, score, compliant := queryComplianceData(r, db, sd.TenantID)
+
+		report := complianceReport{
+			GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
+			ComplianceScore:  score,
+			TotalBuckets:     len(buckets),
+			CompliantBuckets: compliant,
+			Buckets:          buckets,
+		}
+
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			logger.Error("marshal compliance report", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		filename := fmt.Sprintf("compliance-report-%s.json", time.Now().Format("2006-01-02"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+		_, _ = w.Write(out)
+	}
+}
+
+func queryComplianceData(r *http.Request, db *sql.DB, tenantID string) ([]BucketCompliance, int, int) {
+	if db == nil {
+		return nil, 0, 0
+	}
+
+	rows, err := db.QueryContext(r.Context(), `
+		SELECT name, region, sse_enabled, object_lock_enabled,
+		       default_retention_mode, default_retention_days,
+		       versioning_status, logging_enabled, inventory_enabled,
+		       mfa_delete_enabled
+		FROM buckets WHERE tenant_id = $1 ORDER BY name ASC`, tenantID)
+	if err != nil {
+		return nil, 0, 0
+	}
+	defer func() { _ = rows.Close() }()
+
+	var buckets []BucketCompliance
+	for rows.Next() {
+		var b BucketCompliance
+		var versioningStatus string
+		if err := rows.Scan(
+			&b.Name, &b.Region, &b.SSEEnabled, &b.ObjectLockEnabled,
+			&b.RetentionMode, &b.RetentionDays,
+			&versioningStatus, &b.LoggingEnabled, &b.InventoryEnabled,
+			&b.MFADeleteEnabled,
+		); err != nil {
+			continue
+		}
+
+		b.RegionDisplay = drivers.RegionDisplayName(b.Region)
+		b.IsEURegion = drivers.IsEURegion(b.Region)
+		b.VersioningEnabled = versioningStatus == "Enabled"
+
+		_ = db.QueryRowContext(r.Context(), `
+			SELECT COUNT(*) FROM object_head_cache
+			WHERE tenant_id = $1 AND bucket = $2 AND encryption_algorithm != ''`,
+			tenantID, b.Name).Scan(&b.EncryptedObjects)
+
+		_ = db.QueryRowContext(r.Context(), `
+			SELECT COUNT(*) FROM object_head_cache
+			WHERE tenant_id = $1 AND bucket = $2`,
+			tenantID, b.Name).Scan(&b.TotalObjects)
+
+		if b.TotalObjects > 0 {
+			b.EncryptionPct = int(b.EncryptedObjects * 100 / b.TotalObjects)
+		}
+
+		b.IsFullyCompliant = b.SSEEnabled && b.LoggingEnabled && b.VersioningEnabled
+
+		buckets = append(buckets, b)
+	}
+
+	compliant := 0
+	for _, b := range buckets {
+		if b.IsFullyCompliant {
+			compliant++
+		}
+	}
+
+	score := 0
+	if len(buckets) > 0 {
+		score = compliant * 100 / len(buckets)
+	}
+
+	return buckets, score, compliant
+}

--- a/internal/dashboard/handlers/compliance_test.go
+++ b/internal/dashboard/handlers/compliance_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testComplianceTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{block "nav" .}}{{end}}` +
+			`{{block "content" .}}{{end}}` +
+			`{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Compliance{{end}}` +
+			`{{define "content"}}` +
+			`<span class="score">{{.ComplianceScore}}</span>` +
+			`<span class="total">{{.TotalBuckets}}</span>` +
+			`<span class="compliant">{{.CompliantBuckets}}</span>` +
+			`<span class="has">{{.HasBuckets}}</span>` +
+			`{{range .Buckets}}<span class="bucket">{{.Name}}:{{.IsFullyCompliant}}</span>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleCompliance_NoSession(t *testing.T) {
+	// Arrange
+	tmpl := testComplianceTemplate(t)
+	handler := HandleCompliance(tmpl, nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/compliance", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleCompliance_NilDB(t *testing.T) {
+	// Arrange
+	tmpl := testComplianceTemplate(t)
+	handler := HandleCompliance(tmpl, nil, zap.NewNop())
+
+	sd := &dashauth.SessionData{
+		UserID: "user-1", TenantID: "tenant-1",
+		Email: "test@stored.ge", Role: "user",
+	}
+
+	req := httptest.NewRequest("GET", "/dashboard/compliance", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="score">0</span>`)
+	assert.Contains(t, body, `<span class="total">0</span>`)
+	assert.Contains(t, body, `<span class="compliant">0</span>`)
+	assert.Contains(t, body, `<span class="has">false</span>`)
+}
+
+func TestHandleComplianceExport_NoSession(t *testing.T) {
+	// Arrange
+	handler := HandleComplianceExport(nil, zap.NewNop())
+
+	req := httptest.NewRequest("GET", "/dashboard/compliance/export", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleComplianceExport_NilDB(t *testing.T) {
+	// Arrange
+	handler := HandleComplianceExport(nil, zap.NewNop())
+
+	sd := &dashauth.SessionData{
+		UserID: "user-1", TenantID: "tenant-1",
+		Email: "test@stored.ge", Role: "user",
+	}
+
+	req := httptest.NewRequest("GET", "/dashboard/compliance/export", nil)
+	ctx := context.WithValue(req.Context(), dashauth.SessionKey, sd)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "compliance-report-")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".json")
+
+	var report complianceReport
+	err := json.Unmarshal(w.Body.Bytes(), &report)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.ComplianceScore)
+	assert.Equal(t, 0, report.TotalBuckets)
+	assert.Empty(t, report.Buckets)
+}
+
+func TestBucketCompliance_IsFullyCompliant(t *testing.T) {
+	tests := []struct {
+		name      string
+		sse       bool
+		logging   bool
+		version   bool
+		compliant bool
+	}{
+		{"all enabled", true, true, true, true},
+		{"missing sse", false, true, true, false},
+		{"missing logging", true, false, true, false},
+		{"missing versioning", true, true, false, false},
+		{"all disabled", false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := BucketCompliance{
+				SSEEnabled:        tt.sse,
+				LoggingEnabled:    tt.logging,
+				VersioningEnabled: tt.version,
+			}
+			got := b.SSEEnabled && b.LoggingEnabled && b.VersioningEnabled
+			assert.Equal(t, tt.compliant, got)
+		})
+	}
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -211,6 +211,14 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		dr.Get("/billing", handlers.HandleBilling(billingTmpl, deps.Stripe, deps.DB, deps.Logger))
 		dr.Post("/billing/upgrade", handlers.HandleUpgrade(deps.Stripe, deps.DB, deps.Logger))
 		dr.Post("/billing/portal", handlers.HandleManageBilling(deps.Stripe, deps.Logger))
+
+		// Compliance dashboard.
+		complianceTmpl := template.Must(baseTmpl.Clone())
+		template.Must(complianceTmpl.ParseFS(Templates,
+			"templates/customer/compliance.html",
+		))
+		dr.Get("/compliance", handlers.HandleCompliance(complianceTmpl, deps.DB, deps.Logger))
+		dr.Get("/compliance/export", handlers.HandleComplianceExport(deps.DB, deps.Logger))
 	})
 
 	// --- Admin (session + admin role required) ---

--- a/internal/dashboard/templates/customer/compliance.html
+++ b/internal/dashboard/templates/customer/compliance.html
@@ -1,0 +1,83 @@
+{{define "title"}}Compliance — stored.ge{{end}}
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h1>Compliance</h1>
+        <p class="text-muted">Security posture across all buckets</p>
+    </div>
+    {{if .HasBuckets}}
+    <a href="/dashboard/compliance/export" class="btn">Download Report</a>
+    {{end}}
+</div>
+
+<nav class="breadcrumb">
+    <a href="/dashboard/">Dashboard</a> /
+    <strong>Compliance</strong>
+</nav>
+
+{{if not .HasBuckets}}
+<div class="card" style="text-align:center;padding:3rem 1.5rem;">
+    <div style="font-size:2rem;margin-bottom:0.75rem;">&#128274;</div>
+    <h2 style="margin-bottom:0.5rem;">No buckets yet</h2>
+    <p class="text-muted">Create a bucket to see its compliance status here.</p>
+    <a href="/dashboard/buckets" class="btn btn-primary" style="margin-top:1rem;">Create Bucket</a>
+</div>
+{{else}}
+
+<div class="stats-grid stats-grid-3">
+    <div class="stat-card">
+        <div class="stat-label">Compliance Score</div>
+        <div class="stat-value" style="color:{{if ge .ComplianceScore 80}}var(--success){{else if ge .ComplianceScore 50}}var(--warning, #e6a817){{else}}var(--danger){{end}}">{{.ComplianceScore}}%</div>
+        <div class="stat-sub">{{if ge .ComplianceScore 80}}Good standing{{else if ge .ComplianceScore 50}}Needs attention{{else}}Action required{{end}}</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Total Buckets</div>
+        <div class="stat-value">{{.TotalBuckets}}</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Fully Compliant</div>
+        <div class="stat-value">{{.CompliantBuckets}}</div>
+        <div class="stat-sub">Encryption + Logging + Versioning</div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Bucket Security Posture</div>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Bucket</th>
+                    <th>Region</th>
+                    <th style="text-align:center">Encryption</th>
+                    <th style="text-align:center">Object Lock</th>
+                    <th style="text-align:center">Versioning</th>
+                    <th style="text-align:center">Logging</th>
+                    <th style="text-align:center">Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Buckets}}
+                <tr>
+                    <td><a href="/dashboard/buckets/{{.Name}}/settings">{{.Name}}</a></td>
+                    <td>{{.RegionDisplay}}{{if .IsEURegion}} <span class="badge badge-info" style="font-size:0.7rem;">EU</span>{{end}}</td>
+                    <td style="text-align:center">{{if .SSEEnabled}}<span style="color:var(--success)">&#10003;</span>{{else}}<span style="color:var(--danger)">&#10007;</span>{{end}}</td>
+                    <td style="text-align:center">{{if .ObjectLockEnabled}}<span style="color:var(--success)">&#10003;</span>{{else}}<span style="color:var(--danger)">&#10007;</span>{{end}}</td>
+                    <td style="text-align:center">{{if .VersioningEnabled}}<span style="color:var(--success)">&#10003;</span>{{else}}<span style="color:var(--danger)">&#10007;</span>{{end}}</td>
+                    <td style="text-align:center">{{if .LoggingEnabled}}<span style="color:var(--success)">&#10003;</span>{{else}}<span style="color:var(--danger)">&#10007;</span>{{end}}</td>
+                    <td style="text-align:center">
+                        {{if .IsFullyCompliant}}
+                        <span class="badge badge-success">Compliant</span>
+                        {{else}}
+                        <span class="badge badge-warning">Non-compliant</span>
+                        {{end}}
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{{end}}
+{{end}}

--- a/internal/dashboard/templates/customer/dashboard.html
+++ b/internal/dashboard/templates/customer/dashboard.html
@@ -276,5 +276,6 @@ curl -X PUT https://stored.ge/my-first-bucket/hello.txt \
     <a href="/dashboard/usage" class="btn">View Usage</a>
     <a href="/dashboard/settings" class="btn">Settings</a>
     <a href="/dashboard/billing" class="btn">Billing</a>
+    <a href="/dashboard/compliance" class="btn">Compliance</a>
 </div>
 {{end}}


### PR DESCRIPTION
Customer-facing compliance dashboard at `/dashboard/compliance` with per-bucket compliance status (encryption, object lock, versioning, logging) and a CSV export at `/dashboard/compliance/export`.

Stacked on the 5.14.x access-logging stack (PR #262). Merge after #258–#262.

- New: `handlers/compliance.go`, `compliance_test.go`, `templates/customer/compliance.html`
- Routes wired in `router.go`; dashboard nav link added
- Docs updated in dashboard CLAUDE.md files

Tests: `go test -short ./internal/dashboard/...` green.