### PR TITLE
feat(s3): per-object tagging via ?tagging sub-resource [Phase 5.10.17]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -23,6 +23,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **access_log.go** — S3AccessLogTracker: buffered S3 access event writer (Record/Flush) + log delivery to target buckets
 - **s3_logging.go** — GET/PUT ?logging handlers for per-bucket server access logging config
 - **s3_inventory.go** — GET/PUT/DELETE ?inventory handlers + InventoryRunner background job for CSV reports
+- **s3_tagging.go** — GET/PUT/DELETE ?tagging handlers for per-object tags + `tagCount` helper for x-amz-tagging-count
 - **management.go** — JSON response helpers: `writeJSON`, `writeListResponse`, `getRequestID` (Stripe-style envelope)
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
@@ -299,6 +300,29 @@ Per-bucket inventory reports (daily/weekly CSV export of all objects to a destin
 **Inventory object key**: `{prefix}{source_bucket}/{YYYY-MM-DD}T00-00Z/manifest.csv`
 
 **Tables**: `buckets.inventory_enabled`, `buckets.inventory_schedule`, `buckets.inventory_target_bucket`, `buckets.inventory_prefix`, `buckets.inventory_format` (migration 040).
+
+## Object Tagging (Phase 5.10.17)
+
+S3-compatible per-object tagging via the `?tagging` sub-resource. Tags are a flat
+key/value map stored in `object_head_cache.tags` (JSONB), distinct from `metadata`
+(x-amz-meta-* headers). Used by rclone, lifecycle policies, cost allocation, and IAM
+policy conditions.
+
+**S3 API operations** (handlers in `s3_tagging.go`):
+- `GET /{bucket}/{key}?tagging` → `handleGetObjectTagging` — returns `<Tagging><TagSet>` XML; NoSuchKey (404) if object absent
+- `PUT /{bucket}/{key}?tagging` → `handlePutObjectTagging` — **replaces** the entire tag set (not a merge); returns 200 + `x-amz-version-id: null`
+- `DELETE /{bucket}/{key}?tagging` → `handleDeleteObjectTagging` — resets tags to `'{}'`; returns 204
+
+**Validation** (PUT, returns `InvalidTag` 400 on failure): max 10 tags, key ≤ 128 chars,
+value ≤ 256 chars, no empty keys, no duplicate keys.
+
+**x-amz-tagging-count**: HEAD (`s3.go handleHeadObject`) and GET (`s3_engine_adapter.go HandleGet`)
+emit this header (count of tags) only when > 0, matching AWS. Both SELECT `COALESCE(tags, '{}')`
+and count via the `tagCount` helper.
+
+**Error code**: `ErrInvalidTag` in `s3_errors.go` (400, "The tag provided was not valid.").
+
+**Table**: `object_head_cache.tags` JSONB (migration 041).
 
 ## Tenant Context
 

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -168,6 +168,8 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 			req.Operation = "GetObjectLegalHold"
 		} else if _, ok := req.Query["uploadId"]; ok {
 			req.Operation = "ListParts"
+		} else if _, ok := req.Query["tagging"]; ok {
+			req.Operation = "GetObjectTagging"
 		} else {
 			req.Operation = "GetObject"
 		}
@@ -178,12 +180,16 @@ func (p *S3Parser) determineOperation(req *S3Request, method string) {
 			req.Operation = "PutObjectLegalHold"
 		} else if _, ok := req.Query["partNumber"]; ok {
 			req.Operation = "UploadPart"
+		} else if _, ok := req.Query["tagging"]; ok {
+			req.Operation = "PutObjectTagging"
 		} else {
 			req.Operation = "PutObject"
 		}
 	case "DELETE":
 		if _, ok := req.Query["uploadId"]; ok {
 			req.Operation = "AbortMultipartUpload"
+		} else if _, ok := req.Query["tagging"]; ok {
+			req.Operation = "DeleteObjectTagging"
 		} else {
 			req.Operation = "DeleteObject"
 		}
@@ -510,6 +516,12 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 		s.handlePutBucketInventory(cw, r, s3Req)
 	case "DeleteBucketInventory":
 		s.handleDeleteBucketInventory(cw, r, s3Req)
