### PR TITLE
feat(dashboard): admin revenue dashboard (MRR, tier, churn, top customers) [Phase 3.8]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -96,6 +96,7 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/tenants/{id}/reset-mfa` | POST | session + admin | Reset user's 2FA |
 | `/admin/waitlist` | GET | session + admin | Pre-launch waitlist signups (count + list) |
 | `/admin/waitlist/export` | GET | session + admin | Download all waitlist signups as CSV |
+| `/admin/revenue` | GET | session + admin | Revenue dashboard: MRR, tier breakdown, churn, top customers |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -148,6 +148,26 @@ in the api package → `waitlist_signups`, migration 044).
 Both redirect to `/login` without a session; nil-DB degrades to empty/zero. Linked
 from the admin sidebar nav. Template: `templates/admin/waitlist.html`.
 
+## Admin Revenue Dashboard (`admin_revenue.go`)
+
+`HandleAdminRevenue(tmpl, db, logger)` — GET `/admin/revenue`: real MRR from two
+sources: fixed-price Vault plans (`planMonthlyCents` lookup, prices from
+VAULT_SERIES_ECONOMICS.md) + metered tiers (standard/performance via
+`billing.AccruedCents`). Cards: MRR, Active Subs, New This Month, Churn
+(count + rate from `subscriptions` table). Revenue-by-tier table groups fixed plans
+and metered tiers separately. Top 10 customers by storage, ordered DESC. Optional
+SVG bar chart of new MRR added per month (last 12 months, derived from
+`subscriptions.created_at` — no historical MRR snapshot table exists).
+
+Also fixes `admin.go:queryAdminStats` which previously used the non-existent
+`used_bytes` column — corrected to `storage_used_bytes`.
+
+Helper: `planMonthlyCents(plan)` covers vault1/3/5/10/18/50/100; free/starter/metered
+return 0. `formatCents(cents)` → "$X.XX".
+
+Template: `templates/admin/revenue.html`. Nil-DB and empty-state both render 200
+with "$0.00 MRR" zero-state.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/admin.go
+++ b/internal/dashboard/handlers/admin.go
@@ -55,7 +55,7 @@ func queryAdminStats(ctx context.Context, db *sql.DB, logger *zap.Logger) (int, 
 	}
 
 	var totalBytes int64
-	if err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(used_bytes), 0) FROM tenant_quotas`).Scan(&totalBytes); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(storage_used_bytes), 0) FROM tenant_quotas`).Scan(&totalBytes); err != nil {
 		logger.Debug("admin: sum storage", zap.Error(err))
 	}
 

--- a/internal/dashboard/handlers/admin_revenue.go
+++ b/internal/dashboard/handlers/admin_revenue.go
@@ -1,0 +1,385 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/billing"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+// planMonthlyCents returns the monthly price in cents for a fixed-price Vault
+// plan. Metered tiers (standard, performance) return 0 — their revenue is
+// calculated from live storage usage. Prices from VAULT_SERIES_ECONOMICS.md.
+func planMonthlyCents(plan string) int64 {
+	switch plan {
+	case "vault1":
+		return 499
+	case "vault3":
+		return 799
+	case "vault5":
+		return 999
+	case "vault10":
+		return 1299
+	case "vault18":
+		return 1799
+	case "vault50":
+		return 4499
+	case "vault100":
+		return 8499
+	default:
+		return 0
+	}
+}
+
+func formatCents(cents int64) string {
+	return fmt.Sprintf("$%.2f", float64(cents)/100)
+}
+
+type tierRevenue struct {
+	Tier     string
+	Count    int
+	MRRCents int64
+	MRRFmt   string
+}
+
+type custRevenue struct {
+	Email      string
+	Plan       string
+	MRRCents   int64
+	MRRFmt     string
+	StorageFmt string
+}
+
+type trendBar struct {
+	Label string
+	Cents int64
+	Fmt   string
+	X     float64
+	Y     float64
+	W     float64
+	H     float64
+}
+
+func HandleAdminRevenue(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-revenue")
+		withCSRF(r.Context(), data)
+
+		data["MRRFmt"] = "$0.00"
+		data["ActiveSubs"] = 0
+		data["NewThisMonth"] = 0
+		data["ChurnedThisMonth"] = 0
+		data["ChurnRateFmt"] = "0%"
+		data["ByTier"] = []tierRevenue{}
+		data["TopCustomers"] = []custRevenue{}
+		data["TrendBars"] = []trendBar{}
+		data["TrendMaxFmt"] = "$0"
+
+		if db != nil {
+			populateRevenue(r.Context(), db, data, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin revenue", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func populateRevenue(ctx context.Context, db *sql.DB, data map[string]any, logger *zap.Logger) {
+	fixedCents := queryFixedMRR(ctx, db, logger)
+	meteredCents := queryMeteredMRR(ctx, db, logger)
+	totalMRR := fixedCents + meteredCents
+
+	data["MRRFmt"] = formatCents(totalMRR)
+
+	var activeSubs int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tenants WHERE subscription_status = 'active'`).Scan(&activeSubs); err != nil {
+		logger.Debug("revenue: count active subs", zap.Error(err))
+	}
+	data["ActiveSubs"] = activeSubs
+
+	newThisMonth := queryCountSince(ctx, db, logger,
+		`SELECT COUNT(*) FROM subscriptions WHERE created_at >= date_trunc('month', CURRENT_DATE)`)
+	churnedThisMonth := queryCountSince(ctx, db, logger,
+		`SELECT COUNT(*) FROM subscriptions WHERE canceled_at >= date_trunc('month', CURRENT_DATE)`)
+	activeAtStart := queryCountSince(ctx, db, logger,
+		`SELECT COUNT(*) FROM subscriptions
+		 WHERE created_at < date_trunc('month', CURRENT_DATE)
+		   AND (canceled_at IS NULL OR canceled_at >= date_trunc('month', CURRENT_DATE))`)
+
+	data["NewThisMonth"] = newThisMonth
+	data["ChurnedThisMonth"] = churnedThisMonth
+	if activeAtStart > 0 {
+		rate := float64(churnedThisMonth) / float64(activeAtStart) * 100
+		data["ChurnRateFmt"] = fmt.Sprintf("%.1f%%", rate)
+	}
+
+	data["ByTier"] = queryRevenueByTier(ctx, db, logger)
+	data["TopCustomers"] = queryTopCustomers(ctx, db, logger)
+
+	bars := queryMRRTrend(ctx, db, logger)
+	data["TrendBars"] = bars
+	if len(bars) > 0 {
+		var maxCents int64
+		for _, b := range bars {
+			if b.Cents > maxCents {
+				maxCents = b.Cents
+			}
+		}
+		data["TrendMaxFmt"] = formatCents(maxCents)
+	}
+}
+
+func queryFixedMRR(ctx context.Context, db *sql.DB, logger *zap.Logger) int64 {
+	rows, err := db.QueryContext(ctx,
+		`SELECT COALESCE(plan, '') FROM tenants WHERE subscription_status = 'active'`)
+	if err != nil {
+		logger.Debug("revenue: query fixed plans", zap.Error(err))
+		return 0
+	}
+	defer func() { _ = rows.Close() }()
+
+	var total int64
+	for rows.Next() {
+		var plan string
+		if err := rows.Scan(&plan); err != nil {
+			continue
+		}
+		total += planMonthlyCents(plan)
+	}
+	return total
+}
+
+func queryMeteredMRR(ctx context.Context, db *sql.DB, logger *zap.Logger) int64 {
+	rows, err := db.QueryContext(ctx, `
+		SELECT tq.tier, tq.storage_used_bytes, COALESCE(bw.egress, 0)
+		FROM tenant_quotas tq
+		LEFT JOIN (
+			SELECT tenant_id, SUM(egress_bytes) AS egress
+			FROM bandwidth_usage_daily
+			WHERE date >= date_trunc('month', CURRENT_DATE)
+			GROUP BY tenant_id
+		) bw ON bw.tenant_id = tq.tenant_id
+		WHERE tq.tier IN ('standard', 'performance')`)
+	if err != nil {
+		logger.Debug("revenue: query metered tenants", zap.Error(err))
+		return 0
+	}
+	defer func() { _ = rows.Close() }()
+
+	var total int64
+	for rows.Next() {
+		var tier string
+		var storageBytes, egressBytes int64
+		if err := rows.Scan(&tier, &storageBytes, &egressBytes); err != nil {
+			continue
+		}
+		total += billing.AccruedCents(tier, storageBytes, egressBytes)
+	}
+	return total
+}
+
+func queryCountSince(ctx context.Context, db *sql.DB, logger *zap.Logger, query string) int {
+	var count int
+	if err := db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+		logger.Debug("revenue: count query", zap.Error(err))
+	}
+	return count
+}
+
+func queryRevenueByTier(ctx context.Context, db *sql.DB, logger *zap.Logger) []tierRevenue {
+	// Fixed-plan tiers from tenants.
+	fixedRows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(plan, 'free'), COUNT(*)
+		FROM tenants
+		WHERE subscription_status = 'active'
+		GROUP BY plan
+		ORDER BY COUNT(*) DESC`)
+	if err != nil {
+		logger.Debug("revenue: by tier fixed", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = fixedRows.Close() }()
+
+	var tiers []tierRevenue
+	for fixedRows.Next() {
+		var plan string
+		var count int
+		if err := fixedRows.Scan(&plan, &count); err != nil {
+			continue
+		}
+		cents := planMonthlyCents(plan) * int64(count)
+		if plan == "" {
+			plan = "free"
+		}
+		tiers = append(tiers, tierRevenue{
+			Tier:     plan,
+			Count:    count,
+			MRRCents: cents,
+			MRRFmt:   formatCents(cents),
+		})
+	}
+
+	// Metered tiers from tenant_quotas.
+	meteredRows, err := db.QueryContext(ctx, `
+		SELECT tq.tier, COUNT(*), COALESCE(SUM(tq.storage_used_bytes), 0)
+		FROM tenant_quotas tq
+		WHERE tq.tier IN ('standard', 'performance')
+		GROUP BY tq.tier
+		ORDER BY tq.tier`)
+	if err != nil {
+		logger.Debug("revenue: by tier metered", zap.Error(err))
+		return tiers
+	}
+	defer func() { _ = meteredRows.Close() }()
+
+	for meteredRows.Next() {
+		var tier string
+		var count int
+		var totalStorage int64
+		if err := meteredRows.Scan(&tier, &count, &totalStorage); err != nil {
+			continue
+		}
+		cents := billing.AccruedCents(tier, totalStorage, 0)
+		tiers = append(tiers, tierRevenue{
+			Tier:     tier,
+			Count:    count,
+			MRRCents: cents,
+			MRRFmt:   formatCents(cents),
+		})
+	}
+	return tiers
+}
+
+func queryTopCustomers(ctx context.Context, db *sql.DB, logger *zap.Logger) []custRevenue {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.email, COALESCE(t.plan, 'free'),
+			   COALESCE(tq.tier, ''), COALESCE(tq.storage_used_bytes, 0)
+		FROM tenants t
+		LEFT JOIN tenant_quotas tq ON tq.tenant_id = t.id
+		WHERE t.subscription_status = 'active'
+		ORDER BY tq.storage_used_bytes DESC NULLS LAST
+		LIMIT 10`)
+	if err != nil {
+		logger.Debug("revenue: top customers", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var customers []custRevenue
+	for rows.Next() {
+		var email, plan, tier string
+		var storageBytes int64
+		if err := rows.Scan(&email, &plan, &tier, &storageBytes); err != nil {
+			continue
+		}
+		var cents int64
+		if tier == "standard" || tier == "performance" {
+			cents = billing.AccruedCents(tier, storageBytes, 0)
+		} else {
+			cents = planMonthlyCents(plan)
+		}
+		displayPlan := plan
+		if tier == "standard" || tier == "performance" {
+			displayPlan = tier
+		}
+		customers = append(customers, custRevenue{
+			Email:      email,
+			Plan:       displayPlan,
+			MRRCents:   cents,
+			MRRFmt:     formatCents(cents),
+			StorageFmt: formatBytes(storageBytes),
+		})
+	}
+	return customers
+}
+
+func queryMRRTrend(ctx context.Context, db *sql.DB, logger *zap.Logger) []trendBar {
+	rows, err := db.QueryContext(ctx, `
+		SELECT date_trunc('month', created_at) AS month, plan, COUNT(*)
+		FROM subscriptions
+		WHERE created_at >= date_trunc('month', CURRENT_DATE) - INTERVAL '11 months'
+		GROUP BY month, plan
+		ORDER BY month`)
+	if err != nil {
+		logger.Debug("revenue: mrr trend", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	// Accumulate per-month MRR.
+	type monthMRR struct {
+		month time.Time
+		cents int64
+	}
+	monthMap := make(map[string]*monthMRR)
+	var orderedKeys []string
+	for rows.Next() {
+		var month time.Time
+		var plan string
+		var count int
+		if err := rows.Scan(&month, &plan, &count); err != nil {
+			continue
+		}
+		key := month.Format("2006-01")
+		if _, ok := monthMap[key]; !ok {
+			monthMap[key] = &monthMRR{month: month}
+			orderedKeys = append(orderedKeys, key)
+		}
+		monthMap[key].cents += planMonthlyCents(plan) * int64(count)
+	}
+
+	if len(orderedKeys) == 0 {
+		return nil
+	}
+
+	var maxCents int64
+	for _, k := range orderedKeys {
+		if monthMap[k].cents > maxCents {
+			maxCents = monthMap[k].cents
+		}
+	}
+
+	const chartW, chartH = 600.0, 160.0
+	n := float64(len(orderedKeys))
+	barW := chartW / n * 0.75
+	gap := chartW / n * 0.25
+
+	bars := make([]trendBar, 0, len(orderedKeys))
+	for i, key := range orderedKeys {
+		m := monthMap[key]
+		h := 0.0
+		if maxCents > 0 {
+			h = float64(m.cents) / float64(maxCents) * chartH
+		}
+		if m.cents > 0 && h < 3 {
+			h = 3
+		}
+		bars = append(bars, trendBar{
+			Label: m.month.Format("Jan"),
+			Cents: m.cents,
+			Fmt:   formatCents(m.cents),
+			X:     math.Round(float64(i)*(barW+gap)*100) / 100,
+			Y:     math.Round((chartH-h)*100) / 100,
+			W:     math.Round(barW*100) / 100,
+			H:     math.Round(h*100) / 100,
+		})
+	}
+	return bars
+}

--- a/internal/dashboard/handlers/admin_revenue_test.go
+++ b/internal/dashboard/handlers/admin_revenue_test.go
@@ -1,0 +1,430 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testRevenueTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Revenue{{end}}` +
+			`{{define "content"}}` +
+			`<span class="mrr">{{.MRRFmt}}</span>` +
+			`<span class="active">{{.ActiveSubs}}</span>` +
+			`<span class="new">{{.NewThisMonth}}</span>` +
+			`<span class="churned">{{.ChurnedThisMonth}}</span>` +
+			`<span class="churn-rate">{{.ChurnRateFmt}}</span>` +
+			`{{range .ByTier}}<span class="tier">{{.Tier}} {{.Count}} {{.MRRFmt}}</span>{{end}}` +
+			`{{range .TopCustomers}}<span class="customer">{{.Email}} {{.Plan}} {{.MRRFmt}} {{.StorageFmt}}</span>{{end}}` +
+			`{{if not .ByTier}}<p>No tiers</p>{{end}}` +
+			`{{if not .TopCustomers}}<p>No customers</p>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestRevenue_MRRFromFixedPlans(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Fixed MRR: two active Vault tenants.
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants WHERE subscription_status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}).
+			AddRow("vault3").
+			AddRow("vault18"))
+
+	// Metered MRR: no metered tenants.
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+
+	// Active subs count.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants WHERE subscription_status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	// New/churn/active-at-start.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
+	// By tier (fixed).
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}).
+			AddRow("vault3", 1).
+			AddRow("vault18", 1))
+	// By tier (metered).
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+
+	// Top customers.
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}).
+			AddRow("alice@example.com", "vault18", "", int64(5*1024*1024*1024)).
+			AddRow("bob@example.com", "vault3", "", int64(1*1024*1024*1024)))
+
+	// MRR trend.
+	mock.ExpectQuery(`SELECT date_trunc\('month', created_at\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// vault3=799 + vault18=1799 = 2598 cents = $25.98
+	assert.Contains(t, body, "$25.98")
+	assert.Contains(t, body, `<span class="active">2</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_MRRIncludesMetered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Fixed MRR: one vault1.
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants WHERE subscription_status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}).AddRow("vault1"))
+
+	// Metered MRR: one standard tenant with 2 TB.
+	twoTB := int64(2 * 1024 * 1024 * 1024 * 1024)
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}).
+			AddRow("standard", twoTB, int64(0)))
+
+	// Active subs.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants WHERE subscription_status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	// New/churn/active-at-start.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// By tier (fixed).
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}).AddRow("vault1", 1))
+	// By tier (metered).
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}).
+			AddRow("standard", 1, twoTB))
+
+	// Top customers.
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}))
+
+	// MRR trend.
+	mock.ExpectQuery(`SELECT date_trunc\('month', created_at\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// vault1=499 + standard 2TB = 2*3.99*100 = 798 cents. Total = 1297 = $12.97
+	assert.Contains(t, body, "$12.97")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_ByTierBreakdown(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Stubs for MRR.
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}))
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// By-tier: vault5 x3, vault10 x2.
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}).
+			AddRow("vault5", 3).
+			AddRow("vault10", 2))
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}))
+	mock.ExpectQuery(`SELECT date_trunc`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// vault5: 3*999=2997 = $29.97
+	assert.Contains(t, body, "vault5 3 $29.97")
+	// vault10: 2*1299=2598 = $25.98
+	assert.Contains(t, body, "vault10 2 $25.98")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_NewAndChurnThisMonth(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}))
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// 5 new, 2 churned, 10 active at start → 20% churn.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(10))
+
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}))
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}))
+	mock.ExpectQuery(`SELECT date_trunc`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="new">5</span>`)
+	assert.Contains(t, body, `<span class="churned">2</span>`)
+	assert.Contains(t, body, `<span class="churn-rate">20.0%</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_TopCustomers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}))
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}))
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+
+	tenTB := int64(10 * 1024 * 1024 * 1024 * 1024)
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}).
+			AddRow("whale@example.com", "vault100", "", tenTB).
+			AddRow("metered@example.com", "starter", "standard", tenTB))
+
+	mock.ExpectQuery(`SELECT date_trunc`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "whale@example.com")
+	assert.Contains(t, body, "vault100")
+	assert.Contains(t, body, "$84.99") // vault100 MRR
+	assert.Contains(t, body, "metered@example.com")
+	assert.Contains(t, body, "standard")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_ZeroState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// All queries return empty.
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}))
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}))
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}))
+	mock.ExpectQuery(`SELECT date_trunc`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}))
+
+	handler := HandleAdminRevenue(testRevenueTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "$0.00")
+	assert.Contains(t, body, `<span class="active">0</span>`)
+	assert.Contains(t, body, "No tiers")
+	assert.Contains(t, body, "No customers")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRevenue_NoSession(t *testing.T) {
+	handler := HandleAdminRevenue(testRevenueTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestRevenue_NilDB(t *testing.T) {
+	handler := HandleAdminRevenue(testRevenueTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "$0.00")
+	assert.Contains(t, body, `<span class="active">0</span>`)
+}
+
+func TestRevenue_MRRTrend(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COALESCE\(plan, ''\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan"}))
+	mock.ExpectQuery(`SELECT tq.tier, tq.storage_used_bytes`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "storage_used_bytes", "egress"}))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM tenants`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE created_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions WHERE canceled_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM subscriptions`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COALESCE\(plan, 'free'\), COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan", "count"}))
+	mock.ExpectQuery(`SELECT tq.tier, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"tier", "count", "storage"}))
+	mock.ExpectQuery(`SELECT t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes"}))
+
+	// Trend data: Jan 2026 has 2 vault5, Mar 2026 has 1 vault10.
+	mock.ExpectQuery(`SELECT date_trunc\('month', created_at\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"month", "plan", "count"}).
+			AddRow(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "vault5", 2).
+			AddRow(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), "vault10", 1))
+
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Revenue{{end}}` +
+			`{{define "content"}}` +
+			`{{range .TrendBars}}<span class="bar">{{.Label}} {{.Fmt}}</span>{{end}}` +
+			`<span class="max">{{.TrendMaxFmt}}</span>` +
+			`{{end}}`))
+
+	handler := HandleAdminRevenue(tmpl, db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/revenue", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// Jan: 2*999=1998=$19.98, Mar: 1*1299=$12.99
+	assert.Contains(t, body, "Jan $19.98")
+	assert.Contains(t, body, "Mar $12.99")
+	assert.Contains(t, body, `<span class="max">$19.98</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPlanMonthlyCents(t *testing.T) {
+	cases := []struct {
+		plan string
+		want int64
+	}{
+		{"vault1", 499},
+		{"vault3", 799},
+		{"vault5", 999},
+		{"vault10", 1299},
+		{"vault18", 1799},
+		{"vault50", 4499},
+		{"vault100", 8499},
+		{"starter", 0},
+		{"free", 0},
+		{"standard", 0},
+		{"performance", 0},
+		{"", 0},
+		{"unknown", 0},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, planMonthlyCents(tc.plan), "plan=%q", tc.plan)
+	}
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -258,6 +258,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/audit.html",
 	))
