### PR TITLE
feat(dashboard): admin waitlist page with CSV export

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -94,6 +94,8 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/dashboard/settings/cancel-deletion` | POST | session | Cancel pending account deletion |
 | `/admin/tenants/{id}/bandwidth-limit` | POST | session + admin | Update tenant bandwidth limit |
 | `/admin/tenants/{id}/reset-mfa` | POST | session + admin | Reset user's 2FA |
+| `/admin/waitlist` | GET | session + admin | Pre-launch waitlist signups (count + list) |
+| `/admin/waitlist/export` | GET | session + admin | Download all waitlist signups as CSV |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -137,6 +137,17 @@ current month's sum from `bandwidth_usage_daily`. Charge math reuses
 for fixed-price (Vault/free) tenants, so the card is hidden. Template card gated on
 `{{if .IsMetered}}` in `billing.html`.
 
+## Admin Waitlist (`waitlist.go`)
+
+Admin-only view of pre-launch waitlist signups (captured by `POST /api/waitlist`
+in the api package → `waitlist_signups`, migration 044).
+- `HandleAdminWaitlist(tmpl, db, logger)` — GET `/admin/waitlist`: total count + the
+  1000 most recent signups (email, source, date). Renders the `admin` layout.
+- `HandleAdminWaitlistExport(db, logger)` — GET `/admin/waitlist/export`: streams **all**
+  signups as a CSV download (`encoding/csv`, `Content-Disposition: attachment`).
+Both redirect to `/login` without a session; nil-DB degrades to empty/zero. Linked
+from the admin sidebar nav. Template: `templates/admin/waitlist.html`.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/waitlist.go
+++ b/internal/dashboard/handlers/waitlist.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"html/template"
+	"net/http"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// waitlistRow is one pre-launch signup for the admin table.
+type waitlistRow struct {
+	Email      string
+	Source     string
+	CreatedFmt string
+}
+
+// HandleAdminWaitlist renders the admin waitlist page: total count + recent signups.
+func HandleAdminWaitlist(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-waitlist")
+		withCSRF(r.Context(), data)
+		data["SignupCount"] = 0
+		data["Signups"] = []waitlistRow{}
+
+		if db != nil {
+			rows, count := queryWaitlist(r.Context(), db, logger)
+			data["Signups"] = rows
+			data["SignupCount"] = count
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin waitlist", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleAdminWaitlistExport streams all signups as a CSV download.
+func HandleAdminWaitlistExport(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dashauth.GetSession(r.Context()) == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition",
+			`attachment; filename="waitlist-`+time.Now().Format("2006-01-02")+`.csv"`)
+
+		cw := csv.NewWriter(w)
+		defer cw.Flush()
+		_ = cw.Write([]string{"email", "source", "created_at"})
+
+		if db == nil {
+			return
+		}
+		rows, err := db.QueryContext(r.Context(),
+			`SELECT email, source, created_at FROM waitlist_signups ORDER BY created_at DESC`)
+		if err != nil {
+			logger.Error("waitlist export query", zap.Error(err))
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var email, source string
+			var created time.Time
+			if err := rows.Scan(&email, &source, &created); err != nil {
+				logger.Error("waitlist export scan", zap.Error(err))
+				continue
+			}
+			_ = cw.Write([]string{email, source, created.UTC().Format(time.RFC3339)})
+		}
+	}
+}
+
+func queryWaitlist(ctx context.Context, db *sql.DB, logger *zap.Logger) ([]waitlistRow, int) {
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM waitlist_signups`).Scan(&count); err != nil {
+		logger.Debug("waitlist count", zap.Error(err))
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT email, source, created_at FROM waitlist_signups ORDER BY created_at DESC LIMIT 1000`)
+	if err != nil {
+		logger.Error("waitlist list query", zap.Error(err))
+		return nil, count
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []waitlistRow
+	for rows.Next() {
+		var email, source string
+		var created time.Time
+		if err := rows.Scan(&email, &source, &created); err != nil {
+			logger.Error("waitlist list scan", zap.Error(err))
+			continue
+		}
+		out = append(out, waitlistRow{
+			Email:      email,
+			Source:     source,
+			CreatedFmt: created.Format("Jan 2, 2006 15:04 MST"),
+		})
+	}
+	return out, count
+}

--- a/internal/dashboard/handlers/waitlist_test.go
+++ b/internal/dashboard/handlers/waitlist_test.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testWaitlistTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("admin").Parse(
+		`{{define "admin"}}<span class="count">{{.SignupCount}}</span>` +
+			`{{range .Signups}}<span class="row">{{.Email}}</span>{{end}}{{end}}`))
+}
+
+func TestHandleAdminWaitlist_NoSession(t *testing.T) {
+	h := HandleAdminWaitlist(testWaitlistTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/waitlist", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminWaitlist_ListsSignups(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM waitlist_signups`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	mock.ExpectQuery(`SELECT email, source, created_at FROM waitlist_signups`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "source", "created_at"}).
+			AddRow("a@example.com", "landing", time.Now()).
+			AddRow("b@example.com", "landing", time.Now()))
+
+	h := HandleAdminWaitlist(testWaitlistTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/waitlist", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `class="count">2`)
+	assert.Contains(t, body, "a@example.com")
+	assert.Contains(t, body, "b@example.com")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminWaitlistExport_CSV(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT email, source, created_at FROM waitlist_signups`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "source", "created_at"}).
+			AddRow("a@example.com", "landing", time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)))
+
+	h := HandleAdminWaitlistExport(db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/waitlist/export", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	body := w.Body.String()
+	assert.Contains(t, body, "email,source,created_at")
+	assert.Contains(t, body, "a@example.com,landing,2026-06-01T12:00:00Z")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminWaitlistExport_NoSession(t *testing.T) {
+	h := HandleAdminWaitlistExport(nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/waitlist/export", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -242,6 +242,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/backends.html",
 	))
+	waitlistTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/waitlist.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -260,6 +264,8 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/bandwidth-limit", handlers.HandleUpdateBandwidthLimit(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/reset-mfa", handlers.HandleAdminResetMFA(deps.Auth, deps.Logger))
 		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
+		ar.Get("/waitlist", handlers.HandleAdminWaitlist(waitlistTmpl, deps.DB, deps.Logger))
+		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		if deps.Engine != nil {
 			ar.Get("/backends", handlers.HandleAdminBackends(backendsTmpl, deps.Engine, deps.HealthChecker, deps.Logger))
 			ar.Post("/backends/{name}/primary", handlers.HandleSetPrimary(deps.Engine, deps.Logger))

--- a/internal/dashboard/templates/admin/waitlist.html
+++ b/internal/dashboard/templates/admin/waitlist.html
@@ -1,0 +1,44 @@
+{{define "title"}}Waitlist — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Waitlist Signups</h1>
+    <a href="/admin/waitlist/export" class="btn btn-sm">Download CSV</a>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Total Signups</div>
+        <div class="card-value">{{.SignupCount}}</div>
+    </div>
+</div>
+
+<div class="card">
+    {{if .Signups}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Source</th>
+                    <th>Signed Up</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Signups}}
+                <tr>
+                    <td>{{.Email}}</td>
+                    <td>{{.Source}}</td>
+                    <td>{{.CreatedFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{if gt .SignupCount 1000}}
+    <p class="text-muted">Showing the 1000 most recent of {{.SignupCount}}. Use “Download CSV” for the full list.</p>
+    {{end}}
+    {{else}}
+    <p class="text-muted">No signups yet.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -21,6 +21,7 @@
                 <a href="/admin/tenants" class="sidebar-link{{if eq .Page "admin-tenants"}} sidebar-link--active{{end}}">Tenants</a>
                 <a href="/admin/system" class="sidebar-link{{if eq .Page "admin-system"}} sidebar-link--active{{end}}">System</a>
                 <a href="/admin/backends" class="sidebar-link{{if eq .Page "admin-backends"}} sidebar-link--active{{end}}">Backends</a>
+                <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>


### PR DESCRIPTION
Adds an admin-only view of the pre-launch waitlist so signups can be checked without SSHing into Postgres.

- **GET /admin/waitlist** — total count + the 1000 most recent signups (email, source, date)
- **GET /admin/waitlist/export** — full list as a CSV download
- **"Waitlist"** link added to the admin sidebar nav

Reads `waitlist_signups` (migration 044, already on prod). Same admin-role + MFA guards as the rest of `/admin/*`. 4 tests (no-session redirect, list render, CSV export, export auth) — all green; lint clean.

Once merged + deployed, log into the dashboard as admin → **Waitlist** in the sidebar.