### PR TITLE
fix(deploy): clear stale /tmp binary before scp to prevent ETXTBSY

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,11 @@ jobs:
           USER: ${{ secrets.SSH_USER_DEV }}
         run: |
           ssh-keyscan -t ed25519 "$HOST" >> ~/.ssh/known_hosts
+          # Clear stale staging artifacts before uploading. A prior failed deploy or a
+          # stray instance can leave /tmp/vaultaire-linux behind; unlinking frees the
+          # path even when the file is still held by a running process, which otherwise
+          # makes scp fail with "dest open ... Failure" (ETXTBSY).
+          ssh "${USER}@${HOST}" 'rm -f /tmp/vaultaire-linux; rm -rf /tmp/vaultaire-migrations'
           scp vaultaire-linux "${USER}@${HOST}:/tmp/"
           scp -r internal/database/migrations "${USER}@${HOST}:/tmp/vaultaire-migrations"
           ssh "${USER}@${HOST}" 'bash -s' <<'EOF'
@@ -95,6 +100,11 @@ jobs:
           USER: ${{ secrets.SSH_USER_PROD }}
         run: |
           ssh-keyscan -t ed25519 "$HOST" >> ~/.ssh/known_hosts
+          # Clear stale staging artifacts before uploading. A prior failed deploy or a
+          # stray instance can leave /tmp/vaultaire-linux behind; unlinking frees the
+          # path even when the file is still held by a running process, which otherwise
+          # makes scp fail with "dest open ... Failure" (ETXTBSY).
+          ssh "${USER}@${HOST}" 'rm -f /tmp/vaultaire-linux; rm -rf /tmp/vaultaire-migrations'
           scp vaultaire-linux "${USER}@${HOST}:/tmp/"
           scp -r internal/database/migrations "${USER}@${HOST}:/tmp/vaultaire-migrations"
           ssh "${USER}@${HOST}" 'bash -s' <<'EOF'


### PR DESCRIPTION
## Problem
Production deploys were failing at the first step:
```
scp: dest open "/tmp/vaultaire-linux": Failure
```
Root cause: a stray vaultaire instance (started May 13 from `/tmp/vaultaire-linux` on PORT=8001, orphaned under init) kept that binary mapped as a running executable for 17 days. Every deploy's `scp` then hit ETXTBSY because you can't overwrite a binary that's currently executing. The real systemd service on :8000 was unaffected, so prod stayed healthy while deploys silently failed. The orphan + stale file have been cleared manually.

## Fix
Before `scp`, unlink any stale staging artifacts on the host. `rm` removes the directory entry even when the inode is still held by a running process, so the subsequent `scp` always creates a fresh file — making deploys self-healing against this failure mode. Applied to both prod and dev jobs. Plain `rm` (no sudo needed; deploy user owns /tmp staging).

Merging this re-deploys current `main` (Phase 5.14.5) through the hardened pipeline, verifying it end-to-end.