### PR TITLE
feat(api): bandwidth threshold alerts via email + events [Phase 4.3]

### DIFF
--- a/internal/api/bandwidth_alerts.go
+++ b/internal/api/bandwidth_alerts.go
@@ -1,0 +1,256 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/email"
+	"go.uber.org/zap"
+)
+
+// BandwidthAlerter checks tenant egress against configured thresholds and fires
+// alerts (event + email) when a threshold is crossed, once per calendar month.
+type BandwidthAlerter struct {
+	db      *sql.DB
+	emailer email.Sender
+	logger  *zap.Logger
+}
+
+func NewBandwidthAlerter(db *sql.DB, logger *zap.Logger) *BandwidthAlerter {
+	return &BandwidthAlerter{db: db, logger: logger}
+}
+
+func (a *BandwidthAlerter) SetEmailSender(s email.Sender) { a.emailer = s }
+
+// StartBandwidthAlerts launches a goroutine that seeds default alert rows and
+// checks bandwidth thresholds every hour. Nil-safe on receiver and db.
+func (a *BandwidthAlerter) StartBandwidthAlerts(ctx context.Context) {
+	if a == nil || a.db == nil {
+		return
+	}
+	go func() {
+		a.seedDefaultAlerts(ctx)
+		a.checkBandwidthAlerts(ctx)
+
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.seedDefaultAlerts(ctx)
+				a.checkBandwidthAlerts(ctx)
+			}
+		}
+	}()
+}
+
+// seedDefaultAlerts ensures every tenant with a bandwidth limit has 80% and 95%
+// email alert rows. Idempotent via ON CONFLICT DO NOTHING.
+func (a *BandwidthAlerter) seedDefaultAlerts(ctx context.Context) {
+	if a.db == nil {
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	rows, err := a.db.QueryContext(cctx,
+		`SELECT tenant_id FROM tenant_quotas WHERE bandwidth_limit_bytes > 0`)
+	if err != nil {
+		a.logger.Error("query tenants for bandwidth alert seeding", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tenantIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			a.logger.Error("scan tenant for bandwidth alert seeding", zap.Error(err))
+			continue
+		}
+		tenantIDs = append(tenantIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		a.logger.Error("iterate tenants for bandwidth alert seeding", zap.Error(err))
+		return
+	}
+
+	for _, id := range tenantIDs {
+		for _, pct := range []int{80, 95} {
+			if _, err := a.db.ExecContext(cctx,
+				`INSERT INTO bandwidth_alerts (tenant_id, threshold_pct, alert_type)
+				 VALUES ($1, $2, 'email')
+				 ON CONFLICT (tenant_id, threshold_pct, alert_type) DO NOTHING`,
+				id, pct); err != nil {
+				a.logger.Error("seed bandwidth alert",
+					zap.String("tenant", id), zap.Int("pct", pct), zap.Error(err))
+			}
+		}
+	}
+}
+
+// checkBandwidthAlerts iterates tenants with a bandwidth limit and fires alerts
+// for any threshold crossed this calendar month that hasn't already been alerted.
+func (a *BandwidthAlerter) checkBandwidthAlerts(ctx context.Context) {
+	if a.db == nil {
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	rows, err := a.db.QueryContext(cctx,
+		`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas WHERE bandwidth_limit_bytes > 0`)
+	if err != nil {
+		a.logger.Error("query tenants for bandwidth alerts", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type tenantLimit struct {
+		tenantID   string
+		limitBytes int64
+	}
+	var tenants []tenantLimit
+	for rows.Next() {
+		var tl tenantLimit
+		if err := rows.Scan(&tl.tenantID, &tl.limitBytes); err != nil {
+			a.logger.Error("scan tenant bandwidth limit", zap.Error(err))
+			continue
+		}
+		tenants = append(tenants, tl)
+	}
+	if err := rows.Err(); err != nil {
+		a.logger.Error("iterate tenants for bandwidth alerts", zap.Error(err))
+		return
+	}
+
+	for _, tl := range tenants {
+		a.checkTenantAlerts(cctx, tl.tenantID, tl.limitBytes)
+	}
+}
+
+func (a *BandwidthAlerter) checkTenantAlerts(ctx context.Context, tenantID string, limitBytes int64) {
+	var usedBytes int64
+	if err := a.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(egress_bytes), 0)
+		 FROM bandwidth_usage_daily
+		 WHERE tenant_id = $1 AND date >= date_trunc('month', CURRENT_DATE)`,
+		tenantID).Scan(&usedBytes); err != nil {
+		a.logger.Error("query month egress for bandwidth alert",
+			zap.String("tenant", tenantID), zap.Error(err))
+		return
+	}
+
+	rows, err := a.db.QueryContext(ctx,
+		`SELECT id, threshold_pct, alert_type, last_fired_at
+		 FROM bandwidth_alerts
+		 WHERE tenant_id = $1 AND enabled = true`,
+		tenantID)
+	if err != nil {
+		a.logger.Error("query bandwidth alerts for tenant",
+			zap.String("tenant", tenantID), zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	type alertRow struct {
+		id           string
+		thresholdPct int
+		alertType    string
+		lastFiredAt  sql.NullTime
+	}
+	var alerts []alertRow
+	for rows.Next() {
+		var ar alertRow
+		if err := rows.Scan(&ar.id, &ar.thresholdPct, &ar.alertType, &ar.lastFiredAt); err != nil {
+			a.logger.Error("scan bandwidth alert", zap.Error(err))
+			continue
+		}
+		alerts = append(alerts, ar)
+	}
+	if err := rows.Err(); err != nil {
+		a.logger.Error("iterate bandwidth alerts", zap.Error(err))
+		return
+	}
+
+	monthStart := bandwidthAlertMonthStart()
+
+	for _, ar := range alerts {
+		if usedBytes*100 < limitBytes*int64(ar.thresholdPct) {
+			continue
+		}
+		if ar.lastFiredAt.Valid && !ar.lastFiredAt.Time.Before(monthStart) {
+			continue
+		}
+		a.fireAlert(ctx, tenantID, ar.id, ar.thresholdPct, ar.alertType, usedBytes, limitBytes)
+	}
+}
+
+func (a *BandwidthAlerter) fireAlert(ctx context.Context, tenantID, alertID string, thresholdPct int, alertType string, usedBytes, limitBytes int64) {
+	pctUsed := int64(0)
+	if limitBytes > 0 {
+		pctUsed = usedBytes * 100 / limitBytes
+	}
+
+	emitEvent(ctx, a.db, a.logger, "bandwidth.alert", tenantID, map[string]interface{}{
+		"threshold_pct": thresholdPct,
+		"used_bytes":    usedBytes,
+		"limit_bytes":   limitBytes,
+		"pct_used":      pctUsed,
+	})
+
+	if alertType == "email" && a.emailer != nil {
+		to := a.bandwidthTenantEmail(ctx, tenantID)
+		if to != "" {
+			subject := fmt.Sprintf("You've used %d%% of your stored.ge bandwidth limit", pctUsed)
+			body := fmt.Sprintf(
+				"Your stored.ge bandwidth usage has reached %s of your %s monthly limit (%d%%).",
+				formatBandwidthBytes(usedBytes), formatBandwidthBytes(limitBytes), pctUsed)
+			if err := a.emailer.Send(ctx, to, subject, body, body); err != nil {
+				a.logger.Warn("send bandwidth alert email",
+					zap.String("tenant", tenantID), zap.Error(err))
+			}
+		}
+	}
+
+	if _, err := a.db.ExecContext(ctx,
+		`UPDATE bandwidth_alerts SET last_fired_at = NOW() WHERE id = $1`,
+		alertID); err != nil {
+		a.logger.Error("update bandwidth alert last_fired_at",
+			zap.String("alert", alertID), zap.Error(err))
+	}
+}
+
+func (a *BandwidthAlerter) bandwidthTenantEmail(ctx context.Context, tenantID string) string {
+	var e sql.NullString
+	if err := a.db.QueryRowContext(ctx,
+		`SELECT email FROM tenants WHERE id = $1`, tenantID).Scan(&e); err != nil {
+		return ""
+	}
+	if e.Valid {
+		return e.String
+	}
+	return ""
+}
+
+func bandwidthAlertMonthStart() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func formatBandwidthBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/api/bandwidth_alerts_test.go
+++ b/internal/api/bandwidth_alerts_test.go
@@ -1,0 +1,264 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeBandwidthEmailSender struct {
+	mu   sync.Mutex
+	sent []bwEmail
+}
+
+type bwEmail struct {
+	to, subject, html, text string
+}
+
+func (f *fakeBandwidthEmailSender) Send(_ context.Context, to, subject, html, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, bwEmail{to, subject, html, text})
+	return nil
+}
+
+func (f *fakeBandwidthEmailSender) emails() []bwEmail {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]bwEmail, len(f.sent))
+	copy(cp, f.sent)
+	return cp
+}
+
+func TestCheckBandwidthAlerts_FiresAt80(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.MatchExpectationsInOrder(false)
+
+	// 1. Query tenants with bandwidth limits.
+	mock.ExpectQuery(`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bandwidth_limit_bytes"}).
+			AddRow("tenant-1", int64(1000)))
+
+	// 2. Current month egress = 800 (80% of 1000).
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(egress_bytes\), 0\)`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(800)))
+
+	// 3. Enabled alerts for tenant.
+	mock.ExpectQuery(`SELECT id, threshold_pct, alert_type, last_fired_at FROM bandwidth_alerts`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "threshold_pct", "alert_type", "last_fired_at"}).
+			AddRow("alert-1", 80, "email", nil))
+
+	// 4. emitEvent INSERT.
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(sqlmock.AnyArg(), "bandwidth.alert", "tenant-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 5. Async dispatchWebhooks query — return empty.
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+
+	// 6. Tenant email lookup.
+	mock.ExpectQuery(`SELECT email FROM tenants WHERE id`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow("user@example.com"))
+
+	// 7. Update last_fired_at.
+	mock.ExpectExec(`UPDATE bandwidth_alerts SET last_fired_at`).
+		WithArgs("alert-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	emailer := &fakeBandwidthEmailSender{}
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.SetEmailSender(emailer)
+
+	alerter.checkBandwidthAlerts(context.Background())
+
+	// Wait for async dispatchWebhooks goroutine.
+	time.Sleep(100 * time.Millisecond)
+
+	emails := emailer.emails()
+	require.Len(t, emails, 1)
+	assert.Equal(t, "user@example.com", emails[0].to)
+	assert.Contains(t, emails[0].subject, "80%")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckBandwidthAlerts_BelowThreshold_NoFire(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bandwidth_limit_bytes"}).
+			AddRow("tenant-1", int64(1000)))
+
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(egress_bytes\), 0\)`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(700)))
+
+	mock.ExpectQuery(`SELECT id, threshold_pct, alert_type, last_fired_at FROM bandwidth_alerts`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "threshold_pct", "alert_type", "last_fired_at"}).
+			AddRow("alert-1", 80, "email", nil))
+
+	emailer := &fakeBandwidthEmailSender{}
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.SetEmailSender(emailer)
+
+	alerter.checkBandwidthAlerts(context.Background())
+
+	assert.Empty(t, emailer.emails())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckBandwidthAlerts_AlreadyFiredThisMonth_NoRefire(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bandwidth_limit_bytes"}).
+			AddRow("tenant-1", int64(1000)))
+
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(egress_bytes\), 0\)`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(900)))
+
+	// last_fired_at is this month — should not refire.
+	firedThisMonth := time.Now().UTC()
+	mock.ExpectQuery(`SELECT id, threshold_pct, alert_type, last_fired_at FROM bandwidth_alerts`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "threshold_pct", "alert_type", "last_fired_at"}).
+			AddRow("alert-1", 80, "email", firedThisMonth))
+
+	emailer := &fakeBandwidthEmailSender{}
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.SetEmailSender(emailer)
+
+	alerter.checkBandwidthAlerts(context.Background())
+
+	assert.Empty(t, emailer.emails())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckBandwidthAlerts_NoLimit_Skipped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// No tenants with bandwidth limits.
+	mock.ExpectQuery(`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bandwidth_limit_bytes"}))
+
+	emailer := &fakeBandwidthEmailSender{}
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.SetEmailSender(emailer)
+
+	alerter.checkBandwidthAlerts(context.Background())
+
+	assert.Empty(t, emailer.emails())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSeedDefaultAlerts_Idempotent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT tenant_id FROM tenant_quotas WHERE bandwidth_limit_bytes > 0`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id"}).
+			AddRow("tenant-1"))
+
+	mock.ExpectExec(`INSERT INTO bandwidth_alerts`).
+		WithArgs("tenant-1", 80).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec(`INSERT INTO bandwidth_alerts`).
+		WithArgs("tenant-1", 95).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.seedDefaultAlerts(context.Background())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStartBandwidthAlerts_NilSafe(t *testing.T) {
+	// Nil receiver.
+	var nilAlerter *BandwidthAlerter
+	nilAlerter.StartBandwidthAlerts(context.Background()) // must not panic
+
+	// Non-nil receiver, nil db.
+	alerter := &BandwidthAlerter{logger: zap.NewNop()}
+	alerter.StartBandwidthAlerts(context.Background()) // must not panic
+}
+
+func TestBandwidthAlert_EmailContent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.MatchExpectationsInOrder(false)
+
+	limitBytes := int64(100 * 1024 * 1024 * 1024) // 100 GB
+	usedBytes := int64(80 * 1024 * 1024 * 1024)   // 80 GB
+
+	mock.ExpectQuery(`SELECT tenant_id, bandwidth_limit_bytes FROM tenant_quotas`).
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bandwidth_limit_bytes"}).
+			AddRow("tenant-1", limitBytes))
+
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(egress_bytes\), 0\)`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(usedBytes))
+
+	mock.ExpectQuery(`SELECT id, threshold_pct, alert_type, last_fired_at FROM bandwidth_alerts`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "threshold_pct", "alert_type", "last_fired_at"}).
+			AddRow("alert-1", 80, "email", nil))
+
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(sqlmock.AnyArg(), "bandwidth.alert", "tenant-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectQuery(`SELECT id, url, event_filter, secret FROM webhook_endpoints`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "event_filter", "secret"}))
+
+	mock.ExpectQuery(`SELECT email FROM tenants WHERE id`).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow("admin@acme.com"))
+
+	mock.ExpectExec(`UPDATE bandwidth_alerts SET last_fired_at`).
+		WithArgs("alert-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	emailer := &fakeBandwidthEmailSender{}
+	alerter := NewBandwidthAlerter(db, zap.NewNop())
+	alerter.SetEmailSender(emailer)
+
+	alerter.checkBandwidthAlerts(context.Background())
+
+	time.Sleep(100 * time.Millisecond)
+
+	emails := emailer.emails()
+	require.Len(t, emails, 1)
+	assert.Equal(t, "admin@acme.com", emails[0].to)
+	assert.Contains(t, emails[0].subject, "80%")
+	assert.True(t, strings.Contains(emails[0].text, "80.0 GB"), "body should contain used bytes: %s", emails[0].text)
+	assert.True(t, strings.Contains(emails[0].text, "100.0 GB"), "body should contain limit bytes: %s", emails[0].text)
+	assert.Contains(t, emails[0].text, "80%")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -30,6 +30,7 @@ var validEventTypes = []string{
 	"key.revoked",
 	"sts.token_created",
 	"webhook.test",
+	"bandwidth.alert",
 }
 
 func isValidEventType(t string) bool {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -68,6 +68,7 @@ type Server struct {
 	healthChecker    *BackendHealthChecker
 	sessionStore     dashauth.SessionStore
 	bandwidthTracker *BandwidthTracker
+	bandwidthAlerter *BandwidthAlerter
 	googleOAuth      *oauth2.Config
 	githubOAuth      *oauth2.Config
 	mfaService       *auth.MFAService
@@ -239,6 +240,10 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 		}
 	}
 
+	// Bandwidth threshold alerter (Phase 4.3). Active whenever a DB is present;
+	// the alerter skips tenants with no bandwidth_limit_bytes.
+	s.bandwidthAlerter = NewBandwidthAlerter(s.db, logger)
+
 	// Base URL for OAuth callbacks and email links.
 	baseURL := os.Getenv("VAULTAIRE_BASE_URL")
 	if baseURL == "" {
@@ -249,6 +254,7 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 	if s.meteredReporter != nil {
 		s.meteredReporter.SetEmailSender(s.emailSender)
 	}
+	s.bandwidthAlerter.SetEmailSender(s.emailSender)
 	if googleID := os.Getenv("GOOGLE_CLIENT_ID"); googleID != "" {
 		s.googleOAuth = &oauth2.Config{
 			ClientID:     googleID,
@@ -973,6 +979,9 @@ func (s *Server) Start() error {
 	if s.meteredReporter != nil {
 		s.meteredReporter.StartMeteredReporting(ctx)
 	}
+
+	// Check bandwidth thresholds hourly + seed default alerts for new tenants.
+	s.bandwidthAlerter.StartBandwidthAlerts(ctx)
 
 	s.logger.Info("Starting server with RBAC and API Key Management",
 		zap.Int("port", s.config.Server.Port))


### PR DESCRIPTION
## Summary

- **BandwidthAlerter** (`bandwidth_alerts.go`): hourly background job that seeds default 80%/95% alert rows for tenants with bandwidth limits, checks current-month egress against each enabled threshold, and fires once per threshold per calendar month
- **Alert firing**: emits a `bandwidth.alert` event (subscribable via webhooks) + sends an email to the tenant with usage stats + updates `last_fired_at` as the once-per-month guard
- **Wiring**: constructed in `server.go` alongside the metered reporter, email sender injected after construction, started in `Start()` alongside other background jobs
- **Event type**: `bandwidth.alert` added to `validEventTypes` in `events.go` so webhooks can subscribe

## Architecture

Mirrors the `MeteredReporter.checkSpendingCaps` pattern (billing/metered.go): hourly ticker goroutine, collect-then-iterate to avoid open cursor issues with sqlmock, nil-safe on receiver and db. Uses the existing `bandwidth_alerts` table from migration 020 — no new migration needed.

## Test plan

- [x] `TestCheckBandwidthAlerts_FiresAt80` — at 80% threshold: event emitted, email sent, last_fired_at updated
- [x] `TestCheckBandwidthAlerts_BelowThreshold_NoFire` — under threshold: no event, no email
- [x] `TestCheckBandwidthAlerts_AlreadyFiredThisMonth_NoRefire` — already fired this month: skipped
- [x] `TestCheckBandwidthAlerts_NoLimit_Skipped` — no tenants with bandwidth limits: no-op
- [x] `TestSeedDefaultAlerts_Idempotent` — seeds 80/95 rows with ON CONFLICT DO NOTHING
- [x] `TestStartBandwidthAlerts_NilSafe` — nil receiver and nil db both safe
- [x] `TestBandwidthAlert_EmailContent` — email body contains formatted bytes and percentage