### PR TITLE
feat(dashboard): admin audit log viewer with filters + CSV export [Phase 3.6]

### DIFF
--- a/internal/dashboard/handlers/admin_audit.go
+++ b/internal/dashboard/handlers/admin_audit.go
@@ -1,0 +1,253 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/csv"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"time"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+var auditEventTypes = []string{
+	"bandwidth.alert",
+	"bucket.created",
+	"bucket.deleted",
+	"key.created",
+	"key.revoked",
+	"object.created",
+	"object.deleted",
+	"object.downloaded",
+	"sts.token_created",
+	"webhook.test",
+}
+
+type auditEventRow struct {
+	ID          string
+	Type        string
+	TenantID    string
+	DataJSON    string
+	DataSummary string
+	CreatedFmt  string
+	createdRaw  string
+}
+
+type auditFilters struct {
+	Tenant string
+	Type   string
+	From   string
+	To     string
+	Cursor string
+}
+
+const auditPageSize = 50
+
+func HandleAdminAudit(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-audit")
+		withCSRF(r.Context(), data)
+		data["EventTypes"] = auditEventTypes
+		data["Events"] = []auditEventRow{}
+		data["HasMore"] = false
+
+		f := parseAuditFilters(r)
+		data["Filters"] = f
+		data["ExportURL"] = "/admin/audit/export" + auditFilterQS(f)
+
+		if db != nil {
+			events, hasMore, nextCursor := queryAuditEvents(r, db, f, logger)
+			data["Events"] = events
+			data["HasMore"] = hasMore
+			if hasMore {
+				data["NextURL"] = "/admin/audit" + auditNextPageQS(f, nextCursor)
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin audit", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func HandleAdminAuditExport(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dashauth.GetSession(r.Context()) == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition",
+			`attachment; filename="audit-`+time.Now().Format("2006-01-02")+`.csv"`)
+
+		cw := csv.NewWriter(w)
+		defer cw.Flush()
+		_ = cw.Write([]string{"id", "type", "tenant_id", "data", "created_at"})
+
+		if db == nil {
+			return
+		}
+
+		f := parseAuditFilters(r)
+		where, args := auditWhere(f, false)
+		q := "SELECT id, type, tenant_id, data, created_at FROM events" + where + " ORDER BY created_at DESC"
+
+		rows, err := db.QueryContext(r.Context(), q, args...)
+		if err != nil {
+			logger.Error("audit export query", zap.Error(err))
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var id, typ, tenantID string
+			var data []byte
+			var created time.Time
+			if err := rows.Scan(&id, &typ, &tenantID, &data, &created); err != nil {
+				logger.Error("audit export scan", zap.Error(err))
+				continue
+			}
+			_ = cw.Write([]string{id, typ, tenantID, string(data), created.UTC().Format(time.RFC3339)})
+		}
+	}
+}
+
+func parseAuditFilters(r *http.Request) auditFilters {
+	return auditFilters{
+		Tenant: r.URL.Query().Get("tenant"),
+		Type:   r.URL.Query().Get("type"),
+		From:   r.URL.Query().Get("from"),
+		To:     r.URL.Query().Get("to"),
+		Cursor: r.URL.Query().Get("cursor"),
+	}
+}
+
+func auditWhere(f auditFilters, withCursor bool) (string, []interface{}) {
+	where := " WHERE 1=1"
+	var args []interface{}
+	idx := 1
+	if f.Tenant != "" {
+		where += fmt.Sprintf(" AND tenant_id = $%d", idx)
+		args = append(args, f.Tenant)
+		idx++
+	}
+	if f.Type != "" {
+		where += fmt.Sprintf(" AND type = $%d", idx)
+		args = append(args, f.Type)
+		idx++
+	}
+	if f.From != "" {
+		where += fmt.Sprintf(" AND created_at >= $%d::date", idx)
+		args = append(args, f.From)
+		idx++
+	}
+	if f.To != "" {
+		where += fmt.Sprintf(" AND created_at < ($%d::date + INTERVAL '1 day')", idx)
+		args = append(args, f.To)
+		idx++
+	}
+	if withCursor && f.Cursor != "" {
+		where += fmt.Sprintf(" AND created_at < $%d", idx)
+		args = append(args, f.Cursor)
+	}
+	return where, args
+}
+
+func queryAuditEvents(r *http.Request, db *sql.DB, f auditFilters, logger *zap.Logger) ([]auditEventRow, bool, string) {
+	where, args := auditWhere(f, true)
+	q := "SELECT id, type, tenant_id, data, created_at FROM events" + where +
+		fmt.Sprintf(" ORDER BY created_at DESC LIMIT %d", auditPageSize+1)
+
+	rows, err := db.QueryContext(r.Context(), q, args...)
+	if err != nil {
+		logger.Error("audit events query", zap.Error(err))
+		return nil, false, ""
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []auditEventRow
+	for rows.Next() {
+		var id, typ, tenantID string
+		var data []byte
+		var created time.Time
+		if err := rows.Scan(&id, &typ, &tenantID, &data, &created); err != nil {
+			logger.Error("audit events scan", zap.Error(err))
+			continue
+		}
+		dataStr := string(data)
+		events = append(events, auditEventRow{
+			ID:          id,
+			Type:        typ,
+			TenantID:    tenantID,
+			DataJSON:    dataStr,
+			DataSummary: auditSummarize(dataStr),
+			CreatedFmt:  created.Format("Jan 2, 2006 15:04 MST"),
+			createdRaw:  created.Format(time.RFC3339Nano),
+		})
+	}
+
+	hasMore := len(events) > auditPageSize
+	var nextCursor string
+	if hasMore {
+		events = events[:auditPageSize]
+		nextCursor = events[auditPageSize-1].createdRaw
+	}
+	return events, hasMore, nextCursor
+}
+
+func auditSummarize(s string) string {
+	if len(s) <= 80 {
+		return s
+	}
+	return s[:80] + "…"
+}
+
+func auditFilterQS(f auditFilters) string {
+	params := url.Values{}
+	if f.Tenant != "" {
+		params.Set("tenant", f.Tenant)
+	}
+	if f.Type != "" {
+		params.Set("type", f.Type)
+	}
+	if f.From != "" {
+		params.Set("from", f.From)
+	}
+	if f.To != "" {
+		params.Set("to", f.To)
+	}
+	if qs := params.Encode(); qs != "" {
+		return "?" + qs
+	}
+	return ""
+}
+
+func auditNextPageQS(f auditFilters, cursor string) string {
+	params := url.Values{}
+	if f.Tenant != "" {
+		params.Set("tenant", f.Tenant)
+	}
+	if f.Type != "" {
+		params.Set("type", f.Type)
+	}
+	if f.From != "" {
+		params.Set("from", f.From)
+	}
+	if f.To != "" {
+		params.Set("to", f.To)
+	}
+	params.Set("cursor", cursor)
+	return "?" + params.Encode()
+}

--- a/internal/dashboard/handlers/admin_audit.go
+++ b/internal/dashboard/handlers/admin_audit.go
@@ -102,7 +102,7 @@ func HandleAdminAuditExport(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
 
 		f := parseAuditFilters(r)
 		where, args := auditWhere(f, false)
-		q := "SELECT id, type, tenant_id, data, created_at FROM events" + where + " ORDER BY created_at DESC"
+		q := "SELECT id, type, tenant_id, data, created_at FROM events" + where + " ORDER BY created_at DESC" // #nosec G202 -- parameterized $N placeholders only
 
 		rows, err := db.QueryContext(r.Context(), q, args...)
 		if err != nil {
@@ -167,7 +167,7 @@ func auditWhere(f auditFilters, withCursor bool) (string, []interface{}) {
 
 func queryAuditEvents(r *http.Request, db *sql.DB, f auditFilters, logger *zap.Logger) ([]auditEventRow, bool, string) {
 	where, args := auditWhere(f, true)
-	q := "SELECT id, type, tenant_id, data, created_at FROM events" + where +
+	q := "SELECT id, type, tenant_id, data, created_at FROM events" + where + // #nosec G202 -- parameterized $N placeholders only
 		fmt.Sprintf(" ORDER BY created_at DESC LIMIT %d", auditPageSize+1)
 
 	rows, err := db.QueryContext(r.Context(), q, args...)

--- a/internal/dashboard/handlers/admin_audit_test.go
+++ b/internal/dashboard/handlers/admin_audit_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testAdminAuditTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Audit{{end}}` +
+			`{{define "content"}}` +
+			`{{range .Events}}<div class="event">{{.Type}} {{.TenantID}}</div>{{end}}` +
+			`{{if .HasMore}}<a class="next" href="{{.NextURL}}">Next</a>{{end}}` +
+			`{{if not .Events}}<p>No events found.</p>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+var auditCols = []string{"id", "type", "tenant_id", "data", "created_at"}
+
+func TestHandleAdminAudit_RendersEvents(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(auditCols).
+		AddRow("e1", "object.created", "t-1", []byte(`{"key":"photo.jpg"}`), time.Now()).
+		AddRow("e2", "bucket.created", "t-2", []byte(`{"bucket":"my-bucket"}`), time.Now())
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WillReturnRows(rows)
+
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "object.created")
+	assert.Contains(t, body, "t-1")
+	assert.Contains(t, body, "bucket.created")
+	assert.Contains(t, body, "t-2")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAudit_FilterByType(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(auditCols).
+		AddRow("e1", "object.created", "t-1", []byte(`{"key":"a"}`), time.Now())
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WithArgs("object.created").
+		WillReturnRows(rows)
+
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit?type=object.created", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "object.created")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAudit_FilterByTenant(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(auditCols).
+		AddRow("e1", "key.created", "t-99", []byte(`{}`), time.Now())
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WithArgs("t-99").
+		WillReturnRows(rows)
+
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit?tenant=t-99", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "t-99")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAudit_Pagination(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows(auditCols)
+	for i := 0; i < 50; i++ {
+		rows.AddRow(fmt.Sprintf("e-%d", i), "object.created", "t-1", []byte(`{}`),
+			ts.Add(-time.Duration(i)*time.Minute))
+	}
+	rows.AddRow("e-overflow", "OVERFLOW", "t-1", []byte(`{}`), ts.Add(-51*time.Minute))
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WillReturnRows(rows)
+
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Next")
+	assert.NotContains(t, body, "OVERFLOW")
+	assert.Equal(t, 50, strings.Count(body, `class="event"`))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAudit_EmptyState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WillReturnRows(sqlmock.NewRows(auditCols))
+
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "No events found.")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAudit_NoSession(t *testing.T) {
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminAudit_NilDB(t *testing.T) {
+	handler := HandleAdminAudit(testAdminAuditTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "No events found.")
+}
+
+func TestHandleAdminAuditExport_CSV(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(auditCols).
+		AddRow("e1", "object.created", "t-1",
+			[]byte(`{"key":"file.txt"}`),
+			time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC))
+
+	mock.ExpectQuery(`SELECT id, type, tenant_id, data, created_at FROM events`).
+		WillReturnRows(rows)
+
+	handler := HandleAdminAuditExport(db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/audit/export", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "audit-")
+
+	body := w.Body.String()
+	assert.Contains(t, body, "id,type,tenant_id,data,created_at")
+	assert.Contains(t, body, "file.txt")
+	assert.Contains(t, body, "object.created")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -254,6 +254,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/waitlist.html",
 	))
+	auditTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/audit.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -272,6 +276,8 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/tenants/{id}/bandwidth-limit", handlers.HandleUpdateBandwidthLimit(deps.DB, deps.Logger))
 		ar.Post("/tenants/{id}/reset-mfa", handlers.HandleAdminResetMFA(deps.Auth, deps.Logger))
 		ar.Get("/system", handlers.HandleAdminSystem(systemTmpl, deps.DB, deps.Logger))
+		ar.Get("/audit", handlers.HandleAdminAudit(auditTmpl, deps.DB, deps.Logger))
+		ar.Get("/audit/export", handlers.HandleAdminAuditExport(deps.DB, deps.Logger))
 		ar.Get("/waitlist", handlers.HandleAdminWaitlist(waitlistTmpl, deps.DB, deps.Logger))
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		if deps.Engine != nil {

--- a/internal/dashboard/templates/admin/audit.html
+++ b/internal/dashboard/templates/admin/audit.html
@@ -1,0 +1,72 @@
+{{define "title"}}Audit Log — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Audit Log</h1>
+    <a href="{{.ExportURL}}" class="btn btn-sm">Export CSV</a>
+</div>
+
+<div class="card" style="margin-bottom:1.5rem">
+    <form action="/admin/audit" method="GET" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:end">
+        <div>
+            <label style="display:block;font-size:0.85rem;color:#94a3b8;margin-bottom:0.25rem">Tenant ID</label>
+            <input type="text" name="tenant" value="{{.Filters.Tenant}}" placeholder="All tenants" style="padding:0.4rem 0.6rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem">
+        </div>
+        <div>
+            <label style="display:block;font-size:0.85rem;color:#94a3b8;margin-bottom:0.25rem">Event Type</label>
+            <select name="type" style="padding:0.4rem 0.6rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem">
+                <option value="">All types</option>
+                {{range .EventTypes}}<option value="{{.}}"{{if eq . $.Filters.Type}} selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+        </div>
+        <div>
+            <label style="display:block;font-size:0.85rem;color:#94a3b8;margin-bottom:0.25rem">From</label>
+            <input type="date" name="from" value="{{.Filters.From}}" style="padding:0.4rem 0.6rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem">
+        </div>
+        <div>
+            <label style="display:block;font-size:0.85rem;color:#94a3b8;margin-bottom:0.25rem">To</label>
+            <input type="date" name="to" value="{{.Filters.To}}" style="padding:0.4rem 0.6rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem">
+        </div>
+        <button type="submit" class="btn btn-sm">Filter</button>
+    </form>
+</div>
+
+<div class="card">
+    {{if .Events}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Tenant</th>
+                    <th>Data</th>
+                    <th>Time</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Events}}
+                <tr>
+                    <td><code>{{.Type}}</code></td>
+                    <td style="font-family:monospace;font-size:0.85rem">{{.TenantID}}</td>
+                    <td>
+                        <details>
+                            <summary style="cursor:pointer;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{.DataSummary}}</summary>
+                            <pre style="margin-top:0.5rem;padding:0.75rem;background:#0f172a;border-radius:6px;overflow-x:auto;font-size:0.8rem;white-space:pre-wrap;word-break:break-all">{{.DataJSON}}</pre>
+                        </details>
+                    </td>
+                    <td style="white-space:nowrap">{{.CreatedFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{if .HasMore}}
+    <div style="padding:1rem;text-align:center">
+        <a href="{{.NextURL}}" class="btn btn-sm">Next page &rarr;</a>
+    </div>
+    {{end}}
+    {{else}}
+    <p class="text-muted">No events found.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -21,6 +21,7 @@
                 <a href="/admin/tenants" class="sidebar-link{{if eq .Page "admin-tenants"}} sidebar-link--active{{end}}">Tenants</a>
                 <a href="/admin/system" class="sidebar-link{{if eq .Page "admin-system"}} sidebar-link--active{{end}}">System</a>
                 <a href="/admin/backends" class="sidebar-link{{if eq .Page "admin-backends"}} sidebar-link--active{{end}}">Backends</a>
+                <a href="/admin/audit" class="sidebar-link{{if eq .Page "admin-audit"}} sidebar-link--active{{end}}">Audit Log</a>
                 <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
             </nav>
             <div class="sidebar-footer">


### PR DESCRIPTION
## Summary

- **Admin audit page** (`/admin/audit`): browse the `events` table with tenant, type, and date range filters, cursor pagination (50/page), and expandable JSON details via `<details>` elements
- **CSV export** (`/admin/audit/export`): streams all matching events with the same filters applied — for compliance auditors (SOC 2, HIPAA)
- **Sidebar link**: "Audit Log" added to admin nav between Backends and Waitlist

## Architecture

Queries the `events` table directly (36k+ rows in prod, actively written by `emitEvent`). The `audit_logs` table (migration 008) exists but has zero rows — `AuditService` is never instantiated — so this phase ignores it entirely. Event type dropdown is hardcoded to avoid an import cycle with the `api` package.

## Test plan

- [x] `TestHandleAdminAudit_RendersEvents` — 2 mocked rows render with type + tenant
- [x] `TestHandleAdminAudit_FilterByType` — `?type=object.created` passes arg to query
- [x] `TestHandleAdminAudit_FilterByTenant` — `?tenant=t-99` passes arg to query
- [x] `TestHandleAdminAudit_Pagination` — 51 rows → 50 shown, "Next" link present, overflow hidden
- [x] `TestHandleAdminAudit_EmptyState` — empty result → "No events found."
- [x] `TestHandleAdminAudit_NoSession` — no session → 303 redirect to /login
- [x] `TestHandleAdminAudit_NilDB` — nil DB → 200 with empty state
- [x] `TestHandleAdminAuditExport_CSV` — text/csv + attachment header + JSON data present