### PR TITLE
feat(s3): Content-Disposition storage, override, and CDN defaults [Phase 5.10.18]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -24,6 +24,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **s3_logging.go** — GET/PUT ?logging handlers for per-bucket server access logging config
 - **s3_inventory.go** — GET/PUT/DELETE ?inventory handlers + InventoryRunner background job for CSV reports
 - **s3_tagging.go** — GET/PUT/DELETE ?tagging handlers for per-object tags + `tagCount` helper for x-amz-tagging-count
+- **s3_content_disposition.go** — Content-Disposition helpers: `sanitizeContentDisposition` (header-injection guard), `isInlineRenderable`, `attachmentDisposition`, `cdnContentDisposition` (CDN precedence logic)
 - **management.go** — JSON response helpers: `writeJSON`, `writeListResponse`, `getRequestID` (Stripe-style envelope)
 - **management_errors.go** — 7 typed errors with Stripe-style error envelope (`writeManagementError`)
 - **management_routes.go** — RESTful JSON management API under `/api/v1/manage/` (buckets CRUD, objects list, keys CRUD, usage)
@@ -323,6 +324,37 @@ and count via the `tagCount` helper.
 **Error code**: `ErrInvalidTag` in `s3_errors.go` (400, "The tag provided was not valid.").
 
 **Table**: `object_head_cache.tags` JSONB (migration 041).
+
+## Content-Disposition (Phase 5.10.18)
+
+Stored Content-Disposition response header, plus the `?response-content-disposition`
+query override and CDN inline-vs-attachment defaults. Helpers live in
+`s3_content_disposition.go`. Content-Disposition rides on `object_head_cache` like
+content_type — it is not metadata (x-amz-meta-*) or a tag.
+
+**Store on PUT** (`s3_engine_adapter.go HandlePut`): the request `Content-Disposition`
+header is sanitized (`sanitizeContentDisposition` drops any value containing control
+chars — CR/LF/NUL/DEL — to prevent header injection) and stored in
+`object_head_cache.content_disposition`.
+
+**Return on GET** (`s3_engine_adapter.go HandleGet`): `?response-content-disposition`
+(part of the signed request → works for both presigned and plain authenticated GET)
+overrides the stored value; otherwise the stored value is used. The header is set
+**before** the range branch so both 200 and 206 responses carry it. The query value is
+re-sanitized (dropped, not 400'd, on control chars).
+
+**Return on HEAD** (`s3.go handleHeadObject`): returns the stored value (no override).
+
+**CDN defaults** (`cdn.go handleCDNRequest`): `cdnContentDisposition` precedence —
+(1) bucket `cdn_force_download=TRUE` → `attachment; filename="<base>"`; (2) stored
+disposition → use it; (3) renderable content type (`image/`, `video/`, `text/`,
+`application/pdf`) → `inline`; (4) otherwise → attachment. Unknown types default to
+attachment (safe for a CDN serving arbitrary tenant content — avoids inline rendering
+of untrusted HTML/SVG). Filename is `path.Base(key)` with quotes/backslashes/control
+chars stripped.
+
+**Tables**: `object_head_cache.content_disposition` TEXT, `buckets.cdn_force_download`
+BOOLEAN (migration 042).
 
 ## Tenant Context
 

--- a/internal/api/cdn.go
+++ b/internal/api/cdn.go
@@ -38,10 +38,11 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 
 	var visibility, corsOrigins string
 	var cacheMaxAgeSecs int
+	var forceDownload bool
 	err = s.db.QueryRowContext(ctx, `
-		SELECT visibility, cors_origins, cache_max_age_secs
+		SELECT visibility, cors_origins, cache_max_age_secs, COALESCE(cdn_force_download, FALSE)
 		FROM buckets WHERE tenant_id = $1 AND name = $2`,
-		tenantID, bucket).Scan(&visibility, &corsOrigins, &cacheMaxAgeSecs)
+		tenantID, bucket).Scan(&visibility, &corsOrigins, &cacheMaxAgeSecs, &forceDownload)
 	if err != nil || visibility != "public-read" {
 		http.NotFound(w, r)
 		return
@@ -70,11 +71,12 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 	var sizeBytes int64
 	var etag, contentType string
 	var updatedAt time.Time
+	var contentDisposition string
 	err = s.db.QueryRowContext(ctx, `
-		SELECT size_bytes, etag, content_type, updated_at
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(content_disposition, '')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-		tenantID, bucket, key).Scan(&sizeBytes, &etag, &contentType, &updatedAt)
+		tenantID, bucket, key).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &contentDisposition)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -91,6 +93,7 @@ func (s *Server) handleCDNRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", cdnContentDisposition(forceDownload, contentDisposition, contentType, key))
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", sizeBytes))
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
 	w.Header().Set("Cache-Control", cacheControl)

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -592,12 +592,13 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	var backendName string
 	var encAlgo string
 	var tagsJSON []byte
+	var contentDisposition string
 
 	err = s.db.QueryRowContext(r.Context(), `
-		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}')
+		SELECT size_bytes, etag, content_type, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}'), COALESCE(content_disposition, '')
 		FROM object_head_cache
 		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3
