### PR TITLE
fix(security): annotate 2 gosec false positives to restore green CI

### DIFF
--- a/internal/compliance/breach_pg.go
+++ b/internal/compliance/breach_pg.go
@@ -144,11 +144,13 @@ func (s *BreachPgStore) ListBreaches(ctx context.Context, filters map[string]int
 	argIdx := 1
 
 	if severity, ok := filters["severity"].(string); ok && severity != "" {
+		// #nosec G202 -- builds a $N placeholder only; the value is parameterized via args
 		query += fmt.Sprintf(" AND severity = $%d", argIdx)
 		args = append(args, severity)
 		argIdx++
 	}
 	if status, ok := filters["status"].(string); ok && status != "" {
+		// #nosec G202 -- builds a $N placeholder only; the value is parameterized via args
 		query += fmt.Sprintf(" AND status = $%d", argIdx)
 		args = append(args, status)
 	}

--- a/internal/crypto/ssec.go
+++ b/internal/crypto/ssec.go
@@ -3,7 +3,7 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/md5" // #nosec G401 — S3 spec requires MD5 for SSE-C key validation
+	"crypto/md5" // #nosec G401 G501 — S3 spec requires MD5 for SSE-C key validation
 	"crypto/rand"
 	"encoding/base64"
 	"errors"


### PR DESCRIPTION
main's gosec workflow has been red since later phases (5.14.5 HIPAA, 5.14.8 SSE-C) reintroduced two findings, both false positives. This annotates them so gosec passes clean again.

| File | Rule | Why it's a false positive | Fix |
|------|------|---------------------------|-----|
| `crypto/ssec.go:6` | G501 (blocklisted `crypto/md5` import) | MD5 is **required by the S3 SSE-C spec** for customer-key validation | line already had `#nosec G401`; added `G501` |
| `compliance/breach_pg.go:147,152` | G202 (SQL string concatenation) | `fmt.Sprintf` builds a `$N` **placeholder** only; values go through parameterized `QueryContext(ctx, query, args...)` | `#nosec G202` with justification |

Verified locally with the exact CI command — `gosec ... ./...` now exits 0 (zero issues).

Supersedes the stale #232 (which had failing build-and-test and overlapped already-merged gosec work); closing that in favor of this.