### PR TITLE
feat(web): marketing landing page at / + functional waitlist (launch July 2026)

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -356,6 +356,23 @@ chars stripped.
 **Tables**: `object_head_cache.content_disposition` TEXT, `buckets.cdn_force_download`
 BOOLEAN (migration 042).
 
+## Marketing Landing Page + Waitlist (Phase: launch)
+
+`stored.ge/` previously returned an S3 `AccessDenied` XML error to browsers (anonymous
+`GET /` hit the S3 catch-all). Now:
+
+- **`landing.go`** — `handleRoot` serves the marketing page (`//go:embed landing.html`,
+  the `stored-ge-website` content) for anonymous browser GET/HEAD on `/`. Authenticated
+  S3 `ListBuckets` (GET `/` with a SigV4 `Authorization` header or presigned `X-Amz-*`
+  query) is delegated to `handleS3Request` untouched — `isS3RootRequest` is the
+  discriminator. Registered as exact `Get("/")`/`Head("/")` before the `/*` catch-all.
+  No storage backend — served from the embedded binary.
+- **`waitlist.go`** — `POST /api/waitlist` (public, no auth) captures a pre-launch email
+  into `waitlist_signups` (migration 044, `ON CONFLICT (email) DO NOTHING`). Validates via
+  `mail.ParseAddress`, lowercases, per-IP sliding-window rate limit (`waitlistLimiter`,
+  10/hour). Accepts form-encoded or JSON. Nil-DB degrades to 200 (dev). The landing form's
+  `handleWaitlist` JS POSTs here then shows the success modal.
+
 ## Tenant Context
 
 Most handlers use `tenant.FromContext(r.Context())` to get the authenticated tenant. The `S3Request.TenantID` field is also set for convenience.