-	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName, &encAlgo, &tagsJSON)
+	`, t.ID, req.Bucket, req.Object).Scan(&sizeBytes, &etag, &contentType, &updatedAt, &metadataJSON, &backendName, &encAlgo, &tagsJSON, &contentDisposition)
 
 	if err == sql.ErrNoRows {
 		s.logger.Warn("HEAD: object not in metadata cache",
@@ -647,6 +648,9 @@ func (s *Server) handleHeadObject(w http.ResponseWriter, r *http.Request, req *S
 	setS3MetadataHeaders(w, metadataJSON)
 	if n := tagCount(tagsJSON); n > 0 {
 		w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
+	}
+	if cd := sanitizeContentDisposition(contentDisposition); cd != "" {
+		w.Header().Set("Content-Disposition", cd)
 	}
 	// HEAD must not write a body.
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/s3_content_disposition.go
+++ b/internal/api/s3_content_disposition.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"path"
+	"strings"
+)
+
+// sanitizeContentDisposition guards against HTTP response header injection.
+// The value may come from a user-controlled request header (PUT) or query
+// parameter (?response-content-disposition), so any control character (CR, LF,
+// NUL, DEL, …) means we drop the value entirely rather than emit a header that
+// could split the response. Returns "" for empty or unsafe input.
+func sanitizeContentDisposition(v string) string {
+	if v == "" {
+		return ""
+	}
+	for _, c := range v {
+		if c < 0x20 || c == 0x7f {
+			return ""
+		}
+	}
+	return v
+}
+
+// isInlineRenderable reports whether a content type is safe to render inline in
+// a browser. Unknown types default to attachment (download), which is the safe
+// choice for a CDN serving arbitrary tenant content — it avoids inline
+// rendering of untrusted HTML/SVG.
+func isInlineRenderable(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	return strings.HasPrefix(ct, "image/") ||
+		strings.HasPrefix(ct, "video/") ||
+		strings.HasPrefix(ct, "text/") ||
+		ct == "application/pdf"
+}
+
+// attachmentDisposition builds `attachment; filename="<base>"` for an object
+// key, stripping quotes, backslashes, and control characters from the filename.
+func attachmentDisposition(key string) string {
+	base := path.Base(key)
+	base = strings.Map(func(r rune) rune {
+		if r == '"' || r == '\\' || r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, base)
+	if base == "" || base == "." || base == "/" {
+		return "attachment"
+	}
+	return `attachment; filename="` + base + `"`
+}
+
+// cdnContentDisposition computes the Content-Disposition the CDN should serve,
+// in precedence order:
+//  1. force-download flag on the bucket → attachment
+//  2. a stored Content-Disposition on the object → use it
+//  3. a browser-renderable content type → inline
+//  4. otherwise → attachment (safe default)
+func cdnContentDisposition(forceDownload bool, stored, contentType, key string) string {
+	if forceDownload {
+		return attachmentDisposition(key)
+	}
+	if s := sanitizeContentDisposition(stored); s != "" {
+		return s
+	}
+	if isInlineRenderable(contentType) {
+		return "inline"
+	}
+	return attachmentDisposition(key)
+}

--- a/internal/api/s3_content_disposition.go
+++ b/internal/api/s3_content_disposition.go
@@ -31,6 +31,16 @@ func isInlineRenderable(contentType string) bool {
 	if i := strings.IndexByte(ct, ';'); i >= 0 {
 		ct = strings.TrimSpace(ct[:i])
 	}
+	// Never inline active/scriptable types on the shared-origin public CDN
+	// (cdn.stored.ge/{slug}/...): text/html and image/svg+xml execute
+	// JavaScript in that origin, so a tenant could host stored XSS / phishing
+	// on the branded domain. Force them to attachment regardless of prefix.
+	// X-Content-Type-Options: nosniff does not help — these are correctly
+	// typed, not sniffed.
+	switch ct {
+	case "text/html", "application/xhtml+xml", "image/svg+xml":
+		return false
+	}
 	return strings.HasPrefix(ct, "image/") ||
 		strings.HasPrefix(ct, "video/") ||
 		strings.HasPrefix(ct, "text/") ||

--- a/internal/api/s3_content_disposition_test.go
+++ b/internal/api/s3_content_disposition_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestPutGet_ContentDisposition verifies a Content-Disposition set on PUT is
+// stored and returned verbatim on GET.
+func TestPutGet_ContentDisposition(t *testing.T) {
+	f := setupAdapterFixture(t)
+	content := []byte("downloadable report content")
+	disposition := `attachment; filename="report.pdf"`
+
+	putReq := httptest.NewRequest("PUT", "/test-bucket/report.bin", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	putReq.Header.Set("Content-Type", "application/octet-stream")
+	putReq.Header.Set("Content-Disposition", disposition)
+	putReq = putReq.WithContext(tenant.WithTenant(putReq.Context(), f.tenant))
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "report.bin")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/report.bin", nil)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "report.bin")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, disposition, gw.Header().Get("Content-Disposition"))
+}
+
+// TestHeadObject_ContentDisposition verifies HEAD returns the stored value.
+func TestHeadObject_ContentDisposition(t *testing.T) {
+	f := setupAdapterFixture(t)
+	disposition := `attachment; filename="head.txt"`
+
+	_, err := f.db.Exec(`
+		INSERT INTO object_head_cache
+			(tenant_id, bucket, object_key, size_bytes, etag, content_type, content_disposition)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET content_disposition = $7
+	`, f.tenantID, "test-bucket", "head.txt", 10, "abc123", "text/plain", disposition)
+	require.NoError(t, err)
+
+	srv := &Server{db: f.db, logger: zap.NewNop()}
+	req := httptest.NewRequest("HEAD", "/test-bucket/head.txt", nil)
+	req = req.WithContext(tenant.WithTenant(req.Context(), f.tenant))
+	w := httptest.NewRecorder()
+	srv.handleHeadObject(w, req, &S3Request{Bucket: "test-bucket", Object: "head.txt"})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, disposition, w.Header().Get("Content-Disposition"))
+}
+
+// TestGet_ResponseContentDispositionOverride verifies the query-string override
+// wins over the stored value.
+func TestGet_ResponseContentDispositionOverride(t *testing.T) {
+	f := setupAdapterFixture(t)
+	content := []byte("data")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "ovr.bin", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache
+			(tenant_id, bucket, object_key, size_bytes, etag, content_type, content_disposition)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, content_disposition = $7
+	`, f.tenantID, "test-bucket", "ovr.bin", len(content), "abc123", "application/octet-stream", `attachment; filename="stored.bin"`)
+	require.NoError(t, err)
+
+	override := `attachment; filename="override.bin"`
+	getReq := httptest.NewRequest("GET", "/test-bucket/ovr.bin", nil)
+	getReq.URL.RawQuery = "response-content-disposition=" + url.QueryEscape(override)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "ovr.bin")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, override, gw.Header().Get("Content-Disposition"))
+}
+
+// TestGet_ContentDispositionHeaderInjectionStripped verifies a CRLF-laden
+// override value is dropped rather than emitted (header-injection guard).
+func TestGet_ContentDispositionHeaderInjectionStripped(t *testing.T) {
+	f := setupAdapterFixture(t)
+	content := []byte("data")
+	container := f.tenant.NamespaceContainer("test-bucket")
+	_, err := f.eng.Put(context.Background(), container, "inj.bin", bytes.NewReader(content))
+	require.NoError(t, err)
+
+	_, err = f.db.Exec(`
+		INSERT INTO object_head_cache
+			(tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET size_bytes = $4
+	`, f.tenantID, "test-bucket", "inj.bin", len(content), "abc123", "application/octet-stream")
+	require.NoError(t, err)
+
+	// Build the request manually so the raw CRLF survives into the query value.
+	getReq := httptest.NewRequest("GET", "/test-bucket/inj.bin", nil)
+	getReq.URL.RawQuery = "response-content-disposition=attachment\r\nX-Injected: evil"
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "inj.bin")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Empty(t, gw.Header().Get("Content-Disposition"))
+	assert.Empty(t, gw.Header().Get("X-Injected"))
+}
+
+// TestCDN_InlineForRenderable verifies a renderable content type gets inline.
+func TestCDN_InlineForRenderable(t *testing.T) {
+	f := setupCDNFixture(t)
+	seedCDNObject(t, f, "pic.png", "image/png", []byte("\x89PNG fake image data"))
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/pic.png", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "inline", w.Header().Get("Content-Disposition"))
+}
+
+// TestCDN_AttachmentForOther verifies a non-renderable content type gets
+// attachment with a filename.
+func TestCDN_AttachmentForOther(t *testing.T) {
+	f := setupCDNFixture(t)
+	seedCDNObject(t, f, "archive.zip", "application/zip", []byte("PK fake zip data"))
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/archive.zip", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, `attachment; filename="archive.zip"`, w.Header().Get("Content-Disposition"))
+}
+
+// TestCDN_ForceDownload verifies cdn_force_download=TRUE forces attachment even
+// for an otherwise-renderable image.
+func TestCDN_ForceDownload(t *testing.T) {
+	f := setupCDNFixture(t)
+	seedCDNObject(t, f, "forced.png", "image/png", []byte("\x89PNG fake image data"))
+
+	_, err := f.db.Exec(`UPDATE buckets SET cdn_force_download = TRUE WHERE tenant_id = $1 AND name = $2`,
+		f.tenantID, f.bucket)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/forced.png", nil)
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, `attachment; filename="forced.png"`, w.Header().Get("Content-Disposition"))
+}
+
+// seedCDNObject inserts an object into the head cache and writes it to the
+// fixture's local storage backend.
+func seedCDNObject(t *testing.T, f *cdnTestFixture, key, contentType string, content []byte) {
+	t.Helper()
+	_, err := f.db.Exec(`
+		INSERT INTO object_head_cache (tenant_id, bucket, object_key, size_bytes, etag, content_type)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			size_bytes = $4, etag = $5, content_type = $6
+	`, f.tenantID, f.bucket, key, len(content), "etag-"+key, contentType)
+	require.NoError(t, err)
+
+	container := f.tenantID + "_" + f.bucket
+	_, err = f.server.engine.Put(context.Background(), container, key, bytes.NewReader(content))
+	require.NoError(t, err)
+}