+	case "GetObjectTagging":
+		s.handleGetObjectTagging(cw, r, s3Req)
+	case "PutObjectTagging":
+		s.handlePutObjectTagging(cw, r, s3Req)
+	case "DeleteObjectTagging":
+		s.handleDeleteObjectTagging(cw, r, s3Req)
 	default:
 		s.logger.Warn("operation not implemented",
 			zap.String("operation", s3Req.Operation))
@@ -579,12 +591,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	var metadataJSON []byte
 	var backendName string
 	var encAlgo string
+	var tagsJSON []byte
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, '')
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName, &encAlgo)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName, &encAlgo, &tagsJSON)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -632,6 +645,9 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 		w.Header().Set("x-amz-server-side-encryption", "AES256")
 	}
 	setS3MetadataHeaders(w, metadataJSON)
+	if n := tagCount(tagsJSON); n > 0 {
+		w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
+	}
 	// HEAD must not write a body.
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -211,13 +211,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedMetadata []byte
 	var cachedBackendName string
 	var cachedEncAlgo string
+	var cachedTags []byte
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, '')
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}')
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo, &cachedTags)
 		if err == nil {
 			cacheHit = true
 		}
@@ -362,6 +363,9 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 			w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
 		}
 		setS3MetadataHeaders(w, cachedMetadata)
+		if n := tagCount(cachedTags); n > 0 {
+			w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
+		}
 	}
 
 	written, err := io.Copy(w, dataReader)

--- a/internal/api/s3_errors.go
+++ b/internal/api/s3_errors.go
@@ -56,6 +56,7 @@ const (
 	ErrServiceUnavailable                = "ServiceUnavailable"
 	ErrInvalidBucketState                = "InvalidBucketState"
 	ErrInvalidLocationConstraint         = "InvalidLocationConstraint"
+	ErrInvalidTag                        = "InvalidTag"
 )
 
 // Error messages
@@ -95,6 +96,7 @@ var errorMessages = map[string]string{
 	ErrServiceUnavailable:                "All storage backends are temporarily unavailable. Please retry.",
 	ErrInvalidBucketState:                "The request is not valid for the current state of the bucket.",
 	ErrInvalidLocationConstraint:         "The specified location constraint is not valid.",
+	ErrInvalidTag:                        "The tag provided was not valid.",
 }
 
 // HTTP status codes for errors
@@ -134,6 +136,7 @@ var errorStatusCodes = map[string]int{
 	ErrServiceUnavailable:                http.StatusServiceUnavailable,
 	ErrInvalidBucketState:                http.StatusConflict,
 	ErrInvalidLocationConstraint:         http.StatusBadRequest,
+	ErrInvalidTag:                        http.StatusBadRequest,
 }
 
 // WriteS3Error writes an S3-compatible error response