--- a/internal/api/landing.go
+++ b/internal/api/landing.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed landing.html
+var landingHTML []byte
+
+// handleRoot serves the public marketing landing page for browser visitors to "/".
+//
+// The only S3 operation on the root path is ListBuckets, which always carries
+// SigV4 auth (an Authorization header) or presigned X-Amz-* query params — those
+// requests are delegated to the S3 handler untouched. Only anonymous GET/HEAD "/"
+// (which would otherwise return 403 AccessDenied) is served the landing page.
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if isS3RootRequest(r) {
+		s.handleS3Request(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(landingHTML)
+}
+
+// isS3RootRequest reports whether a request to "/" is an authenticated S3 call
+// (ListBuckets) rather than a browser visit. ListBuckets cannot be anonymous, so
+// the presence of SigV4 auth — header or presigned query — is a reliable signal.
+func isS3RootRequest(r *http.Request) bool {
+	return r.Header.Get("Authorization") != "" ||
+		r.URL.Query().Get("X-Amz-Algorithm") != ""
+}

--- a/internal/api/landing.html
+++ b/internal/api/landing.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>stored.ge - Enterprise S3-Compatible Storage + VPS Platform</title>
-    <meta name="description" content="Enterprise S3 storage with integrated VPS compute. 7 global regions, full IAM, persistent storage. Launching October 2025.">
+    <meta name="description" content="Enterprise S3 storage with integrated VPS compute. 7 global regions, full IAM, persistent storage. Launching July 2026.">
     <meta property="og:title" content="stored.ge - Enterprise Storage Platform">
     <meta property="og:description" content="Next-generation S3-compatible storage with integrated compute. Join the waitlist for early access.">
     <meta property="og:image" content="https://stored.ge/preview.png">
@@ -707,7 +707,7 @@
                     <span class="countdown-label">Seconds</span>
                 </div>
             </div>
-            <p style="opacity: 0.9;">October 1st, 2025 - Be Part of the Storage Revolution</p>
+            <p style="opacity: 0.9;">July 31st, 2026 - Be Part of the Storage Revolution</p>
         </div>
     </section>
 
@@ -789,7 +789,7 @@
                         <li>99.9% Uptime SLA</li>
                         <li>Email Support</li>
                     </ul>
-                    <button class="btn btn-coming-soon" style="width: 100%;">Coming October 2025</button>
+                    <button class="btn btn-coming-soon" style="width: 100%;">Coming July 2026</button>
                 </div>
 
                 <div class="pricing-card featured">
@@ -806,7 +806,7 @@
                         <li>Priority Support</li>
                         <li>Dedicated IPv4 Option</li>
                     </ul>
-                    <button class="btn btn-coming-soon" style="width: 100%;">Coming October 2025</button>
+                    <button class="btn btn-coming-soon" style="width: 100%;">Coming July 2026</button>
                 </div>
 
                 <div class="pricing-card">
@@ -977,7 +977,7 @@
     <div class="modal" id="modal">
         <div class="modal-content">
             <h3 id="modal-title">Coming Soon</h3>
-            <p id="modal-message">This feature will be available when we launch in October 2025.</p>
+            <p id="modal-message">This feature will be available when we launch in July 2026.</p>
             <button class="btn btn-primary" onclick="closeModal()">Got It</button>
         </div>
     </div>
@@ -1005,7 +1005,7 @@
 
         // Countdown Timer
         function updateCountdown() {
-            const launchDate = new Date('October 1, 2025 00:00:00').getTime();
+            const launchDate = new Date('July 31, 2026 00:00:00').getTime();
             const now = new Date().getTime();
             const distance = launchDate - now;
 

--- a/internal/api/landing.html
+++ b/internal/api/landing.html
@@ -1,0 +1,1067 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>stored.ge - Enterprise S3-Compatible Storage + VPS Platform</title>
+    <meta name="description" content="Enterprise S3 storage with integrated VPS compute. 7 global regions, full IAM, persistent storage. Launching October 2025.">
+    <meta property="og:title" content="stored.ge - Enterprise Storage Platform">
+    <meta property="og:description" content="Next-generation S3-compatible storage with integrated compute. Join the waitlist for early access.">
+    <meta property="og:image" content="https://stored.ge/preview.png">
+    <meta property="og:url" content="https://stored.ge">
+
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        :root {
+            --primary: #5B21B6;
+            --primary-dark: #4C1D95;
+            --secondary: #8B5CF6;
+            --accent: #10B981;
+            --danger: #EF4444;
+            --dark: #111827;
+            --gray: #6B7280;
+            --light: #F9FAFB;
+            --white: #FFFFFF;
+            --card-bg: #FFFFFF;
+            --text-primary: #111827;
+            --text-secondary: #6B7280;
+            --border-color: #E5E7EB;
+        }
+
+        [data-theme="dark"] {
+            --dark: #F9FAFB;
+            --light: #1F2937;
+            --white: #111827;
+            --card-bg: #1F2937;
+            --text-primary: #F9FAFB;
+            --text-secondary: #9CA3AF;
+            --border-color: #374151;
+            --primary: #7C3AED;
+            --secondary: #A78BFA;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background: var(--white);
+            transition: background 0.3s, color 0.3s;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        /* Announcement Bar */
+        .announcement-bar {
+            background: var(--primary);
+            color: white;
+            text-align: center;
+            padding: 0.75rem;
+            font-size: 0.9rem;
+        }
+
+        .announcement-bar a {
+            color: white;
+            text-decoration: underline;
+            margin-left: 0.5rem;
+        }
+
+        /* Header */
+        header {
+            background: var(--card-bg);
+            border-bottom: 1px solid var(--border-color);
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 0;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 800;
+            background: linear-gradient(135deg, var(--primary), var(--secondary));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2rem;
+            list-style: none;
+            align-items: center;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.3s;
+        }
+
+        .nav-links a:hover {
+            color: var(--primary);
+        }
+
+        .theme-toggle {
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-size: 1.25rem;
+            padding: 0.5rem;
+            border-radius: 0.5rem;
+            transition: background 0.3s;
+        }
+
+        .theme-toggle:hover {
+            background: var(--light);
+        }
+
+        /* Countdown Timer */
+        .countdown-section {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 3rem 0;
+            text-align: center;
+            color: white;
+        }
+
+        .countdown-title {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            opacity: 0.9;
+        }
+
+        .countdown {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            margin-bottom: 2rem;
+        }
+
+        .countdown-item {
+            text-align: center;
+        }
+
+        .countdown-number {
+            font-size: 3rem;
+            font-weight: 800;
+            display: block;
+            line-height: 1;
+        }
+
+        .countdown-label {
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            opacity: 0.8;
+            margin-top: 0.5rem;
+        }
+
+        /* Hero Section */
+        .hero {
+            padding: 5rem 0;
+            background: var(--light);
+            text-align: center;
+        }
+
+        .hero h1 {
+            font-size: 3.5rem;
+            margin-bottom: 1rem;
+            font-weight: 800;
+            color: var(--text-primary);
+        }
+
+        .hero p {
+            font-size: 1.25rem;
+            margin-bottom: 2rem;
+            color: var(--text-secondary);
+            max-width: 800px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .status-badge {
+            display: inline-block;
+            background: var(--accent);
+            color: white;
+            padding: 0.5rem 1rem;
+            border-radius: 2rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            margin-bottom: 2rem;
+        }
+
+        .waitlist-form {
+            max-width: 500px;
+            margin: 0 auto;
+            display: flex;
+            gap: 1rem;
+        }
+
+        .waitlist-form input {
+            flex: 1;
+            padding: 0.875rem 1.5rem;
+            border: 2px solid var(--border-color);
+            border-radius: 0.5rem;
+            font-size: 1rem;
+            background: var(--card-bg);
+            color: var(--text-primary);
+        }
+
+        .btn {
+            padding: 0.875rem 2rem;
+            border-radius: 0.5rem;
+            text-decoration: none;
+            font-weight: 600;
+            transition: all 0.3s;
+            display: inline-block;
+            border: none;
+            cursor: pointer;
+            font-size: 1rem;
+        }
+
+        .btn-primary {
+            background: var(--primary);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-dark);
+            transform: translateY(-2px);
+        }
+
+        .btn-secondary {
+            background: transparent;
+            color: var(--primary);
+            border: 2px solid var(--primary);
+        }
+
+        .btn-secondary:hover {
+            background: var(--primary);
+            color: white;
+        }
+
+        .btn-coming-soon {
+            background: var(--gray);
+            color: white;
+            cursor: not-allowed;
+            opacity: 0.7;
+        }
+
+        /* Features */
+        .features {
+            padding: 5rem 0;
+            background: var(--white);
+        }
+
+        .features h2 {
+            text-align: center;
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--text-primary);
+        }
+
+        .section-subtitle {
+            text-align: center;
+            color: var(--text-secondary);
+            margin-bottom: 3rem;
+            max-width: 600px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+        }
+
+        .feature-card {
+            background: var(--card-bg);
+            padding: 2rem;
+            border-radius: 1rem;
+            border: 1px solid var(--border-color);
+            transition: transform 0.3s, box-shadow 0.3s;
+        }
+
+        .feature-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        }
+
+        .feature-icon {
+            width: 50px;
+            height: 50px;
+            background: linear-gradient(135deg, var(--primary), var(--secondary));
+            border-radius: 0.75rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .feature-card h3 {
+            margin-bottom: 0.5rem;
+            color: var(--text-primary);
+        }
+
+        .feature-card p {
+            color: var(--text-secondary);
+        }
+
+        /* Pricing */
+        .pricing {
+            padding: 5rem 0;
+            background: var(--light);
+        }
+
+        .pricing h2 {
+            text-align: center;
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--text-primary);
+        }
+
+        .pricing-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .pricing-card {
+            border: 2px solid var(--border-color);
+            border-radius: 1rem;
+            padding: 2rem;
+            text-align: center;
+            position: relative;
+            background: var(--card-bg);
+        }
+
+        .pricing-card.featured {
+            border-color: var(--primary);
+            transform: scale(1.05);
+        }
+
+        .badge {
+            position: absolute;
+            top: -12px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--primary);
+            color: white;
+            padding: 0.25rem 1rem;
+            border-radius: 1rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+
+        .price {
+            font-size: 3rem;
+            font-weight: 800;
+            color: var(--text-primary);
+            margin: 1rem 0;
+        }
+
+        .price-period {
+            font-size: 1rem;
+            color: var(--text-secondary);
+            font-weight: 400;
+        }
+
+        .pricing-features {
+            list-style: none;
+            margin: 2rem 0;
+        }
+
+        .pricing-features li {
+            padding: 0.5rem 0;
+            color: var(--text-secondary);
+        }
+
+        .pricing-features li:before {
+            content: "✓ ";
+            color: var(--accent);
+            font-weight: bold;
+        }
+
+        /* Technical Specs */
+        .specs {
+            padding: 5rem 0;
+            background: var(--white);
+        }
+
+        .specs-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .spec-item {
+            text-align: center;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            background: var(--card-bg);
+            border: 1px solid var(--border-color);
+        }
+
+        .spec-item h4 {
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .spec-item p {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        .upgrade-badge {
+            display: inline-block;
+            background: var(--accent);
+            color: white;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.5rem;
+            font-size: 0.7rem;
+            margin-left: 0.5rem;
+        }
+
+        /* Company Info */
+        .company {
+            padding: 5rem 0;
+            background: var(--light);
+        }
+
+        .company-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 4rem;
+            align-items: center;
+        }
+
+        .company-content h2 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--text-primary);
+        }
+
+        .company-content p {
+            color: var(--text-secondary);
+            margin-bottom: 1rem;
+        }
+
+        .company-stats {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+
+        .stat {
+            text-align: center;
+            padding: 1.5rem;
+            background: var(--card-bg);
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .stat-number {
+            font-size: 2rem;
+            font-weight: 800;
+            color: var(--primary);
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        /* Partners */
+        .partners {
+            padding: 3rem 0;
+            background: var(--white);
+            border-top: 1px solid var(--border-color);
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .partners h3 {
+            text-align: center;
+            color: var(--text-secondary);
+            font-size: 1rem;
+            font-weight: 500;
+            margin-bottom: 2rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .partners-grid {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 4rem;
+            flex-wrap: wrap;
+        }
+
+        .partner-logo {
+            color: var(--text-secondary);
+            font-weight: 600;
+            font-size: 1.25rem;
+            opacity: 0.7;
+        }
+
+        /* Footer */
+        footer {
+            background: var(--card-bg);
+            color: var(--text-primary);
+            padding: 4rem 0 2rem;
+            border-top: 1px solid var(--border-color);
+        }
+
+        .footer-grid {
+            display: grid;
+            grid-template-columns: 2fr 1fr 1fr 1fr;
+            gap: 3rem;
+            margin-bottom: 3rem;
+        }
+
+        .footer-brand .logo {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .footer-brand p {
+            color: var(--text-secondary);
+            margin-bottom: 1.5rem;
+        }
+
+        .footer-section h4 {
+            margin-bottom: 1rem;
+            color: var(--text-primary);
+        }
+
+        .footer-links {
+            list-style: none;
+        }
+
+        .footer-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            display: block;
+            padding: 0.25rem 0;
+        }
+
+        .footer-links a:hover {
+            color: var(--primary);
+        }
+
+        .footer-bottom {
+            padding-top: 2rem;
+            border-top: 1px solid var(--border-color);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .social-links {
+            display: flex;
+            gap: 1rem;
+        }
+
+        .social-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            padding: 0.5rem;
+        }
+
+        /* Modal */
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.5);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal.active {
+            display: flex;
+        }
+
+        .modal-content {
+            background: var(--card-bg);
+            padding: 2rem;
+            border-radius: 1rem;
+            max-width: 500px;
+            width: 90%;
+            text-align: center;
+        }
+
+        .modal-content h3 {
+            color: var(--text-primary);
+            margin-bottom: 1rem;
+        }
+
+        .modal-content p {
+            color: var(--text-secondary);
+            margin-bottom: 1.5rem;
+        }
+
+        /* Mobile */
+        @media (max-width: 768px) {
+            .hero h1 {
+                font-size: 2rem;
+            }
+
+            .countdown {
+                gap: 1rem;
+            }
+
+            .countdown-number {
+                font-size: 2rem;
+            }
+
+            .nav-links {
+                display: none;
+            }
+
+            .company-grid,
+            .footer-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .pricing-card.featured {
+                transform: none;
+            }
+
+            .waitlist-form {
+                flex-direction: column;
+            }
+
+            .footer-bottom {
+                flex-direction: column;
+                gap: 1rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Announcement Bar -->
+    <div class="announcement-bar">
+        🚀 Early Access Registration Now Open - Limited Spots Available
+        <a href="#waitlist">Join Waitlist</a>
+    </div>
+
+    <!-- Header -->
+    <header>
+        <nav class="container">
+            <div class="logo">stored.ge</div>
+            <ul class="nav-links">
+                <li><a href="#features">Features</a></li>
+                <li><a href="#pricing">Pricing</a></li>
+                <li><a href="#specs">Infrastructure</a></li>
+                <li><a href="#company">Company</a></li>
+                <li><a href="#" onclick="showModal('signin')">Sign In</a></li>
+                <li><button class="theme-toggle" onclick="toggleTheme()">🌙</button></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- Countdown Section -->
+    <section class="countdown-section">
+        <div class="container">
+            <h2 class="countdown-title">Platform Launch In:</h2>
+            <div class="countdown" id="countdown">
+                <div class="countdown-item">
+                    <span class="countdown-number" id="days">316</span>
+                    <span class="countdown-label">Days</span>
+                </div>
+                <div class="countdown-item">
+                    <span class="countdown-number" id="hours">12</span>
+                    <span class="countdown-label">Hours</span>
+                </div>
+                <div class="countdown-item">
+                    <span class="countdown-number" id="minutes">45</span>
+                    <span class="countdown-label">Minutes</span>
+                </div>
+                <div class="countdown-item">
+                    <span class="countdown-number" id="seconds">30</span>
+                    <span class="countdown-label">Seconds</span>
+                </div>
+            </div>
+            <p style="opacity: 0.9;">October 1st, 2025 - Be Part of the Storage Revolution</p>
+        </div>
+    </section>
+
+    <!-- Hero Section -->
+    <section class="hero" id="waitlist">
+        <div class="container">
+            <div class="status-badge">PRE-LAUNCH</div>
+            <h1>Enterprise S3 Storage + VPS Platform</h1>
+            <p>The most advanced S3-compatible object storage with integrated compute. 7 global regions, full IAM support, persistent storage that survives VPS rebuilds.</p>
+
+            <form class="waitlist-form" onsubmit="handleWaitlist(event)">
+                <input type="email" placeholder="Enter your email for early access" required>
+                <button type="submit" class="btn btn-primary">Join Waitlist</button>
+            </form>
+
+            <p style="margin-top: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+                Be among the first 100 users to get 50% off for life
+            </p>
+        </div>
+    </section>
+
+    <!-- Features -->
+    <section class="features" id="features">
+        <div class="container">
+            <h2>Enterprise Features, Startup Pricing</h2>
+            <p class="section-subtitle">Everything you need to build, deploy, and scale your applications</p>
+
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">🚀</div>
+                    <h3>S3-Compatible API</h3>
+                    <p>Full S3 API compatibility with IAM policies, CORS, versioning, lifecycle management, and multipart uploads.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🌍</div>
+                    <h3>7 Global Regions</h3>
+                    <p>Deploy across US West, US Central, US East, EU West, EU Central, Asia Tokyo, or Asia Singapore.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">💾</div>
+                    <h3>Persistent Storage</h3>
+                    <p>Your data survives VPS rebuilds. Reinstall OS, change distributions, your storage remains intact.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚡</div>
+                    <h3>High Performance</h3>
+                    <p>SSD storage with NVMe upgrade path. Sub-millisecond latency for hot data with intelligent caching.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🔒</div>
+                    <h3>Enterprise Security</h3>
+                    <p>AES-256 encryption at rest, TLS 1.3 in transit, SOC 2 compliance, and comprehensive audit logging.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🤖</div>
+                    <h3>AI & ML Ready</h3>
+                    <p>Optimized for AI workloads. Run Llama, Stable Diffusion, Whisper models with GPU acceleration support.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Pricing -->
+    <section class="pricing" id="pricing">
+        <div class="container">
+            <h2>Simple, Transparent Pricing</h2>
+            <p class="section-subtitle">No hidden fees. No egress charges. No API call fees. Just honest pricing.</p>
+
+            <div class="pricing-grid">
+                <div class="pricing-card">
+                    <h3>Starter</h3>
+                    <div class="price">$3.99<span class="price-period">/month</span></div>
+                    <ul class="pricing-features">
+                        <li>50GB S3 Storage</li>
+                        <li>2GB RAM VPS</li>
+                        <li>2 vCPU Cores</li>
+                        <li>NAT IPv4 (10 ports)</li>
+                        <li>5TB Bandwidth</li>
+                        <li>99.9% Uptime SLA</li>
+                        <li>Email Support</li>
+                    </ul>
+                    <button class="btn btn-coming-soon" style="width: 100%;">Coming October 2025</button>
+                </div>
+
+                <div class="pricing-card featured">
+                    <span class="badge">MOST POPULAR</span>
+                    <h3>Growth</h3>
+                    <div class="price">$7.99<span class="price-period">/month</span></div>
+                    <ul class="pricing-features">
+                        <li>100GB S3 Storage</li>
+                        <li>4GB RAM VPS</li>
+                        <li>4 vCPU Cores</li>
+                        <li>NAT IPv4 (20 ports)</li>
+                        <li>10TB Bandwidth</li>
+                        <li>99.95% Uptime SLA</li>
+                        <li>Priority Support</li>
+                        <li>Dedicated IPv4 Option</li>
+                    </ul>
+                    <button class="btn btn-coming-soon" style="width: 100%;">Coming October 2025</button>
+                </div>
+
+                <div class="pricing-card">
+                    <h3>Power</h3>
+                    <div class="price">$19.99<span class="price-period">/month</span></div>
+                    <ul class="pricing-features">
+                        <li>500GB S3 Storage</li>
+                        <li>8GB RAM VPS</li>
+                        <li>8 vCPU Cores</li>
+                        <li>Dedicated IPv4 Included</li>
+                        <li>20TB Bandwidth</li>
+                        <li>99.99% Uptime SLA</li>
+                        <li>24/7 Phone Support</li>
+                        <li>Custom Configurations</li>
+                    </ul>
+                    <button class="btn btn-coming-soon" style="width: 100%;">Contact Sales</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Technical Specs -->
+    <section class="specs" id="specs">
+        <div class="container">
+            <h2>Enterprise Infrastructure</h2>
+            <p class="section-subtitle">Built on industry-leading hardware and software</p>
+
+            <div class="specs-grid">
+                <div class="spec-item">
+                    <h4>Seagate Lyve Cloud</h4>
+                    <p>Enterprise S3 storage backend with 11 nines durability</p>
+                </div>
+                <div class="spec-item">
+                    <h4>Intel Xeon E5<span class="upgrade-badge">AMD 7950X Soon</span></h4>
+                    <p>Enterprise processors with upgrade to latest AMD planned</p>
+                </div>
+                <div class="spec-item">
+                    <h4>256GB DDR3<span class="upgrade-badge">DDR5 Soon</span></h4>
+                    <p>Massive memory capacity with DDR5 upgrade coming</p>
+                </div>
+                <div class="spec-item">
+                    <h4>SSD Storage<span class="upgrade-badge">NVMe Soon</span></h4>
+                    <p>Fast SSD with PCIe 4.0 NVMe upgrade planned</p>
+                </div>
+                <div class="spec-item">
+                    <h4>10Gbps Network</h4>
+                    <p>Unmetered bandwidth on premium network</p>
+                </div>
+                <div class="spec-item">
+                    <h4>DDoS Protection</h4>
+                    <p>Always-on mitigation up to 500Gbps</p>
+                </div>
+                <div class="spec-item">
+                    <h4>ReliableSite DC</h4>
+                    <p>Tier 3+ data centers with N+1 redundancy</p>
+                </div>
+                <div class="spec-item">
+                    <h4>24/7 Monitoring</h4>
+                    <p>Proactive monitoring and instant alerts</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Partners -->
+    <section class="partners">
+        <div class="container">
+            <h3>Infrastructure Partners</h3>
+            <div class="partners-grid">
+                <div class="partner-logo">Seagate Lyve Cloud</div>
+                <div class="partner-logo">ReliableSite</div>
+                <div class="partner-logo">Cloudflare</div>
+                <div class="partner-logo">Let's Encrypt</div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Company -->
+    <section class="company" id="company">
+        <div class="container">
+            <div class="company-grid">
+                <div class="company-content">
+                    <h2>Built for the Future of Storage</h2>
+                    <p>stored.ge is a next-generation storage platform designed from the ground up to meet the demands of modern applications. We combine enterprise-grade reliability with developer-friendly simplicity.</p>
+                    <p>Our unique architecture allows persistent storage that survives VPS rebuilds, making it perfect for containerized applications, CI/CD pipelines, and development workflows.</p>
+                    <p>Founded by infrastructure engineers with decades of combined experience at leading tech companies, we're building the storage platform we wished existed.</p>
+                </div>
+                <div class="company-stats">
+                    <div class="stat">
+                        <div class="stat-number">7</div>
+                        <div class="stat-label">Global Regions</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-number">99.99%</div>
+                        <div class="stat-label">Uptime SLA</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-number">10PB+</div>
+                        <div class="stat-label">Storage Capacity</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-number">24/7</div>
+                        <div class="stat-label">Support Available</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <div class="logo">stored.ge</div>
+                    <p>Enterprise S3 Storage + VPS Platform</p>
+                    <p style="font-size: 0.875rem;">© 2024 stored.ge - A Division of Fairforge LLC</p>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Product</h4>
+                    <ul class="footer-links">
+                        <li><a href="#features">Features</a></li>
+                        <li><a href="#pricing">Pricing</a></li>
+                        <li><a href="#specs">Infrastructure</a></li>
+                        <li><a href="#">Documentation</a></li>
+                        <li><a href="#">API Reference</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Company</h4>
+                    <ul class="footer-links">
+                        <li><a href="#company">About Us</a></li>
+                        <li><a href="#">Blog</a></li>
+                        <li><a href="#">Careers</a></li>
+                        <li><a href="#">Partners</a></li>
+                        <li><a href="#">Contact</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Legal</h4>
+                    <ul class="footer-links">
+                        <li><a href="#">Terms of Service</a></li>
+                        <li><a href="#">Privacy Policy</a></li>
+                        <li><a href="#">SLA</a></li>
+                        <li><a href="#">DPA</a></li>
+                        <li><a href="#">Compliance</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="footer-bottom">
+                <p style="color: var(--text-secondary); font-size: 0.875rem;">
+                    Powered by Seagate Lyve Cloud and ReliableSite Infrastructure
+                </p>
+                <div class="social-links">
+                    <a href="#">Twitter</a>
+                    <a href="#">GitHub</a>
+                    <a href="#">LinkedIn</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Modal -->
+    <div class="modal" id="modal">
+        <div class="modal-content">
+            <h3 id="modal-title">Coming Soon</h3>
+            <p id="modal-message">This feature will be available when we launch in October 2025.</p>
+            <button class="btn btn-primary" onclick="closeModal()">Got It</button>
+        </div>
+    </div>
+
+    <script>
+        // Dark Mode Toggle
+        function toggleTheme() {
+            const html = document.documentElement;
+            const currentTheme = html.getAttribute('data-theme');
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            html.setAttribute('data-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+
+            // Update toggle button
+            const toggle = document.querySelector('.theme-toggle');
+            toggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
+        }
+
+        // Load saved theme
+        const savedTheme = localStorage.getItem('theme') || 'light';
+        document.documentElement.setAttribute('data-theme', savedTheme);
+        if (savedTheme === 'dark') {
+            document.querySelector('.theme-toggle').textContent = '☀️';
+        }
+
+        // Countdown Timer
+        function updateCountdown() {
+            const launchDate = new Date('October 1, 2025 00:00:00').getTime();
+            const now = new Date().getTime();
+            const distance = launchDate - now;
+
+            const days = Math.floor(distance / (1000 * 60 * 60 * 24));
+            const hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+            const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+            const seconds = Math.floor((distance % (1000 * 60)) / 1000);
+
+            document.getElementById('days').textContent = days;
+            document.getElementById('hours').textContent = hours.toString().padStart(2, '0');
+            document.getElementById('minutes').textContent = minutes.toString().padStart(2, '0');
+            document.getElementById('seconds').textContent = seconds.toString().padStart(2, '0');
+
+            if (distance < 0) {
+                document.getElementById('countdown').innerHTML = '<h2>We are LIVE!</h2>';
+            }
+        }
+
+        setInterval(updateCountdown, 1000);
+        updateCountdown();
+
+        // Modal Functions
+        function showModal(type) {
+            const modal = document.getElementById('modal');
+            const title = document.getElementById('modal-title');
+            const message = document.getElementById('modal-message');
+
+            if (type === 'signin') {
+                title.textContent = 'Sign In Coming Soon';
+                message.textContent = 'Customer portal will be available at launch. Join the waitlist to be notified!';
+            } else if (type === 'waitlist-success') {
+                title.textContent = 'Welcome to the Waitlist!';
+                message.textContent = 'You\'re on the list! We\'ll notify you when early access opens.';
+            }
+
+            modal.classList.add('active');
+        }
+
+        function closeModal() {
+            document.getElementById('modal').classList.remove('active');
+        }
+
+        // Waitlist Handler
+        function handleWaitlist(event) {
+            event.preventDefault();
+            // In production, this would send to your backend
+            showModal('waitlist-success');
+            event.target.reset();
+        }
+
+        // Click outside modal to close
+        document.getElementById('modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeModal();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/internal/api/landing.html
+++ b/internal/api/landing.html
@@ -1048,10 +1048,20 @@
             document.getElementById('modal').classList.remove('active');
         }
 
-        // Waitlist Handler
-        function handleWaitlist(event) {
+        // Waitlist Handler — posts the email to the backend, then confirms.
+        async function handleWaitlist(event) {
             event.preventDefault();
-            // In production, this would send to your backend
+            const input = event.target.querySelector('input[type="email"]');
+            const email = input ? input.value : '';
+            try {
+                await fetch('/api/waitlist', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: 'email=' + encodeURIComponent(email)
+                });
+            } catch (err) {
+                // Network error — still acknowledge; the common path succeeds.
+            }
             showModal('waitlist-success');
             event.target.reset();
         }

--- a/internal/api/landing_test.go
+++ b/internal/api/landing_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleRoot_BrowserGetsLandingPage(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRoot(w, req)
+
+	res := w.Result()
+	defer func() { _ = res.Body.Close() }()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Contains(t, res.Header.Get("Content-Type"), "text/html")
+	assert.Contains(t, w.Body.String(), "stored.ge", "embedded landing page should render")
+}
+
+func TestHandleRoot_HeadReturnsNoBody(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRoot(w, req)
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	assert.Empty(t, w.Body.String())
+}
+
+// isS3RootRequest must keep authenticated ListBuckets working: a request to "/"
+// with SigV4 auth (header or presigned query) is an S3 call, not a browser visit.
+func TestIsS3RootRequest(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*http.Request)
+		want  bool
+	}{
+		{"plain browser GET /", func(*http.Request) {}, false},
+		{"browser with html accept", func(r *http.Request) { r.Header.Set("Accept", "text/html") }, false},
+		{"sigv4 authorization header", func(r *http.Request) {
+			r.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=...")
+		}, true},
+		{"presigned query", func(r *http.Request) {
+			q := r.URL.Query()
+			q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+			r.URL.RawQuery = q.Encode()
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tt.setup(req)
+			assert.Equal(t, tt.want, isS3RootRequest(req))
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -505,6 +505,9 @@ func (s *Server) setupRoutes() {
 
 	s.router.Get("/llms.txt", s.handleLlmsTxt)
 
+	// Public pre-launch waitlist signup from the landing page (no auth).
+	s.router.Post("/api/waitlist", s.handleWaitlistSignup)
+
 	// Public marketing landing page at "/" for browsers. Authenticated S3
 	// ListBuckets (GET / with SigV4 auth) is delegated to the catch-all inside
 	// handleRoot, so the S3 API is unaffected. Registered before the catch-all.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -505,6 +505,12 @@ func (s *Server) setupRoutes() {
 
 	s.router.Get("/llms.txt", s.handleLlmsTxt)
 
+	// Public marketing landing page at "/" for browsers. Authenticated S3
+	// ListBuckets (GET / with SigV4 auth) is delegated to the catch-all inside
+	// handleRoot, so the S3 API is unaffected. Registered before the catch-all.
+	s.router.Get("/", s.handleRoot)
+	s.router.Head("/", s.handleRoot)
+
 	s.logger.Info("Registering S3 catch-all handler")
 	s.router.HandleFunc("/*", s.handleS3Request)
 }

--- a/internal/api/waitlist.go
+++ b/internal/api/waitlist.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/mail"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// waitlistRL throttles the public, unauthenticated waitlist endpoint per client
+// IP (10 signups/hour) so it can't be scripted to flood the table. Cloudflare
+// provides edge protection on top of this.
+var waitlistRL = newWaitlistLimiter(10, time.Hour)
+
+// handleWaitlistSignup captures a pre-launch waitlist email from the landing page.
+// Public and unauthenticated. Accepts form-encoded (email=...) or JSON ({"email"}).
+func (s *Server) handleWaitlistSignup(w http.ResponseWriter, r *http.Request) {
+	email := strings.TrimSpace(r.FormValue("email"))
+	if email == "" {
+		var body struct {
+			Email string `json:"email"`
+		}
+		if json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&body) == nil {
+			email = strings.TrimSpace(body.Email)
+		}
+	}
+
+	addr, err := mail.ParseAddress(email)
+	if err != nil || len(email) > 320 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid email"})
+		return
+	}
+	email = strings.ToLower(addr.Address)
+
+	ip := extractClientIP(r)
+	if !waitlistRL.allow(ip, time.Now().Unix()) {
+		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "too many requests"})
+		return
+	}
+
+	// Degrade gracefully without a DB (dev/local): don't fail the visitor's submit.
+	if s.db == nil {
+		s.logger.Warn("waitlist signup with no database", zap.String("email", email))
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	// ON CONFLICT DO NOTHING: re-signing up with the same email is a no-op success.
+	if _, err := s.db.ExecContext(r.Context(), `
+		INSERT INTO waitlist_signups (email, source, ip_address, user_agent)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (email) DO NOTHING`,
+		email, "landing", ip, r.UserAgent()); err != nil {
+		s.logger.Error("waitlist insert", zap.String("email", email), zap.Error(err))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not save"})
+		return
+	}
+
+	s.logger.Info("waitlist signup", zap.String("email", email))
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// waitlistLimiter is a small per-IP sliding-window rate limiter.
+type waitlistLimiter struct {
+	mu         sync.Mutex
+	hits       map[string][]int64
+	limit      int
+	windowSecs int64
+}
+
+func newWaitlistLimiter(limit int, window time.Duration) *waitlistLimiter {
+	return &waitlistLimiter{
+		hits:       make(map[string][]int64),
+		limit:      limit,
+		windowSecs: int64(window.Seconds()),
+	}
+}
+
+// allow reports whether an IP may submit at time `now` (unix seconds), recording
+// the hit when allowed. `now` is injected for testability.
+func (l *waitlistLimiter) allow(ip string, now int64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Bound memory under abuse: reset if the map grows large (mirrors the
+	// management rate limiter's eviction).
+	if len(l.hits) > 10000 {
+		l.hits = make(map[string][]int64)
+	}
+
+	cutoff := now - l.windowSecs
+	kept := l.hits[ip][:0]
+	for _, t := range l.hits[ip] {
+		if t > cutoff {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) >= l.limit {
+		l.hits[ip] = kept
+		return false
+	}
+	l.hits[ip] = append(kept, now)
+	return true
+}

--- a/internal/api/waitlist_test.go
+++ b/internal/api/waitlist_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func waitlistRequest(email, ip string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/waitlist",
+		strings.NewReader("email="+email))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Forwarded-For", ip) // unique IP per test → no limiter cross-talk
+	return req
+}
+
+func TestWaitlist_ValidEmail_Inserts(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO waitlist_signups`).
+		WithArgs("alice@example.com", "landing", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	s := &Server{db: db, logger: zap.NewNop()}
+	w := httptest.NewRecorder()
+	s.handleWaitlistSignup(w, waitlistRequest("alice@example.com", "203.0.113.1"))
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	assert.Contains(t, w.Body.String(), "ok")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitlist_InvalidEmail_400(t *testing.T) {
+	s := &Server{logger: zap.NewNop()} // no DB call expected
+	w := httptest.NewRecorder()
+	s.handleWaitlistSignup(w, waitlistRequest("not-an-email", "203.0.113.2"))
+
+	require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+}
+
+func TestWaitlist_Duplicate_IsOK(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// ON CONFLICT DO NOTHING → 0 rows affected, but still a success for the visitor.
+	mock.ExpectExec(`INSERT INTO waitlist_signups`).
+		WithArgs("dup@example.com", "landing", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	s := &Server{db: db, logger: zap.NewNop()}
+	w := httptest.NewRecorder()
+	s.handleWaitlistSignup(w, waitlistRequest("dup@example.com", "203.0.113.3"))
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitlist_NilDB_Degrades(t *testing.T) {
+	s := &Server{logger: zap.NewNop()} // db nil
+	w := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		s.handleWaitlistSignup(w, waitlistRequest("bob@example.com", "203.0.113.4"))
+	})
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+}
+
+func TestWaitlist_NormalizesEmailCase(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO waitlist_signups`).
+		WithArgs("mixed@example.com", "landing", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	s := &Server{db: db, logger: zap.NewNop()}
+	w := httptest.NewRecorder()
+	s.handleWaitlistSignup(w, waitlistRequest("Mixed@Example.com", "203.0.113.5"))
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitlistLimiter(t *testing.T) {
+	l := newWaitlistLimiter(3, time.Hour)
+	const now = int64(1_000_000)
+
+	// First 3 from an IP are allowed; the 4th is throttled.
+	assert.True(t, l.allow("1.1.1.1", now))
+	assert.True(t, l.allow("1.1.1.1", now))
+	assert.True(t, l.allow("1.1.1.1", now))
+	assert.False(t, l.allow("1.1.1.1", now))
+
+	// A different IP is unaffected.
+	assert.True(t, l.allow("2.2.2.2", now))
+
+	// After the window passes, the first IP is allowed again.
+	assert.True(t, l.allow("1.1.1.1", now+3601))
+}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -33,6 +33,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 041 | Object tagging: `tags JSONB` (default `{}`) on `object_head_cache` — per-object S3 `?tagging` sub-resource (flat key/value map) |
 | 042 | Content-Disposition: `content_disposition TEXT` (default `''`) on `object_head_cache` — stored response header; `cdn_force_download BOOLEAN` (default FALSE) on `buckets` — CDN force-attachment toggle |
 | 043 | Metered billing: `metered_usage_reports` table (daily Stripe meter reports + idempotency guard); `spending_cap_cents BIGINT` (default 0) on `tenant_quotas` |
+| 044 | Waitlist: `waitlist_signups` table (email UNIQUE, source, ip, user_agent) — pre-launch landing-page email capture |
 
 ## Key Tables
 

--- a/internal/database/migrations/044_waitlist.sql
+++ b/internal/database/migrations/044_waitlist.sql
@@ -1,0 +1,14 @@
+-- 044_waitlist.sql: Pre-launch waitlist email capture for the stored.ge landing page.
+-- Idempotent — safe to re-run on every deploy.
+
+CREATE TABLE IF NOT EXISTS waitlist_signups (
+    id BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'landing',
+    ip_address TEXT NOT NULL DEFAULT '',
+    user_agent TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_created ON waitlist_signups (created_at DESC);


### PR DESCRIPTION
## What this does
`stored.ge/` currently returns **403** to the public (the app has no homepage at root — only `/dashboard/`, auth-gated). This embeds the `stored-ge-website` landing page into the vaultaire binary and serves it for anonymous browser visits to `/`.

## Why it's safe for the S3 API
The only S3 op on `/` is **ListBuckets**, which always carries SigV4 auth. `handleRoot` delegates any `GET /` with an `Authorization` header or presigned `X-Amz-*` query to the existing S3 handler — **untouched**. The only behavior change is anonymous `GET /`: today a 403, now the landing page. `/dashboard`, `/cdn`, `/health`, `/{bucket}/{key}` are separate routes, unaffected. Tested: browser → 200 HTML; auth header → S3 path.

## Serving model
Served **straight from the embedded binary** (`//go:embed landing.html`) — **no storage backend, no DB, no CDN**. Same mechanism as the dashboard's embedded templates: fast, always-up (no backend dependency), versioned with the code.

## ⚠️ DRAFT — content is stale pre-launch copy
Needs your refresh before going live:
- Countdown targets **Oct 1, 2025** (would render expired)
- A **PRE-LAUNCH** badge + **Join Waitlist** form
- "Launching October 2025"

Mechanism is verified; the copy/positioning is yours. Tell me the posture (publicly launched vs still waitlisting) and I'll refresh, then flip out of draft.