--- a/internal/api/s3_content_disposition_test.go
+++ b/internal/api/s3_content_disposition_test.go
@@ -165,6 +165,28 @@ func TestCDN_ForceDownload(t *testing.T) {
 	assert.Equal(t, `attachment; filename="forced.png"`, w.Header().Get("Content-Disposition"))
 }
 
+// TestCDN_ActiveContentNotInline verifies scriptable types (HTML, SVG) are never
+// served inline on the shared-origin public CDN — inline rendering would execute
+// JavaScript in the cdn.stored.ge origin (stored XSS / hosted phishing). They
+// must be forced to attachment even though text/* and image/* are otherwise
+// renderable.
+func TestCDN_ActiveContentNotInline(t *testing.T) {
+	f := setupCDNFixture(t)
+	seedCDNObject(t, f, "evil.html", "text/html", []byte("<script>alert(document.domain)</script>"))
+	seedCDNObject(t, f, "evil.svg", "image/svg+xml", []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`))
+
+	for _, tc := range []struct{ key, want string }{
+		{"evil.html", `attachment; filename="evil.html"`},
+		{"evil.svg", `attachment; filename="evil.svg"`},
+	} {
+		req := httptest.NewRequest("GET", "/cdn/"+f.slug+"/"+f.bucket+"/"+tc.key, nil)
+		w := httptest.NewRecorder()
+		f.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "key=%s", tc.key)
+		assert.Equal(t, tc.want, w.Header().Get("Content-Disposition"), "key=%s", tc.key)
+	}
+}
+
 // seedCDNObject inserts an object into the head cache and writes it to the
 // fixture's local storage backend.
 func seedCDNObject(t *testing.T, f *cdnTestFixture, key, contentType string, content []byte) {

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -212,13 +212,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedBackendName string
 	var cachedEncAlgo string
 	var cachedTags []byte
+	var cachedContentDisposition string
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}')
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}'), COALESCE(content_disposition, '')
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo, &cachedTags)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo, &cachedTags, &cachedContentDisposition)
 		if err == nil {
 			cacheHit = true
 		}
@@ -322,6 +323,18 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 		dataReader = bytes.NewReader(plaintext)
 		w.Header().Set("x-amz-server-side-encryption", "AES256")
+	}
+
+	// Content-Disposition: ?response-content-disposition overrides the stored
+	// value (applies to both presigned and plain authenticated GET, since it's
+	// part of the signed request). Set before the range branch so both 200 and
+	// 206 responses carry it.
+	disposition := r.URL.Query().Get("response-content-disposition")
+	if disposition == "" {
+		disposition = cachedContentDisposition
+	}
+	if disposition = sanitizeContentDisposition(disposition); disposition != "" {
+		w.Header().Set("Content-Disposition", disposition)
 	}
 
 	rangeHeader := r.Header.Get("Range")
@@ -617,6 +630,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		contentType = "application/octet-stream"
 	}
 
+	contentDisposition := sanitizeContentDisposition(r.Header.Get("Content-Disposition"))
+
 	userMeta := extractS3Metadata(r)
 	if err := validateMetadata(userMeta); err != nil {
 		WriteS3Error(w, ErrInvalidRequest, r.URL.Path, generateRequestID())
@@ -627,8 +642,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	if a.db != nil {
 		_, dbErr := a.db.ExecContext(r.Context(), `
 			INSERT INTO object_head_cache
-				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, content_disposition, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
 			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
 				size_bytes            = EXCLUDED.size_bytes,
 				etag                  = EXCLUDED.etag,
@@ -636,8 +651,9 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 				backend_name          = EXCLUDED.backend_name,
 				metadata              = EXCLUDED.metadata,
 				encryption_algorithm  = EXCLUDED.encryption_algorithm,
+				content_disposition   = EXCLUDED.content_disposition,
 				updated_at            = NOW()
-		`, t.ID, bucket, artifact, metadataSize, etag, contentType, backendName, metaJSON, encryptionAlgorithm)
+		`, t.ID, bucket, artifact, metadataSize, etag, contentType, backendName, metaJSON, encryptionAlgorithm, contentDisposition)
 		if dbErr != nil {
 			a.logger.Error("failed to cache object metadata",
 				zap.Error(dbErr),

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -31,6 +31,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 038 | Account deletion: `deletion_scheduled_at` + `deletion_reason` on users, `account_exports` table |
 | 040 | S3 access logging + inventory: `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format` on `buckets`; `s3_access_log` table |
 | 041 | Object tagging: `tags JSONB` (default `{}`) on `object_head_cache` — per-object S3 `?tagging` sub-resource (flat key/value map) |
+| 042 | Content-Disposition: `content_disposition TEXT` (default `''`) on `object_head_cache` — stored response header; `cdn_force_download BOOLEAN` (default FALSE) on `buckets` — CDN force-attachment toggle |
 
 ## Key Tables
 
@@ -41,8 +42,8 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`
-- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`)
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`, `cdn_force_download`
+- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`); `content_disposition` TEXT holds the stored Content-Disposition response header
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`

--- a/internal/database/migrations/042_content_disposition.sql
+++ b/internal/database/migrations/042_content_disposition.sql
@@ -1,0 +1,10 @@
+-- 042_content_disposition.sql: Stored Content-Disposition response header + CDN force-download toggle.
+
+-- Content-Disposition is a stored response header (like content_type), distinct
+-- from metadata (x-amz-meta-*) and tags. Set on PUT, returned on GET/HEAD, and
+-- overridable per-request via ?response-content-disposition.
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS content_disposition TEXT NOT NULL DEFAULT '';
+
+-- When TRUE, the CDN forces "attachment" disposition for all objects in the
+-- bucket regardless of content type — useful for download-only buckets.
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS cdn_force_download BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
Stores Content-Disposition on objects and serves it across S3 GET/HEAD, the `?response-content-disposition` presigned/query override, and the public CDN with sensible inline-vs-attachment defaults + a per-bucket force-download toggle. Migration 042 (content_disposition + cdn_force_download).

- PUT stores the (sanitized) header; GET returns it with `?response-content-disposition` override set before the range branch so 200 and 206 both carry it; HEAD returns stored value.
- CDN precedence: force-download → stored → inline-for-renderable → attachment.
- **Security:** all dispositions pass a CRLF/control-char guard (header-injection); and HTML/SVG/XHTML are forced to `attachment` on the shared-origin CDN to prevent stored XSS / hosted phishing (X-Content-Type-Options does not cover this).
- 8 integration tests (incl. injection-stripped and HTML/SVG-not-inline), full internal/api suite green under -race.

Closes the S3-hardening gap-fill line. Reviewed; the HTML/SVG-inline XSS finding was caught in review and fixed before merge.