--- a/internal/api/s3_tagging.go
+++ b/internal/api/s3_tagging.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"go.uber.org/zap"
+)
+
+const (
+	maxTaggingBodyBytes = 10240 // 10 KB
+	maxObjectTags       = 10
+	maxTagKeyLen        = 128
+	maxTagValueLen      = 256
+)
+
+// Tagging is the S3 XML document for object tagging (GET/PUT ?tagging).
+type Tagging struct {
+	XMLName xml.Name `xml:"Tagging"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	TagSet  TagSet   `xml:"TagSet"`
+}
+
+// TagSet wraps the list of tags.
+type TagSet struct {
+	Tags []Tag `xml:"Tag"`
+}
+
+// Tag is a single key/value tag.
+type Tag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// tagCount returns the number of tags in a JSONB tag map. Returns 0 for empty
+// or malformed input. Used to emit x-amz-tagging-count on HEAD and GET.
+func tagCount(tagsJSON []byte) int {
+	if len(tagsJSON) == 0 {
+		return 0
+	}
+	tagMap := map[string]string{}
+	if err := json.Unmarshal(tagsJSON, &tagMap); err != nil {
+		return 0
+	}
+	return len(tagMap)
+}
+
+// handleGetObjectTagging returns the tag set for an object as XML.
+func (s *Server) handleGetObjectTagging(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var tagsJSON []byte
+	err = s.db.QueryRowContext(r.Context(), `
+		SELECT COALESCE(tags, '{}')
+		FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		t.ID, req.Bucket, req.Object).Scan(&tagsJSON)
+	if err == sql.ErrNoRows {
+		reqID := generateRequestID()
+		if suggestion := keySuggestion(r.Context(), s.db, t.ID, req.Bucket, req.Object); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchKey, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, reqID)
+		}
+		return
+	}
+	if err != nil {
+		s.logger.Error("query object tags", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	tagMap := map[string]string{}
+	if len(tagsJSON) > 0 {
+		_ = json.Unmarshal(tagsJSON, &tagMap)
+	}
+
+	resp := Tagging{Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/"}
+	for k, v := range tagMap {
+		resp.TagSet.Tags = append(resp.TagSet.Tags, Tag{Key: k, Value: v})
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+// handlePutObjectTagging replaces the entire tag set for an object. It is not a
+// merge — the provided tag set fully replaces any existing tags.
+func (s *Server) handlePutObjectTagging(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxTaggingBodyBytes))
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	var doc Tagging
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		WriteS3Error(w, ErrMalformedXML, r.URL.Path, generateRequestID())
+		return
+	}
+
+	// Validate and build the tag map.
+	if len(doc.TagSet.Tags) > maxObjectTags {
+		WriteS3ErrorWithContext(w, ErrInvalidTag, r.URL.Path, generateRequestID(),
+			WithSuggestion("An object cannot have more than 10 tags."))
+		return
+	}
+	tagMap := make(map[string]string, len(doc.TagSet.Tags))
+	for _, tag := range doc.TagSet.Tags {
+		if tag.Key == "" {
+			WriteS3ErrorWithContext(w, ErrInvalidTag, r.URL.Path, generateRequestID(),
+				WithSuggestion("Tag keys must not be empty."))
+			return
+		}
+		if len(tag.Key) > maxTagKeyLen {
+			WriteS3ErrorWithContext(w, ErrInvalidTag, r.URL.Path, generateRequestID(),
+				WithSuggestion("Tag keys may be at most 128 characters."))
+			return
+		}
+		if len(tag.Value) > maxTagValueLen {
+			WriteS3ErrorWithContext(w, ErrInvalidTag, r.URL.Path, generateRequestID(),
+				WithSuggestion("Tag values may be at most 256 characters."))
+			return
+		}
+		if _, dup := tagMap[tag.Key]; dup {
+			WriteS3ErrorWithContext(w, ErrInvalidTag, r.URL.Path, generateRequestID(),
+				WithSuggestion("Duplicate tag keys are not allowed."))
+			return
+		}
+		tagMap[tag.Key] = tag.Value
+	}
+
+	tagsJSON, err := json.Marshal(tagMap)
+	if err != nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	res, err := s.db.ExecContext(r.Context(), `
+		UPDATE object_head_cache SET tags = $4
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		t.ID, req.Bucket, req.Object, tagsJSON)
+	if err != nil {
+		s.logger.Error("update object tags", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		reqID := generateRequestID()
+		if suggestion := keySuggestion(r.Context(), s.db, t.ID, req.Bucket, req.Object); suggestion != "" {
+			WriteS3ErrorWithContext(w, ErrNoSuchKey, r.URL.Path, reqID, WithSuggestion(suggestion))
+		} else {
+			WriteS3Error(w, ErrNoSuchKey, r.URL.Path, reqID)
+		}
+		return
+	}
+
+	w.Header().Set("x-amz-version-id", "null")
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleDeleteObjectTagging removes all tags from an object (resets to '{}').
+func (s *Server) handleDeleteObjectTagging(w http.ResponseWriter, r *http.Request, req *S3Request) {
+	t, err := tenant.FromContext(r.Context())
+	if err != nil || t == nil {
+		WriteS3Error(w, ErrAccessDenied, r.URL.Path, generateRequestID())
+		return
+	}
+
+	if s.db == nil {
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	_, err = s.db.ExecContext(r.Context(), `
+		UPDATE object_head_cache SET tags = '{}'
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		t.ID, req.Bucket, req.Object)
+	if err != nil {
+		s.logger.Error("delete object tags", zap.Error(err))
+		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/s3_tagging_test.go
+++ b/internal/api/s3_tagging_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/engine"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/lib/pq"
+)
+
+type taggingFixture struct {
+	server   *Server
+	db       *sql.DB
+	tenantID string
+	tenant   *tenant.Tenant
+	bucket   string
+	object   string
+}
+
+func setupTaggingFixture(t *testing.T) *taggingFixture {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	logger := zap.NewNop()
+	eng := engine.NewEngine(nil, logger, nil)
+
+	tenantID := fmt.Sprintf("tag-%d", os.Getpid())
+	bucket := "tag-bucket"
+	object := "doc.txt"
+	email := fmt.Sprintf("tag-%d@test.local", os.Getpid())
+
+	_, err = db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tenantID, "Tagging Test", email, "AK-"+tenantID, "SK-"+tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO buckets (tenant_id, name, visibility)
+		VALUES ($1, $2, 'private')
+		ON CONFLICT (tenant_id, name) DO NOTHING
+	`, tenantID, bucket)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, 5, 'abc123', 'text/plain')
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET tags = '{}'
+	`, tenantID, bucket, object)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM buckets WHERE tenant_id = $1", tenantID)
+		_, _ = db.Exec("DELETE FROM tenants WHERE id = $1", tenantID)
+	})
+
+	tn := &tenant.Tenant{
+		ID:        tenantID,
+		Namespace: "tenant/" + tenantID + "/",
+	}
+
+	srv := &Server{
+		logger:   logger,
+		router:   chi.NewRouter(),
+		engine:   eng,
+		db:       db,
+		testMode: true,
+	}
+
+	return &taggingFixture{
+		server:   srv,
+		db:       db,
+		tenantID: tenantID,
+		tenant:   tn,
+		bucket:   bucket,
+		object:   object,
+	}
+}
+
+func (f *taggingFixture) get(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	s3Req := &S3Request{Bucket: f.bucket, Object: f.object, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("GET", "/"+f.bucket+"/"+f.object+"?tagging", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handleGetObjectTagging(w, r, s3Req)
+	return w
+}
+
+func (f *taggingFixture) put(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	s3Req := &S3Request{Bucket: f.bucket, Object: f.object, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"/"+f.object+"?tagging", bytes.NewReader([]byte(body))).WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutObjectTagging(w, r, s3Req)
+	return w
+}
+
+func taggingXML(tags ...[2]string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet>`)
+	for _, tag := range tags {
+		fmt.Fprintf(&b, `<Tag><Key>%s</Key><Value>%s</Value></Tag>`, tag[0], tag[1])
+	}
+	b.WriteString(`</TagSet></Tagging>`)
+	return b.String()
+}
+
+func TestGetObjectTagging_NoTags(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	w := f.get(t)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/xml")
+
+	var resp Tagging
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.TagSet.Tags)
+}
+
+func TestPutObjectTagging_Valid(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	w := f.put(t, taggingXML([2]string{"env", "prod"}, [2]string{"team", "storage"}, [2]string{"cost", "infra"}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null", w.Header().Get("x-amz-version-id"))
+}
+
+func TestGetObjectTagging_AfterPut(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	wp := f.put(t, taggingXML([2]string{"env", "prod"}, [2]string{"team", "storage"}))
+	require.Equal(t, http.StatusOK, wp.Code)
+
+	w := f.get(t)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp Tagging
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.TagSet.Tags, 2)
+
+	got := map[string]string{}
+	for _, tag := range resp.TagSet.Tags {
+		got[tag.Key] = tag.Value
+	}
+	assert.Equal(t, "prod", got["env"])
+	assert.Equal(t, "storage", got["team"])
+}
+
+func TestPutObjectTagging_TooMany(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	tags := make([][2]string, 11)
+	for i := range tags {
+		tags[i] = [2]string{fmt.Sprintf("k%d", i), "v"}
+	}
+	w := f.put(t, taggingXML(tags...))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrInvalidTag)
+}
+
+func TestPutObjectTagging_KeyTooLong(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	w := f.put(t, taggingXML([2]string{strings.Repeat("k", 129), "v"}))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrInvalidTag)
+}
+
+func TestPutObjectTagging_ValueTooLong(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	w := f.put(t, taggingXML([2]string{"k", strings.Repeat("v", 257)}))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrInvalidTag)
+}
+
+func TestDeleteObjectTagging(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	wp := f.put(t, taggingXML([2]string{"env", "prod"}))
+	require.Equal(t, http.StatusOK, wp.Code)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: f.object, TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("DELETE", "/"+f.bucket+"/"+f.object+"?tagging", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handleDeleteObjectTagging(w, r, s3Req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	wg := f.get(t)
+	require.Equal(t, http.StatusOK, wg.Code)
+	var resp Tagging
+	require.NoError(t, xml.Unmarshal(wg.Body.Bytes(), &resp))
+	assert.Empty(t, resp.TagSet.Tags)
+}
+
+func TestPutObjectTagging_ObjectNotFound(t *testing.T) {
+	f := setupTaggingFixture(t)
+
+	s3Req := &S3Request{Bucket: f.bucket, Object: "does-not-exist.txt", TenantID: f.tenantID}
+	ctx := tenant.WithTenant(context.Background(), f.tenant)
+	r := httptest.NewRequest("PUT", "/"+f.bucket+"/does-not-exist.txt?tagging",
+		bytes.NewReader([]byte(taggingXML([2]string{"env", "prod"})))).WithContext(ctx)
+	w := httptest.NewRecorder()
+	f.server.handlePutObjectTagging(w, r, s3Req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), ErrNoSuchKey)
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -30,6 +30,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 036 | MFA Delete: `mfa_delete_enabled` BOOLEAN on `buckets` (default FALSE) |
 | 038 | Account deletion: `deletion_scheduled_at` + `deletion_reason` on users, `account_exports` table |
 | 040 | S3 access logging + inventory: `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format` on `buckets`; `s3_access_log` table |
+| 041 | Object tagging: `tags JSONB` (default `{}`) on `object_head_cache` — per-object S3 `?tagging` sub-resource (flat key/value map) |
 
 ## Key Tables
 
@@ -41,7 +42,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
 - **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`
-- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT)
+- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`)
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`

--- a/internal/database/migrations/041_object_tags.sql
+++ b/internal/database/migrations/041_object_tags.sql
@@ -1,0 +1,6 @@
+-- 041_object_tags.sql: Per-object tagging (S3 ?tagging sub-resource).
+
+-- Object tags are stored as a flat JSONB map {"key": "value", ...} on the
+-- HEAD cache row. Distinct from metadata (x-amz-meta-*) which lives in the
+-- metadata column. Tags are set/replaced/deleted via the ?tagging sub-resource.
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS tags JSONB NOT NULL DEFAULT '{}';


### PR DESCRIPTION
S3-compatible object tagging: `GET/PUT/DELETE /{bucket}/{key}?tagging` with per-object tags stored in `object_head_cache.tags` (JSONB, migration 041). Distinct from x-amz-meta-* metadata. Prerequisite for full rclone compatibility; used by lifecycle policies, cost allocation, IAM conditions.

Stacked on top of #263 (dashboard) and the 5.14.x stack. Merge last.

- New: `s3_tagging.go` (GET/PUT/DELETE handlers + tagCount helper), `s3_tagging_test.go` (8 integration tests), migration 041
- PUT replaces the full tag set (not merge); validates ≤10 tags, key ≤128, value ≤256, no empty/dup keys → `InvalidTag` (400)
- `x-amz-tagging-count` emitted on HEAD and GET when >0 (matches AWS)
- `ErrInvalidTag` added to s3_errors.go; routing + dispatch in s3.go

Tests: all 8 pass against local Postgres; full `internal/api` suite green; lint clean.