### PR TITLE
feat(auth): SIGNUPS_ENABLED gate to close public signups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ GitHub Actions Deploy (`.github/workflows/deploy.yml`):
 | `GITHUB_CLIENT_SECRET` | — | GitHub OAuth App client secret |
 | `VAULTAIRE_BASE_URL` | http://localhost:8000 | Base URL for OAuth callbacks |
 | `JWT_SECRET` | — | **Required** — JWT signing key for API auth |
+| `SIGNUPS_ENABLED` | true | Set to `false` to close public signups (gates web form, `/auth/register` API, and OAuth signup at `auth.CreateUserWithTenant`); existing-user login still works |
 | `VERIFY_SECRET` | — | HMAC secret for email verification tokens |
 | `GEYSER_ACCESS_KEY`, `GEYSER_SECRET_KEY` | — | Geyser tape S3 credentials |
 | `GEYSER_BUCKET`, `GEYSER_ENDPOINT` | — | Geyser bucket name and endpoint URL |

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -123,6 +125,18 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		verifySecret = os.Getenv("JWT_SECRET")
 	}
 	s.auth.SetVerifySecret(verifySecret)
+
+	// Public signups: enabled by default; set SIGNUPS_ENABLED=false to close them
+	// (pre-launch). Gated at CreateUserWithTenant, so the web form, /auth/register
+	// API, and OAuth signup are all blocked; existing-user login still works.
+	if v := os.Getenv("SIGNUPS_ENABLED"); v != "" {
+		if enabled, parseErr := strconv.ParseBool(v); parseErr == nil {
+			s.auth.SetSignupsEnabled(enabled)
+			if !enabled {
+				logger.Info("public signups DISABLED (SIGNUPS_ENABLED=false)")
+			}
+		}
+	}
 
 	// Populate in-memory maps from PostgreSQL so that existing users
 	// can authenticate immediately after a restart/deploy.
