### PR TITLE
ci: smoke test probes liveness (/health/live) not backend readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,14 @@ jobs:
           go build -o vaultaire cmd/vaultaire/main.go
           ./vaultaire &
           sleep 5
-          # Retry to ride out transient startup hiccups. The server runs a
-          # backend health check that TCP-dials an external host at boot; when
-          # that DNS is slow in CI it can briefly perturb request handling, so
-          # we retry rather than fail the whole build on a flake.
-          curl -sf --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused http://localhost:8000/health
-          curl -sf --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused http://localhost:8000/status | grep -q "operational"
+          # Liveness smoke: assert the server booted and serves HTTP — NOT that
+          # backends are ready. /health is a READINESS probe that returns 503
+          # when an external backend (e.g. the decommissioned quotaless endpoint)
+          # is unreachable; that says nothing about whether the build is good and
+          # can't be retried away when the host is persistently down. /health/live
+          # and /status always return 200 once the process is up.
+          curl -sf --retry 5 --retry-delay 2 --retry-connrefused http://localhost:8000/health/live
+          curl -sf --retry 5 --retry-delay 2 --retry-connrefused http://localhost:8000/status > /dev/null
         env:
           DATABASE_URL: postgres://viera@localhost:5432/vaultaire?sslmode=disable
           JWT_SECRET: ci-test-secret-not-for-production


### PR DESCRIPTION
The CI smoke test was failing at `curl -sf /health` (exit 22 after retries). Root cause: `/health` is a **readiness** probe that returns **503** when a backend is unhealthy, and the server unconditionally health-checks the decommissioned `io.quotaless.cloud` (account locked) — whose DNS is now persistently failing on the runners. A boot smoke test should assert **liveness** (process up, serving HTTP), not external-backend readiness, so retries (#266) couldn't fix a persistent readiness failure.

Fix: probe `/health/live` (always 200 when the process is alive) and `/status` (always renders 200), dropping the readiness `/health` and the `grep operational` body assertion. No app change. Unblocks #267 and all future phases.

Follow-up (separate, deferred): make the quotaless boot health check conditional so prod `/health` readiness is accurate too — tracked in the Quotaless follow-ups note.