### PR TITLE
feat(billing): metered usage reporting to Stripe Billing Meters [Phase 2.7]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ GitHub Actions Deploy (`.github/workflows/deploy.yml`):
 | `STRIPE_SECRET_KEY` | — | Stripe API key (sk_test_... or sk_live_...) |
 | `STRIPE_WEBHOOK_SECRET` | — | Stripe webhook endpoint secret (whsec_...) |
 | `STRIPE_PRICE_VAULT3`, `STRIPE_PRICE_VAULT9`, etc. | — | Stripe Price IDs for each plan |
+| `STRIPE_METER_STORAGE`, `STRIPE_METER_EGRESS` | — | Stripe Billing Meter event-names for metered tiers (both required to enable metered reporting) |
 | `GOOGLE_CLIENT_ID` | — | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | — | Google OAuth client secret |
 | `GITHUB_CLIENT_ID` | — | GitHub OAuth App client ID |

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	auditLogger      *auth.AuditLogger
 	stripe           *billing.StripeService
 	webhookHandler   *billing.WebhookHandler
+	meteredReporter  *billing.MeteredReporter
 	requestCount     int64
 	testMode         bool
 	errorCount       int64
@@ -210,6 +211,18 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		registerStripePlans(s.stripe)
 
 		logger.Info("stripe billing service initialized")
+
+		// Metered usage reporter (Phase 2.7). Dormant unless both meter event-name
+		// envs are set — these are the Stripe Billing Meter names configured in the
+		// dashboard. Without them, no-op (correct: nothing is reported).
+		storageMeter := os.Getenv("STRIPE_METER_STORAGE")
+		egressMeter := os.Getenv("STRIPE_METER_EGRESS")
+		if storageMeter != "" && egressMeter != "" {
+			s.meteredReporter = billing.NewMeteredReporter(s.stripe, s.db, logger, storageMeter, egressMeter)
+			logger.Info("metered billing reporter initialized")
+		} else {
+			logger.Info("metered billing dormant (STRIPE_METER_STORAGE/STRIPE_METER_EGRESS not set)")
+		}
 	}
 
 	// Base URL for OAuth callbacks and email links.
@@ -219,6 +232,9 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	}
 	s.baseURL = baseURL
 	s.emailSender = email.NewSender(logger)