@@ -602,6 +616,10 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	user, tenant, apiKey, err := s.auth.CreateUserWithTenant(
 		r.Context(), req.Email, req.Password, req.Company)
 	if err != nil {
+		if errors.Is(err, auth.ErrSignupsDisabled) {
+			http.Error(w, "Signups are currently closed. Join the waitlist at https://stored.ge", http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -69,6 +69,25 @@ Password reset rate limiting is in-memory (per-email, 3/hour, sliding window). T
 
 `Auth.ValidateRequest` (handlers.go) — returns `(tenantID, *KeyScope, error)`. Queries `tenants` first (primary key, full access), falls back to `api_keys` JOIN users+tenants for scoped keys.
 
+## Signup Gate (pre-launch)
+
+Public account creation can be closed with a single switch. `CreateUserWithTenant`
+is the **sole chokepoint** for every signup path — the dashboard `/register` form,
+the JSON `POST /auth/register` API, **and** OAuth signup (`CreateUserFromOAuth`
+calls `CreateUserWithTenant` internally). Gating that one function blocks all three.
+
+- `SetSignupsEnabled(bool)` / `SignupsEnabled() bool` — toggle/read. Default **true**.
+- When disabled, `CreateUserWithTenant` returns `ErrSignupsDisabled` before any work
+  (no DB write, no in-memory entry). OAuth wraps it with `%w`, so callers use
+  `errors.Is(err, auth.ErrSignupsDisabled)`.
+- **Existing-user login is unaffected** — only *new account creation* is gated.
+  Password login and OAuth login for already-linked users still work (those paths
+  don't call `CreateUserWithTenant`).
+- Wired in `server.go`: `SIGNUPS_ENABLED` env (parsed with `strconv.ParseBool`;
+  unset = enabled). Handlers respond gracefully: dashboard `/register` shows
+  "Signups are closed — join the waitlist" (and the GET page redirects to `/`),
+  `/auth/register` returns 403, OAuth callback redirects would-be new signups to `/`.
+
 ## Slug Generation + Bucket Backfill (`slug.go`, `backfill.go`)
 
 - `GenerateSlug(company)` — URL-safe slug from company name (deterministic, no DB)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -71,7 +72,15 @@ type AuthService struct {
 	resetMu         sync.Mutex
 	activityTracker *ActivityTracker
 	auditLogger     *AuditLogger
+	signupsEnabled  bool // when false, all account creation is rejected
 }
+
+// ErrSignupsDisabled is returned by CreateUserWithTenant — the single chokepoint
+// for the web form (/register), the JSON API (/auth/register), AND OAuth signup
+// (CreateUserFromOAuth calls CreateUserWithTenant) — when public signups are
+// turned off via SetSignupsEnabled(false). Gating this one function blocks every
+// account-creation path at the source.
+var ErrSignupsDisabled = errors.New("signups are currently disabled")
 
 // Database interface for auth operations
 type Database interface {
@@ -106,8 +115,18 @@ func NewAuthService(db Database, sqlDB *sql.DB) *AuthService {
 		resetRates:      make(map[string][]time.Time),
 		activityTracker: nil,
 		auditLogger:     nil,
+		signupsEnabled:  true, // default: signups allowed (prod sets SIGNUPS_ENABLED=false to close)
 	}
 }
+
+// SetSignupsEnabled toggles public account creation. When disabled,
+// CreateUserWithTenant rejects new accounts — which closes the web form, the
+// /auth/register API, and OAuth signup, since all three funnel through it.
+// Existing-user login (password or OAuth) is unaffected.
+func (a *AuthService) SetSignupsEnabled(enabled bool) { a.signupsEnabled = enabled }
+
+// SignupsEnabled reports whether public account creation is currently allowed.
+func (a *AuthService) SignupsEnabled() bool { return a.signupsEnabled }
 
 // SetJWTSecret overrides the default JWT signing key.
 // Call this from main.go with the value from the JWT_SECRET env var.
@@ -271,6 +290,12 @@ func (a *AuthService) CreateUser(ctx context.Context, email, password string) (*
 // caller should surface the error so the operator knows persistence
 // failed.
 func (a *AuthService) CreateUserWithTenant(ctx context.Context, email, password, company string) (*User, *Tenant, *APIKey, error) {
+	// Single chokepoint: when signups are disabled, reject before any work so
+	// the web form, /auth/register API, and OAuth signup are all blocked here.
+	if !a.signupsEnabled {
+		return nil, nil, nil, ErrSignupsDisabled
+	}
+
 	// Validate email
 	email = strings.ToLower(strings.TrimSpace(email))
 	if !strings.Contains(email, "@") {

--- a/internal/auth/signup_gate_test.go
+++ b/internal/auth/signup_gate_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignupsEnabled_DefaultTrue(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	assert.True(t, svc.SignupsEnabled(), "signups should default to enabled")
+}
+
+func TestCreateUserWithTenant_BlockedWhenSignupsDisabled(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetSignupsEnabled(false)
+
+	user, tenant, key, err := svc.CreateUserWithTenant(
+		context.Background(), "blocked@example.com", "pw-123456", "Co")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSignupsDisabled)
+	assert.Nil(t, user)
+	assert.Nil(t, tenant)
+	assert.Nil(t, key)
+
+	// Nothing leaked into the in-memory maps.
+	_, exists := svc.users["blocked@example.com"]
+	assert.False(t, exists, "no user should be created when signups are disabled")
+}
+
+func TestCreateUserFromOAuth_BlockedWhenSignupsDisabled(t *testing.T) {
+	svc := NewAuthService(nil, nil)
+	svc.SetSignupsEnabled(false)
+
+	// OAuth signup funnels through CreateUserWithTenant, so it is blocked at the
+	// same chokepoint; the wrapped error still matches via errors.Is.
+	user, tenant, err := svc.CreateUserFromOAuth(
+		context.Background(), "oauth@example.com", "Name", "google", "g-123")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSignupsDisabled),
+		"OAuth signup must be blocked via the chokepoint")
+	assert.Nil(t, user)
+	assert.Nil(t, tenant)
+}
+
+func TestCreateUserWithTenant_AllowedWhenEnabled(t *testing.T) {
+	svc := NewAuthService(nil, nil) // default enabled
+
+	user, _, _, err := svc.CreateUserWithTenant(
+		context.Background(), "ok@example.com", "pw-123456", "Co")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
+	// Toggling back on after a disable works.
+	svc.SetSignupsEnabled(false)
+	svc.SetSignupsEnabled(true)
+	user2, _, _, err := svc.CreateUserWithTenant(
+		context.Background(), "ok2@example.com", "pw-123456", "Co")
+	require.NoError(t, err)
+	require.NotNil(t, user2)
+}

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -47,8 +47,8 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/static/*` | GET | none | CSS, JS assets |
 | `/login` | GET | none | Login page |
 | `/login` | POST | none | Validate credentials, create session, redirect to /dashboard |
-| `/register` | GET | none | Registration page |
-| `/register` | POST | none | Create user+tenant, create session, redirect to /dashboard |
+| `/register` | GET | none | Registration page (redirects to `/` when signups closed) |
+| `/register` | POST | none | Create user+tenant, create session, redirect to /dashboard (gated by `SIGNUPS_ENABLED`) |
 | `/logout` | GET | none | Delete session, clear cookie, redirect to /login |
 | `/legal/privacy` | GET | none | Privacy Policy (GDPR-compliant) |
 | `/legal/terms` | GET | none | Terms of Service |

--- a/internal/dashboard/handlers/oauth.go
+++ b/internal/dashboard/handlers/oauth.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,9 +122,15 @@ func HandleOAuthCallback(
 			return
 		}
 
-		// Find or create user.
+		// Find or create user. Existing users log in; new accounts are created
+		// unless signups are closed (CreateUserFromOAuth → CreateUserWithTenant).
 		user, err := findOrCreateOAuthUser(r.Context(), authSvc, db, provider, ou)
 		if err != nil {
+			if errors.Is(err, auth.ErrSignupsDisabled) {
+				// Would-be new signup while closed — send them to the waitlist.
+				http.Redirect(w, r, "/", http.StatusSeeOther)
+				return
+			}
 			logger.Error("oauth: find or create user", zap.String("provider", provider), zap.Error(err))
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -60,7 +60,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	// --- Public auth routes ---
 	r.Get("/login", renderAuthPage(baseTmpl, "login", deps))
 	r.Post("/login", loginRL.Limit(handleLogin(baseTmpl, deps)).ServeHTTP)
-	r.Get("/register", renderAuthPage(baseTmpl, "register", deps))
+	// When signups are closed, the register page redirects to the homepage
+	// (waitlist). The POST is still gated server-side at CreateUserWithTenant.
+	r.Get("/register", func(w http.ResponseWriter, r *http.Request) {
+		if deps.Auth != nil && !deps.Auth.SignupsEnabled() {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
+		renderAuthPage(baseTmpl, "register", deps)(w, r)
+	})
 	r.Post("/register", handleRegister(baseTmpl, deps))
 	r.Get("/logout", handleLogout(deps.Sessions))
 
@@ -407,9 +415,12 @@ func handleRegister(baseTmpl *template.Template, deps Deps) http.HandlerFunc {
 
 		user, _, _, err := deps.Auth.CreateUserWithTenant(r.Context(), email, password, company)
 		if err != nil {
-			if err.Error() == "user already exists" {
+			switch {
+			case errors.Is(err, auth.ErrSignupsDisabled):
+				renderErr("Signups are closed for now — join the waitlist on our homepage.")
+			case err.Error() == "user already exists":
 				renderErr("An account with that email already exists.")
-			} else {
+			default:
 				deps.Logger.Error("registration failed", zap.Error(err))
 				renderErr("Registration failed. Please try again.")
 			}


### PR DESCRIPTION
Closes public account creation for pre-launch — a **true** block, not just hiding the form.

## Why a single gate works
There are three signup paths, but they all funnel through one function:
- Dashboard `POST /register` → `CreateUserWithTenant`
- JSON API `POST /auth/register` → `CreateUserWithTenant`
- OAuth (Google/GitHub) `first login auto-creates` → `CreateUserFromOAuth` → **`CreateUserWithTenant`**

So gating `CreateUserWithTenant` blocks **all three** at the source (form, curl-able API, and OAuth). Hiding the web form alone would have left the API and OAuth open.

## Behavior
- `SIGNUPS_ENABLED=false` (env) → `CreateUserWithTenant` returns `ErrSignupsDisabled` before any work. Default (unset) = enabled.
- **Existing-user login is unaffected** — password and OAuth login for already-linked users still work; only *new account creation* is gated.
- Graceful UX: `/register` form shows "signups closed — join the waitlist" and the GET page redirects to `/`; `/auth/register` returns 403; OAuth callback sends would-be new signups to the waitlist.

## Tests
`internal/auth/signup_gate_test.go` — blocked-when-disabled (no user leaked into maps), OAuth path blocked via wrapped error, allowed-when-enabled, default-true. Race + lint clean.

## ⚠️ Activation requires an env change on prod
Merging this is inert until `SIGNUPS_ENABLED=false` is set in `/opt/vaultaire/configs/.env` on SLC (then the deploy restart picks it up). Documented in CLAUDE.md.