+	revenueTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/revenue.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -280,6 +284,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Get("/audit/export", handlers.HandleAdminAuditExport(deps.DB, deps.Logger))
 		ar.Get("/waitlist", handlers.HandleAdminWaitlist(waitlistTmpl, deps.DB, deps.Logger))
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
+		ar.Get("/revenue", handlers.HandleAdminRevenue(revenueTmpl, deps.DB, deps.Logger))
 		if deps.Engine != nil {
 			ar.Get("/backends", handlers.HandleAdminBackends(backendsTmpl, deps.Engine, deps.HealthChecker, deps.Logger))
 			ar.Post("/backends/{name}/primary", handlers.HandleSetPrimary(deps.Engine, deps.Logger))

--- a/internal/dashboard/templates/admin/revenue.html
+++ b/internal/dashboard/templates/admin/revenue.html
@@ -1,0 +1,97 @@
+{{define "title"}}Revenue — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Revenue</h1>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Monthly Recurring Revenue</div>
+        <div class="card-value">{{.MRRFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Active Subscriptions</div>
+        <div class="card-value">{{.ActiveSubs}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">New This Month</div>
+        <div class="card-value">{{.NewThisMonth}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Churn</div>
+        <div class="card-value">{{.ChurnedThisMonth}} <span style="font-size:0.7em;color:#94a3b8">({{.ChurnRateFmt}})</span></div>
+    </div>
+</div>
+
+{{if .TrendBars}}
+<div class="card" style="margin-bottom:1.5rem">
+    <div class="card-title" style="margin-bottom:0.75rem">New MRR Added (Last 12 Months)</div>
+    <svg viewBox="0 0 600 200" style="width:100%;max-width:600px;height:auto">
+        {{range .TrendBars}}
+        <rect x="{{.X}}" y="{{.Y}}" width="{{.W}}" height="{{.H}}" rx="3" fill="#6366f1" opacity="0.85">
+            <title>{{.Label}}: {{.Fmt}}</title>
+        </rect>
+        <text x="{{.X}}" y="195" fill="#94a3b8" font-size="11" font-family="system-ui,sans-serif">{{.Label}}</text>
+        {{end}}
+    </svg>
+</div>
+{{end}}
+
+<div class="card" style="margin-bottom:1.5rem">
+    <div class="card-title" style="margin-bottom:0.75rem">Revenue by Tier</div>
+    {{if .ByTier}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Tier / Plan</th>
+                    <th style="text-align:right">Subscribers</th>
+                    <th style="text-align:right">MRR</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .ByTier}}
+                <tr>
+                    <td><code>{{.Tier}}</code></td>
+                    <td style="text-align:right">{{.Count}}</td>
+                    <td style="text-align:right">{{.MRRFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No active subscriptions.</p>
+    {{end}}
+</div>
+
+<div class="card">
+    <div class="card-title" style="margin-bottom:0.75rem">Top Customers</div>
+    {{if .TopCustomers}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Plan</th>
+                    <th style="text-align:right">MRR</th>
+                    <th style="text-align:right">Storage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .TopCustomers}}
+                <tr>
+                    <td>{{.Email}}</td>
+                    <td><code>{{.Plan}}</code></td>
+                    <td style="text-align:right">{{.MRRFmt}}</td>
+                    <td style="text-align:right">{{.StorageFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No active customers.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -23,6 +23,7 @@
                 <a href="/admin/backends" class="sidebar-link{{if eq .Page "admin-backends"}} sidebar-link--active{{end}}">Backends</a>
                 <a href="/admin/audit" class="sidebar-link{{if eq .Page "admin-audit"}} sidebar-link--active{{end}}">Audit Log</a>
                 <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
+                <a href="/admin/revenue" class="sidebar-link{{if eq .Page "admin-revenue"}} sidebar-link--active{{end}}">Revenue</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>


### PR DESCRIPTION
## Summary

- Adds `/admin/revenue` page with **real MRR** computed from two sources: fixed-price Vault plans (`planMonthlyCents` covering all 7 tiers from VAULT_SERIES_ECONOMICS.md) + metered tiers (standard/performance via `billing.AccruedCents`)
- Revenue-by-tier table, new/churn this month with churn rate (from `subscriptions` table), top 10 customers by storage, and SVG trend chart of new MRR added per month (last 12 months)
- All queries COALESCE to zero — pre-launch empty state renders clean "$0.00 MRR"
- **Bugfix**: corrects `admin.go:queryAdminStats` which used non-existent `used_bytes` column → `storage_used_bytes`

## Files changed

| File | Change |
|------|--------|
| `handlers/admin_revenue.go` | New handler + all query/formatting logic |
| `handlers/admin_revenue_test.go` | 10 tests (fixed MRR, metered MRR, by-tier, new/churn, top customers, zero-state, no-session, nil-DB, trend, planMonthlyCents unit) |
| `templates/admin/revenue.html` | New template (cards, by-tier table, top-customers table, SVG trend) |
| `router.go` | Parse revenue template + register `GET /admin/revenue` |
| `templates/layouts/admin.html` | Sidebar link for Revenue |
| `handlers/admin.go` | Fix `used_bytes` → `storage_used_bytes` |

## Test plan

- [x] `go test ./internal/dashboard/handlers/ -run TestRevenue -v` — all 9 handler tests pass
- [x] `TestPlanMonthlyCents` — all 13 plan→cents mappings verified
- [x] Full suite `go test ./... -short` — no regressions
- [x] `golangci-lint run ./internal/dashboard/...` — 0 issues
- [ ] CI build-and-test