+	if s.meteredReporter != nil {
+		s.meteredReporter.SetEmailSender(s.emailSender)
+	}
 	if googleID := os.Getenv("GOOGLE_CLIENT_ID"); googleID != "" {
 		s.googleOAuth = &oauth2.Config{
 			ClientID:     googleID,
@@ -924,6 +940,11 @@ func (s *Server) Start() error {
 	// Clean up expired STS tokens hourly.
 	if s.db != nil {
 		auth.StartSTSCleanup(ctx, s.db, s.logger)
+	}
+
+	// Report metered usage to Stripe daily + check spending caps hourly.
+	if s.meteredReporter != nil {
+		s.meteredReporter.StartMeteredReporting(ctx)
 	}
 
 	s.logger.Info("Starting server with RBAC and API Key Management",

--- a/internal/billing/CLAUDE.md
+++ b/internal/billing/CLAUDE.md
@@ -47,11 +47,51 @@ Stripe billing integration for stored.ge subscriptions, payments, and invoices.
 - Registration → auto-creates Stripe customer (server.go:511-514)
 - Stripe event idempotency via `stripe_events` table (migration 019)
 
+## Metered Usage Reporting (Phase 2.7)
+
+`metered.go` — **MeteredReporter** reports daily usage for metered tiers
+(`standard`, `performance`) to Stripe Billing Meters. Fixed-price Vault packs and
+the free tier are never metered.
+
+- `NewMeteredReporter(stripe, db, logger, storageMeter, egressMeter)` — meter args
+  are the Stripe Billing Meter **event-name** strings.
+- `ReportDaily(ctx, date)` — for each metered tenant with a `stripe_customer_id`:
+  sends a storage event (gauge = `tenant_quotas.storage_used_bytes`) and an egress
+  event (sum of `bandwidth_usage_daily.egress_bytes` for `date`). Records each in
+  `metered_usage_reports`.
+- `StartMeteredReporting(ctx)` — hourly goroutine; runs `ReportDaily` for the
+  **previous** UTC day at hour 0 (and once on startup as catch-up), checks spending
+  caps hourly. Nil-safe on stripe/db.
+- `SetEmailSender(email.Sender)` — optional; wires the spending-cap alert email.
+- `AccruedCents(tier, storageBytes, egressBytes)` / `MeteredRatePerTB(tier)` —
+  exported pricing helpers (Standard $3.99/TB, Performance $6.00/TB; egress $0).
+  Used by the dashboard billing handler for the "≈ $X.XX this month" estimate.
+
+**Idempotency / no double-billing**: `metered_usage_reports` has
+`UNIQUE(tenant_id, meter, period_date)`. `reportMeter` skips the Stripe call if a
+row already exists, and the Stripe meter event `identifier`
+(`{tenant}-{meter}-{date}`) is a second dedup layer, so a crash between send and
+record cannot double-count. A failed send writes **no** row → the next run retries.
+
+**Stripe SDK note**: stripe-go **v75 has no Billing Meter Events API**, so events are
+POSTed raw to the stable `/v1/billing/meter_events` REST endpoint
+(`httpMeterSender`, auth via the SDK-global API key). The `meterSender` interface
+lets tests substitute a fake.
+
+**Spending caps**: `tenant_quotas.spending_cap_cents` (0 = none). `checkSpendingCaps`
+alerts at 80%/95% of cap, each threshold once per month (guarded by synthetic
+`alert:80`/`alert:95` rows in `metered_usage_reports` keyed by first-of-month).
+Each alert records a `billing.spending_cap_alert` event (inserted directly — billing
+cannot import `api.emitEvent` without a cycle) and emails the tenant.
+
+**Operator setup (config, not code)**: in the Stripe dashboard create two Billing
+Meters — storage with **"last value"** aggregation (it's a gauge), egress with
+**"sum"** (daily counter) — attach them to the Standard/Performance metered prices,
+and set `STRIPE_METER_STORAGE` / `STRIPE_METER_EGRESS` to their event-name strings.
+Without both envs the reporter stays dormant (no-op).
+
 ## Testing
 
 - Unit tests: `go test ./internal/billing/... -short` (no Stripe key needed)
+- `metered_test.go` uses a `fakeMeterSender` + sqlmock (no real Stripe/DB).
 - Integration tests: set `STRIPE_TEST_KEY` env var + `stripe listen --forward-to localhost:8000/webhook/stripe`
-
-## Next: Phase 2.7 (Metered Billing)
-
-Stripe Billing Meters API for pay-per-TB tiers (Standard, Performance). See plan file.

--- a/internal/billing/metered.go
+++ b/internal/billing/metered.go
@@ -1,0 +1,428 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/email"
+	"github.com/google/uuid"
+	"github.com/stripe/stripe-go/v75"
+	"go.uber.org/zap"
+)
+
+// Per-TB storage prices for the two metered tiers (USD/TB/month). Fixed-price
+// Vault packs and the free tier are never metered.
+const (
+	pricePerTBStandard    = 3.99
+	pricePerTBPerformance = 6.00
+	bytesPerTB            = 1024.0 * 1024 * 1024 * 1024
+)
+
+// MeteredRatePerTB returns the per-TB storage price for a metered tier, or 0 for
+// non-metered tiers (vault*/free).
+func MeteredRatePerTB(tier string) float64 {
+	switch tier {
+	case "standard":
+		return pricePerTBStandard
+	case "performance":
+		return pricePerTBPerformance
+	default:
+		return 0
+	}
+}
+
+// AccruedCents estimates the current-month metered charge in cents from a storage
+// gauge (bytes) and month-to-date egress (bytes). Egress is currently free on
+// metered tiers, so only storage contributes — but the signature carries egress
+// so the rate can change without touching callers.
+func AccruedCents(tier string, storageBytes, egressBytes int64) int64 {
+	storageTB := float64(storageBytes) / bytesPerTB
+	dollars := storageTB * MeteredRatePerTB(tier)
+	// egress is $0/TB on metered tiers today; reported to Stripe for tracking only.
+	return int64(math.Round(dollars * 100))
+}
+
+// meterSender sends a single Stripe Billing Meter event. Abstracted so tests can
+// substitute a fake for the live HTTP call.
+type meterSender interface {
+	send(ctx context.Context, eventName, customerID string, value int64, identifier string, ts time.Time) (string, error)
+}
+
+// MeteredReporter reports daily storage and egress usage for metered-tier tenants
+// to Stripe Billing Meters, and alerts on optional per-tenant spending caps.
+type MeteredReporter struct {
+	stripe       *StripeService
+	db           *sql.DB
+	logger       *zap.Logger
+	storageMeter string
+	egressMeter  string
+	sender       meterSender
+	emailer      email.Sender
+}
+
+// NewMeteredReporter constructs a reporter. The live sender reads the Stripe API
+// key from the SDK global set by NewStripeService — v75 predates the Billing
+// Meter Events API, so events are POSTed raw to the stable /v1/billing/meter_events
+// endpoint. Nil-safe on stripe/db (StartMeteredReporting then no-ops).
+func NewMeteredReporter(stripeSvc *StripeService, db *sql.DB, logger *zap.Logger, storageMeter, egressMeter string) *MeteredReporter {
+	return &MeteredReporter{
+		stripe:       stripeSvc,
+		db:           db,
+		logger:       logger,
+		storageMeter: storageMeter,
+		egressMeter:  egressMeter,
+		sender: &httpMeterSender{
+			apiKey:  stripe.Key,
+			client:  &http.Client{Timeout: 15 * time.Second},
+			baseURL: "https://api.stripe.com",
+		},
+	}
+}
+
+// SetEmailSender wires the sender used for spending-cap alerts. Optional and
+// nil-safe — cap alerts are still recorded as events without it.
+func (r *MeteredReporter) SetEmailSender(s email.Sender) { r.emailer = s }
+
+// StartMeteredReporting launches a goroutine that reports the previous day's usage
+// once per UTC day (at hour 0) and checks spending caps hourly. It mirrors
+// CDNAnalyticsTracker.StartRollup / auth.StartSTSCleanup. Nil-safe.
+func (r *MeteredReporter) StartMeteredReporting(ctx context.Context) {
+	if r == nil || r.db == nil || r.stripe == nil {
+		return
+	}
+	go func() {
+		// Catch-up on startup: yesterday's usage is complete and the report is
+		// idempotent, so this safely backfills a missed midnight run.
+		r.runDaily(ctx)
+		r.checkSpendingCaps(ctx)
+
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if time.Now().UTC().Hour() == 0 {
+					r.runDaily(ctx)
+				}
+				r.checkSpendingCaps(ctx)
+			}
+		}
+	}()
+}
+
+// runDaily reports the previous (complete) UTC day's usage. Reporting whole-day
+// values keyed by date — not deltas — is what makes the job safe to re-run.
+func (r *MeteredReporter) runDaily(ctx context.Context) {
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	if err := r.ReportDaily(cctx, yesterday); err != nil {
+		r.logger.Error("metered daily report", zap.Error(err))
+	}
+}
+
+// ReportDaily reports storage (a point-in-time gauge) and egress (a daily sum) for
+// every metered-tier tenant to Stripe, keyed by date. Idempotent: an existing row
+// in metered_usage_reports for (tenant, meter, date) means it was already sent, so
+// the Stripe call is skipped. Tenants without a Stripe customer are skipped.
+func (r *MeteredReporter) ReportDaily(ctx context.Context, date time.Time) error {
+	if r.db == nil {
+		return nil
+	}
+	day := date.UTC().Format("2006-01-02")
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT tq.tenant_id, tq.storage_used_bytes, COALESCE(t.stripe_customer_id, '')
+		FROM tenant_quotas tq
+		JOIN tenants t ON t.id = tq.tenant_id
+		WHERE tq.tier IN ('standard', 'performance')`)
+	if err != nil {
+		return fmt.Errorf("query metered tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type tenantUsage struct {
+		id           string
+		storageBytes int64
+		customerID   string
+	}
+	var tenants []tenantUsage
+	for rows.Next() {
+		var tu tenantUsage
+		if err := rows.Scan(&tu.id, &tu.storageBytes, &tu.customerID); err != nil {
+			r.logger.Error("scan metered tenant", zap.Error(err))
+			continue
+		}
+		tenants = append(tenants, tu)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate metered tenants: %w", err)
+	}
+
+	for _, tu := range tenants {
+		if tu.customerID == "" {
+			continue // no Stripe customer — nothing to bill
+		}
+
+		// Storage: report the current gauge value (Stripe meter aggregates "last").
+		r.reportMeter(ctx, tu.customerID, tu.id, r.storageMeter, tu.storageBytes, date, day)
+
+		// Egress: sum the day's bytes (Stripe meter aggregates "sum").
+		var egress int64
+		if err := r.db.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(egress_bytes), 0)
+			FROM bandwidth_usage_daily
+			WHERE tenant_id = $1 AND date = $2`, tu.id, day).Scan(&egress); err != nil {
+			r.logger.Error("sum egress", zap.String("tenant", tu.id), zap.Error(err))
+			continue
+		}
+		r.reportMeter(ctx, tu.customerID, tu.id, r.egressMeter, egress, date, day)
+	}
+	return nil
+}
+
+// reportMeter sends one meter event then records it. The existence check skips the
+// Stripe call on re-runs; the Stripe identifier is a second idempotency layer so a
+// crash between send and record cannot double-bill (re-send dedupes by identifier).
+func (r *MeteredReporter) reportMeter(ctx context.Context, customerID, tenantID, meter string, value int64, ts time.Time, day string) {
+	if meter == "" {
+		return
+	}
+
+	var existing int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT 1 FROM metered_usage_reports WHERE tenant_id = $1 AND meter = $2 AND period_date = $3`,
+		tenantID, meter, day).Scan(&existing)
+	if err == nil {
+		return // already reported for this day
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		r.logger.Error("check metered report", zap.String("tenant", tenantID), zap.Error(err))
+		return
+	}
+
+	identifier := fmt.Sprintf("%s-%s-%s", tenantID, meter, day)
+	eventID, sendErr := r.sender.send(ctx, meter, customerID, value, identifier, ts)
+	if sendErr != nil {
+		// No row written → the next run retries; nothing was billed.
+		r.logger.Error("send meter event",
+			zap.String("tenant", tenantID), zap.String("meter", meter), zap.Error(sendErr))
+		return
+	}
+
+	if _, err := r.db.ExecContext(ctx, `
+		INSERT INTO metered_usage_reports (tenant_id, meter, period_date, value, stripe_event_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, meter, period_date) DO NOTHING`,
+		tenantID, meter, day, value, eventID); err != nil {
+		r.logger.Error("record metered report", zap.String("tenant", tenantID), zap.Error(err))
+	}
+}
+
+// checkSpendingCaps alerts tenants whose month-to-date accrued charge crosses 80%
+// or 95% of their optional spending cap. Each threshold fires once per month,
+// guarded by a synthetic row in metered_usage_reports.
+func (r *MeteredReporter) checkSpendingCaps(ctx context.Context) {
+	if r.db == nil {
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	monthStart := firstOfMonthUTC(time.Now().UTC())
+
+	rows, err := r.db.QueryContext(cctx, `
+		SELECT tenant_id, tier, spending_cap_cents
+		FROM tenant_quotas
+		WHERE tier IN ('standard', 'performance') AND spending_cap_cents > 0`)
+	if err != nil {
+		r.logger.Error("query spending caps", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type capRow struct {
+		tenantID string
+		tier     string
+		capCents int64
+	}
+	var caps []capRow
+	for rows.Next() {
+		var c capRow
+		if err := rows.Scan(&c.tenantID, &c.tier, &c.capCents); err != nil {
+			r.logger.Error("scan spending cap", zap.Error(err))
+			continue
+		}
+		caps = append(caps, c)
+	}
+	if err := rows.Err(); err != nil {
+		r.logger.Error("iterate spending caps", zap.Error(err))
+		return
+	}
+
+	for _, c := range caps {
+		accrued := r.accruedCents(cctx, c.tenantID, c.tier, monthStart)
+		for _, th := range []struct {
+			pct   int64
+			label string
+		}{{80, "alert:80"}, {95, "alert:95"}} {
+			// accrued >= cap * pct/100, rearranged to avoid float rounding.
+			if accrued*100 >= c.capCents*th.pct {
+				r.fireCapAlert(cctx, c.tenantID, th.label, th.pct, accrued, c.capCents, monthStart)
+			}
+		}
+	}
+}
+
+// accruedCents computes month-to-date accrued charge in cents from what has been
+// reported to Stripe (the billed-to-date source): the latest storage gauge plus
+// the summed egress for the current month.
+func (r *MeteredReporter) accruedCents(ctx context.Context, tenantID, tier string, monthStart time.Time) int64 {
+	month := monthStart.Format("2006-01-02")
+	var storageBytes, egressBytes int64
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE((SELECT value FROM metered_usage_reports
+			          WHERE tenant_id = $1 AND meter = $2 AND period_date >= $3
+			          ORDER BY period_date DESC LIMIT 1), 0),
+			COALESCE((SELECT SUM(value) FROM metered_usage_reports
+			          WHERE tenant_id = $1 AND meter = $4 AND period_date >= $3), 0)`,
+		tenantID, r.storageMeter, month, r.egressMeter).Scan(&storageBytes, &egressBytes)
+	if err != nil {
+		r.logger.Error("accrued charges", zap.String("tenant", tenantID), zap.Error(err))
+		return 0
+	}
+	return AccruedCents(tier, storageBytes, egressBytes)
+}
+
+// fireCapAlert records a once-per-month guard row and, only if newly inserted,
+// emits a billing event and sends an email (if an emailer is wired).
+func (r *MeteredReporter) fireCapAlert(ctx context.Context, tenantID, label string, pct, accrued, capCents int64, monthStart time.Time) {
+	month := monthStart.Format("2006-01-02")
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO metered_usage_reports (tenant_id, meter, period_date, value)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (tenant_id, meter, period_date) DO NOTHING`,
+		tenantID, label, month, accrued)
+	if err != nil {
+		r.logger.Error("guard cap alert", zap.String("tenant", tenantID), zap.Error(err))
+		return
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return // already alerted this month
+	}
+
+	r.insertEvent(ctx, "billing.spending_cap_alert", tenantID, map[string]interface{}{
+		"threshold_pct": pct,
+		"accrued_cents": accrued,
+		"cap_cents":     capCents,
+	})
+
+	if r.emailer == nil {
+		return
+	}
+	to := r.tenantEmail(ctx, tenantID)
+	if to == "" {
+		return
+	}
+	subject := fmt.Sprintf("You've used %d%% of your stored.ge spending cap", pct)
+	body := fmt.Sprintf(
+		"Your stored.ge usage has reached $%.2f of your $%.2f monthly spending cap (%d%%).",
+		float64(accrued)/100, float64(capCents)/100, pct)
+	if err := r.emailer.Send(ctx, to, subject, body, body); err != nil {
+		r.logger.Warn("send cap alert email", zap.String("tenant", tenantID), zap.Error(err))
+	}
+}
+
+// insertEvent records an event row directly (billing cannot import the api package
+// where emitEvent lives — that would be an import cycle). The events table has no
+// type constraint, so a billing-specific type is valid; it is not webhook-dispatched.
+func (r *MeteredReporter) insertEvent(ctx context.Context, eventType, tenantID string, data map[string]interface{}) {
+	if r.db == nil {
+		return
+	}
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		r.logger.Error("marshal event data", zap.Error(err))
+		return
+	}
+	if _, err := r.db.ExecContext(ctx,
+		`INSERT INTO events (id, type, tenant_id, data) VALUES ($1, $2, $3, $4)`,
+		uuid.New().String(), eventType, tenantID, dataJSON); err != nil {
+		r.logger.Error("insert billing event", zap.String("type", eventType), zap.Error(err))
+	}
+}
+
+func (r *MeteredReporter) tenantEmail(ctx context.Context, tenantID string) string {
+	var e sql.NullString
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT email FROM tenants WHERE id = $1`, tenantID).Scan(&e); err != nil {
+		return ""
+	}
+	if e.Valid {
+		return e.String
+	}
+	return ""
+}
+
+func firstOfMonthUTC(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+// httpMeterSender POSTs meter events to the stable /v1/billing/meter_events REST
+// endpoint (the v75 SDK has no typed support for it).
+type httpMeterSender struct {
+	apiKey  string
+	client  *http.Client
+	baseURL string
+}
+
+func (h *httpMeterSender) send(ctx context.Context, eventName, customerID string, value int64, identifier string, ts time.Time) (string, error) {
+	form := url.Values{}
+	form.Set("event_name", eventName)
+	form.Set("identifier", identifier)
+	form.Set("timestamp", strconv.FormatInt(ts.UTC().Unix(), 10))
+	form.Set("payload[stripe_customer_id]", customerID)
+	form.Set("payload[value]", strconv.FormatInt(value, 10))
+
+	endpoint := strings.TrimRight(h.baseURL, "/") + "/v1/billing/meter_events"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build meter event request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+h.apiKey)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("post meter event: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("stripe meter event %s: status %d: %s",
+			eventName, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed struct {
+		Identifier string `json:"identifier"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Identifier != "" {
+		return parsed.Identifier, nil
+	}
+	return identifier, nil // event sent; fall back to our identifier
+}

--- a/internal/billing/metered_test.go
+++ b/internal/billing/metered_test.go
@@ -1,0 +1,331 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// fakeMeterSender records every meter event instead of calling Stripe.
+type fakeMeterSender struct {
+	calls []meterCall
+	err   error
+}
+
+type meterCall struct {
+	eventName  string
+	customerID string
+	value      int64
+	identifier string
+}
+
+func (f *fakeMeterSender) send(_ context.Context, eventName, customerID string, value int64, identifier string, _ time.Time) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	f.calls = append(f.calls, meterCall{eventName, customerID, value, identifier})
+	return "evt_" + identifier, nil
+}
+
+func TestReportDaily_MeteredTiersOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	fake := &fakeMeterSender{}
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes", sender: fake,
+	}
+
+	// Only standard/performance tenants come back from the query (the WHERE clause
+	// filters vault*/free server-side), so the mock returns exactly those.
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t-std", int64(2*1024*1024*1024*1024), "cus_std").
+			AddRow("t-perf", int64(1024*1024*1024*1024), "cus_perf"))
+
+	// t-std: storage existence check (none) → INSERT; egress sum → existence → INSERT.
+	expectReport(mock, "t-std", "storage_bytes")
+	expectEgressSum(mock, "t-std", 0)
+	expectReport(mock, "t-std", "egress_bytes")
+	// t-perf: same shape.
+	expectReport(mock, "t-perf", "storage_bytes")
+	expectEgressSum(mock, "t-perf", 0)
+	expectReport(mock, "t-perf", "egress_bytes")
+
+	date := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// Two tenants × two meters = four events; all metered tiers, none skipped.
+	require.Len(t, fake.calls, 4)
+	names := map[string]int{}
+	for _, c := range fake.calls {
+		names[c.eventName]++
+	}
+	assert.Equal(t, 2, names["storage_bytes"])
+	assert.Equal(t, 2, names["egress_bytes"])
+}
+
+func TestReportDaily_Idempotent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	fake := &fakeMeterSender{}
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes", sender: fake,
+	}
+	date := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
+
+	// First run: no existing rows → sends + inserts both meters.
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t1", int64(1024*1024*1024*1024), "cus_1"))
+	expectReport(mock, "t1", "storage_bytes")
+	expectEgressSum(mock, "t1", 0)
+	expectReport(mock, "t1", "egress_bytes")
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+
+	// Second run for the same date: existence checks find rows → no send, no insert.
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t1", int64(1024*1024*1024*1024), "cus_1"))
+	expectReportExists(mock, "t1", "storage_bytes")
+	expectEgressSum(mock, "t1", 0)
+	expectReportExists(mock, "t1", "egress_bytes")
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+
+	require.NoError(t, mock.ExpectationsWereMet())
+	// Two sends from the first run only; the re-run sent nothing.
+	assert.Len(t, fake.calls, 2)
+}
+
+func TestReportDaily_SkipsNoStripeCustomer(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	fake := &fakeMeterSender{}
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes", sender: fake,
+	}
+
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t-nocust", int64(1024*1024*1024*1024), ""))
+	// No per-tenant queries expected: the tenant is skipped before any meter call.
+
+	date := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+	require.NoError(t, mock.ExpectationsWereMet())
+	assert.Empty(t, fake.calls)
+}
+
+func TestReportDaily_StorageAndEgress(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	fake := &fakeMeterSender{}
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes", sender: fake,
+	}
+
+	const storage = int64(3 * 1024 * 1024 * 1024 * 1024)
+	const egress = int64(500 * 1024 * 1024 * 1024)
+
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t1", storage, "cus_1"))
+	expectReport(mock, "t1", "storage_bytes")
+	expectEgressSum(mock, "t1", egress)
+	expectReport(mock, "t1", "egress_bytes")
+
+	date := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Len(t, fake.calls, 2)
+	byMeter := map[string]meterCall{}
+	for _, c := range fake.calls {
+		byMeter[c.eventName] = c
+	}
+	assert.Equal(t, storage, byMeter["storage_bytes"].value)
+	assert.Equal(t, egress, byMeter["egress_bytes"].value)
+	assert.Equal(t, "cus_1", byMeter["storage_bytes"].customerID)
+	assert.Equal(t, "t1-storage_bytes-2026-05-30", byMeter["storage_bytes"].identifier)
+}
+
+func TestReportDaily_StripeFailureLeavesNoRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Sender errors → reportMeter must NOT insert a row (so the next run retries).
+	fake := &fakeMeterSender{err: assertErr("stripe down")}
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes", sender: fake,
+	}
+
+	mock.ExpectQuery(`SELECT tq.tenant_id, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "storage_used_bytes", "stripe_customer_id"}).
+			AddRow("t1", int64(1024*1024*1024*1024), "cus_1"))
+	// storage: existence check (none), then NO insert (send failed).
+	mock.ExpectQuery(`SELECT 1 FROM metered_usage_reports`).
+		WithArgs("t1", "storage_bytes", "2026-05-30").
+		WillReturnError(sqlNoRows())
+	expectEgressSum(mock, "t1", 0)
+	// egress: existence check (none), then NO insert (send failed).
+	mock.ExpectQuery(`SELECT 1 FROM metered_usage_reports`).
+		WithArgs("t1", "egress_bytes", "2026-05-30").
+		WillReturnError(sqlNoRows())
+
+	date := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, r.ReportDaily(context.Background(), date))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSpendingCap_AlertAt80And95(t *testing.T) {
+	capCents := int64(10000) // $100.00 cap
+
+	cases := []struct {
+		name         string
+		accruedCents int64
+		wantAlerts   []string // labels expected to be inserted (and thus emit)
+	}{
+		{"below 80%", 5000, nil},
+		{"at 85%", 8500, []string{"alert:80"}},
+		{"at 96%", 9600, []string{"alert:80", "alert:95"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			r := &MeteredReporter{
+				stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+				storageMeter: "storage_bytes", egressMeter: "egress_bytes",
+				// no emailer: cap alert records an event but sends no email.
+			}
+
+			// One performance tenant with a cap.
+			mock.ExpectQuery(`SELECT tenant_id, tier, spending_cap_cents`).
+				WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "tier", "spending_cap_cents"}).
+					AddRow("t1", "performance", capCents))
+
+			// accrued: derive storage bytes that map to tc.accruedCents at $6/TB.
+			storageBytes := centsToStorageBytes(tc.accruedCents, pricePerTBPerformance)
+			mock.ExpectQuery(`SELECT\s+COALESCE\(\(SELECT value FROM metered_usage_reports`).
+				WillReturnRows(sqlmock.NewRows([]string{"storage", "egress"}).
+					AddRow(storageBytes, int64(0)))
+
+			for _, label := range tc.wantAlerts {
+				// guard insert returns 1 row → newly alerted → event insert follows.
+				mock.ExpectExec(`INSERT INTO metered_usage_reports`).
+					WithArgs("t1", label, sqlmock.AnyArg(), sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec(`INSERT INTO events`).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+
+			r.checkSpendingCaps(context.Background())
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSpendingCap_GuardSuppressesRepeat(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	r := &MeteredReporter{
+		stripe: &StripeService{}, db: db, logger: zap.NewNop(),
+		storageMeter: "storage_bytes", egressMeter: "egress_bytes",
+	}
+
+	mock.ExpectQuery(`SELECT tenant_id, tier, spending_cap_cents`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "tier", "spending_cap_cents"}).
+			AddRow("t1", "standard", int64(10000)))
+	mock.ExpectQuery(`SELECT\s+COALESCE\(\(SELECT value FROM metered_usage_reports`).
+		WillReturnRows(sqlmock.NewRows([]string{"storage", "egress"}).
+			AddRow(centsToStorageBytes(8500, pricePerTBStandard), int64(0)))
+
+	// 80% crossed, but the guard insert affects 0 rows (already alerted) → NO event.
+	mock.ExpectExec(`INSERT INTO metered_usage_reports`).
+		WithArgs("t1", "alert:80", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	r.checkSpendingCaps(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStartMeteredReporting_NilSafe(t *testing.T) {
+	// Nil stripe + nil db must not panic and must not start a goroutine that touches them.
+	require.NotPanics(t, func() {
+		r := NewMeteredReporter(nil, nil, zap.NewNop(), "storage_bytes", "egress_bytes")
+		r.StartMeteredReporting(context.Background())
+	})
+	// A nil receiver is also tolerated.
+	require.NotPanics(t, func() {
+		var r *MeteredReporter
+		r.StartMeteredReporting(context.Background())
+	})
+}
+
+func TestAccruedCents(t *testing.T) {
+	tb := int64(1024 * 1024 * 1024 * 1024)
+	assert.Equal(t, int64(399), AccruedCents("standard", tb, 0))    // $3.99
+	assert.Equal(t, int64(600), AccruedCents("performance", tb, 0)) // $6.00
+	assert.Equal(t, int64(0), AccruedCents("vault3", tb, 0))        // fixed-price tier
+	assert.Equal(t, int64(0), AccruedCents("free", tb, 0))
+	assert.Equal(t, int64(1197), AccruedCents("standard", 3*tb, 0)) // $11.97
+}
+
+// --- helpers ---
+
+func expectReport(mock sqlmock.Sqlmock, tenant, meter string) {
+	mock.ExpectQuery(`SELECT 1 FROM metered_usage_reports`).
+		WithArgs(tenant, meter, sqlmock.AnyArg()).
+		WillReturnError(sqlNoRows())
+	mock.ExpectExec(`INSERT INTO metered_usage_reports`).
+		WithArgs(tenant, meter, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func expectReportExists(mock sqlmock.Sqlmock, tenant, meter string) {
+	mock.ExpectQuery(`SELECT 1 FROM metered_usage_reports`).
+		WithArgs(tenant, meter, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+}
+
+func expectEgressSum(mock sqlmock.Sqlmock, tenant string, egress int64) {
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(egress_bytes\), 0\)`).
+		WithArgs(tenant, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(egress))
+}
+
+func centsToStorageBytes(cents int64, ratePerTB float64) int64 {
+	tb := float64(cents) / 100 / ratePerTB
+	return int64(tb * bytesPerTB)
+}
+
+func sqlNoRows() error { return sql.ErrNoRows }
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -123,6 +123,20 @@ Two handlers:
 
 Shared `queryComplianceData(r, db, tenantID)` helper queries buckets table + `object_head_cache` for encryption percentages. Template: `templates/customer/compliance.html`.
 
+## Billing (`billing.go`)
+
+`HandleBilling`, `HandleUpgrade` (Stripe Checkout), `HandleManageBilling` (Stripe
+Billing Portal). Renders plan, subscription status, value stack, and cost
+comparison.
+
+**Accrued charges (Phase 2.7)**: `populateAccruedCharges(ctx, db, data, tenantID)`
+shows "≈ $X.XX this month" for metered-tier tenants (`standard`/`performance`
+only). Storage is the live `tenant_quotas.storage_used_bytes` gauge; egress is the
+current month's sum from `bandwidth_usage_daily`. Charge math reuses
+`billing.AccruedCents(tier, storageBytes, egressBytes)`. Sets `IsMetered=false`
+for fixed-price (Vault/free) tenants, so the card is hidden. Template card gated on
+`{{if .IsMetered}}` in `billing.html`.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/billing.go
+++ b/internal/dashboard/handlers/billing.go
@@ -27,6 +27,7 @@ func HandleBilling(tmpl *template.Template, stripe *billing.StripeService, db *s
 		ctx := r.Context()
 
 		populateBillingPlan(ctx, db, data, sd.TenantID)
+		populateAccruedCharges(ctx, db, data, sd.TenantID)
 		populateBillingPlans(stripe, data)
 		populateValueStack(ctx, db, data, sd.TenantID)
 		populateCostComparison(ctx, db, data, sd.TenantID)
@@ -158,6 +159,39 @@ func populateBillingPlan(ctx context.Context, db *sql.DB, data map[string]any, t
 		data["StatusClass"] = "default"
 		data["StatusLabel"] = "Free"
 	}
+}
+
+// populateAccruedCharges shows the month-to-date metered charge for Standard /
+// Performance tenants. Fixed-price Vault packs and the free tier show nothing.
+// Storage is the live gauge; egress is the current month's sum — the same live
+// tables the rest of the page reads, so the estimate tracks current usage.
+func populateAccruedCharges(ctx context.Context, db *sql.DB, data map[string]any, tenantID string) {
+	data["IsMetered"] = false
+	if db == nil {
+		return
+	}
+
+	var tier string
+	var storageBytes int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT tier, storage_used_bytes FROM tenant_quotas WHERE tenant_id = $1`, tenantID).
+		Scan(&tier, &storageBytes); err != nil {
+		return
+	}
+	if tier != "standard" && tier != "performance" {
+		return // not a metered tier — fixed-price subscription
+	}
+
+	var egressBytes int64
+	_ = db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(egress_bytes), 0) FROM bandwidth_usage_daily
+		 WHERE tenant_id = $1 AND date >= date_trunc('month', CURRENT_DATE)`,
+		tenantID).Scan(&egressBytes)
+
+	cents := billing.AccruedCents(tier, storageBytes, egressBytes)
+	data["IsMetered"] = true
+	data["MeteredTier"] = tier
+	data["AccruedCharges"] = fmt.Sprintf("$%.2f", float64(cents)/100)
 }
 
 func populateBillingPlans(stripe *billing.StripeService, data map[string]any) {

--- a/internal/dashboard/templates/customer/billing.html
+++ b/internal/dashboard/templates/customer/billing.html
@@ -43,6 +43,15 @@
         <div class="card-title">Storage Used</div>
         <div class="card-value">{{.StorageUsedFmt}}</div>
     </div>
+    {{if .IsMetered}}
+    <div class="card">
+        <div class="card-title">Accrued This Month</div>
+        <div class="card-value">&approx; {{.AccruedCharges}}</div>
+        <div class="card-detail">
+            <span class="text-muted">metered usage, billed monthly</span>
+        </div>
+    </div>
+    {{end}}
 </div>
 
 {{if not .HasSubscription}}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -32,6 +32,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 040 | S3 access logging + inventory: `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format` on `buckets`; `s3_access_log` table |
 | 041 | Object tagging: `tags JSONB` (default `{}`) on `object_head_cache` — per-object S3 `?tagging` sub-resource (flat key/value map) |
 | 042 | Content-Disposition: `content_disposition TEXT` (default `''`) on `object_head_cache` — stored response header; `cdn_force_download BOOLEAN` (default FALSE) on `buckets` — CDN force-attachment toggle |
+| 043 | Metered billing: `metered_usage_reports` table (daily Stripe meter reports + idempotency guard); `spending_cap_cents BIGINT` (default 0) on `tenant_quotas` |
 
 ## Key Tables
 
@@ -58,6 +59,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **cdn_stats_daily** — `(tenant_id, bucket, date) PK`, `requests`, `bytes_sent`, `unique_objects` — daily CDN rollup
 - **account_exports** — `id (UUID PK)`, `user_id → users`, `tenant_id`, `status` (pending/processing/completed/failed), `format`, `file_path`, `file_size_bytes`, `error_message`, `created_at`, `completed_at`, `expires_at` — GDPR data export tracking
 - **s3_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `operation`, `status_code`, `bytes_sent`, `bytes_received`, `source_ip`, `user_agent`, `request_id`, `error_code`, `logged_at` — buffered S3 access events, delivered as log objects to target buckets
+- **metered_usage_reports** — `id (BIGSERIAL PK)`, `tenant_id`, `meter`, `period_date`, `value`, `stripe_event_id`, `reported_at`, `UNIQUE(tenant_id, meter, period_date)` — daily Stripe Billing Meter reports; the unique constraint is the no-double-billing guard and also gates once-per-month spending-cap alerts (synthetic `alert:80`/`alert:95` meters)
 
 ## Connection
 

--- a/internal/database/migrations/043_metered_billing.sql
+++ b/internal/database/migrations/043_metered_billing.sql
@@ -1,0 +1,24 @@
+-- 043_metered_billing.sql: Metered usage reporting to Stripe Billing Meters.
+-- Idempotent — safe to re-run on every deploy.
+
+-- Accrued-charge source + idempotency guard for daily meter reports.
+-- One row per (tenant, meter, period_date). The reporter's ON CONFLICT DO NOTHING
+-- means a crashed/re-run job never double-reports to Stripe. The same table also
+-- guards spending-cap alerts (synthetic meters 'alert:80'/'alert:95' keyed by the
+-- first-of-month date fire each threshold once per month).
+CREATE TABLE IF NOT EXISTS metered_usage_reports (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    meter TEXT NOT NULL,
+    period_date DATE NOT NULL,
+    value BIGINT NOT NULL DEFAULT 0,
+    stripe_event_id TEXT NOT NULL DEFAULT '',
+    reported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, meter, period_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metered_usage_tenant_period
+    ON metered_usage_reports (tenant_id, period_date);
+
+-- Optional per-tenant monthly spending cap, in cents. 0 = no cap (the default).
+ALTER TABLE tenant_quotas ADD COLUMN IF NOT EXISTS spending_cap_cents BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

Phase 2.7 — Stripe computes the monthly bill from reported usage for metered tiers (`standard`, `performance`). Vault packs and the free tier stay fixed-price (never metered). The dashboard shows current-month accrued charges, and tenants are alerted at 80%/95% of an optional spending cap.

## What's included

- **Migration 043** — `metered_usage_reports` table (daily report + idempotency guard, `UNIQUE(tenant, meter, period_date)`) and `tenant_quotas.spending_cap_cents` (0 = no cap). Idempotent; verified applies twice cleanly.
- **`internal/billing/metered.go`** — `MeteredReporter`:
  - `ReportDaily(ctx, date)` — storage (gauge) + egress (daily sum) per metered tenant with a `stripe_customer_id`. Skips non-metered tiers and customer-less tenants.
  - `StartMeteredReporting(ctx)` — hourly goroutine, reports the **previous** complete UTC day at hour 0 (+ startup catch-up), checks spending caps hourly. Nil-safe.
  - `checkSpendingCaps` — 80%/95% alerts, each once per month (guarded by synthetic `alert:80`/`alert:95` rows), emits a `billing.spending_cap_alert` event + email.
  - Exported `AccruedCents` / `MeteredRatePerTB` pricing helpers.
- **Wire-up** (`server.go`) — reporter constructed in the Stripe init block (dormant unless `STRIPE_METER_STORAGE` **and** `STRIPE_METER_EGRESS` are set), email sender wired, `StartMeteredReporting` launched alongside the other cleanup goroutines.
- **Dashboard** — `populateAccruedCharges` shows "≈ $X.XX this month" for metered tenants on the billing page.
- **Tests** — `metered_test.go`: tiers-only, idempotent re-run, skip-no-customer, storage+egress values, Stripe-failure-leaves-no-row, cap alerts at 80/95, guard suppresses repeat, nil-safe start, pricing. Uses a `fakeMeterSender` + sqlmock (no real Stripe/DB).

## Key decisions

- **stripe-go v75 has no Billing Meter Events API** (verified). Rather than a risky major SDK bump that would touch all existing billing code, meter events are POSTed raw to the stable `/v1/billing/meter_events` endpoint (`httpMeterSender`). The `meterSender` interface keeps it testable.
- **No double-billing**: existence-check skips the Stripe call on re-runs; the meter event `identifier` (`{tenant}-{meter}-{date}`) is a second dedup layer on Stripe's side; a failed send writes no row so the next run retries.
- **Aggregation**: storage is a gauge (report current value → Stripe meter "last value"); egress is a daily counter (sum → "sum").

## Operator setup (config, not code)

Create two Stripe Billing Meters — storage (**last value** aggregation), egress (**sum**) — attach to the Standard/Performance metered prices, and set `STRIPE_METER_STORAGE` / `STRIPE_METER_EGRESS` to their event-name strings. Without both envs the reporter stays dormant (no-op).

## Testing

- `go test -short -race ./internal/billing/... ./internal/api/... ./internal/dashboard/handlers/...` — pass
- `golangci-lint run ./...` — 0 issues
- Migration applied + re-applied locally (idempotent)