### PR TITLE
feat(dashboard): admin backend cost + margin dashboard [Phase 3.9]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -97,6 +97,7 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/waitlist` | GET | session + admin | Pre-launch waitlist signups (count + list) |
 | `/admin/waitlist/export` | GET | session + admin | Download all waitlist signups as CSV |
 | `/admin/revenue` | GET | session + admin | Revenue dashboard: MRR, tier breakdown, churn, top customers |
+| `/admin/costs` | GET | session + admin | Cost dashboard: backend spend, per-tenant margin, negative-margin alerts |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -168,6 +168,30 @@ return 0. `formatCents(cents)` → "$X.XX".
 Template: `templates/admin/revenue.html`. Nil-DB and empty-state both render 200
 with "$0.00 MRR" zero-state.
 
+## Admin Cost Dashboard (`admin_costs.go`)
+
+`HandleAdminCosts(tmpl, db, logger)` — GET `/admin/costs`: estimated backend spend,
+per-tenant margin (revenue minus cost), and negative-margin alerts.
+
+Cost model: `backendCostPerTBCents` map (geyser=155, idrive=330, hetzner=381,
+onedrive/gorilla/local/edge=0) + fixed costs (Geyser $155/mo floor, Gorilla
+configurable). `tierBackend(plan, tier)` maps vault*→geyser, standard/performance→idrive,
+free→local. Egress cost is a first-class column (currently $0 — matters when BYOB/edge
+land).
+
+Revenue side reuses `planMonthlyCents` (fixed plans) and `billing.AccruedCents`
+(metered tiers) from admin_revenue.go. Margin = revenue − cost per tenant.
+
+Cards: Est. Monthly Spend (sum + fixed floors), Blended COGS/TB, Gross Margin %,
+Negative-Margin Tenants. Tables: cost-by-backend (storage, variable, fixed, total)
+and per-tenant margin table with negative margins highlighted in red.
+
+Projected month-end: linear extrapolation from current day-of-month. Caption notes
+estimates are from intended tier→backend mapping, not live backend.
+
+Template: `templates/admin/costs.html`. Nil-DB and empty-state both render 200
+with $0.00 zero-state.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/admin_costs.go
+++ b/internal/dashboard/handlers/admin_costs.go
@@ -1,0 +1,317 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/FairForge/vaultaire/internal/billing"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"go.uber.org/zap"
+)
+
+const (
+	geyserFloorCents  = 15500 // $155/mo minimum
+	gorillaFixedCents = 0     // set when Gorilla subscription cost is known
+
+	bytesPerTBCost = 1024.0 * 1024 * 1024 * 1024
+)
+
+// backendCostPerTBCents maps backend names to their per-TB storage cost in cents.
+// Zero means free (contributed, local, or fixed-only).
+var backendCostPerTBCents = map[string]int64{
+	"geyser":   155, // $1.55/TB
+	"idrive":   330, // $3.30/TB
+	"hetzner":  381, // ~€3.81/TB
+	"onedrive": 0,
+	"gorilla":  0,
+	"local":    0,
+	"edge":     0,
+}
+
+// egressCostPerTBCents maps backend names to their per-TB egress cost in cents.
+// Currently $0 across the board — will matter once BYOB/edge nodes are wired.
+var egressCostPerTBCents = map[string]int64{
+	"geyser":   0,
+	"idrive":   0,
+	"hetzner":  0,
+	"onedrive": 0,
+	"gorilla":  0,
+	"local":    0,
+	"edge":     0,
+}
+
+// tierBackend maps a tenant's plan/tier to the intended storage backend.
+func tierBackend(plan, tier string) string {
+	if tier == "performance" {
+		return "idrive"
+	}
+	if tier == "standard" {
+		return "idrive"
+	}
+	switch plan {
+	case "vault1", "vault3", "vault5", "vault10", "vault18", "vault50", "vault100":
+		return "geyser"
+	case "free", "starter", "":
+		return "local"
+	default:
+		return "local"
+	}
+}
+
+type backendCostRow struct {
+	Backend    string
+	StorageTB  float64
+	StorageFmt string
+	CostCents  int64
+	CostFmt    string
+	FixedCents int64
+	FixedFmt   string
+	TotalCents int64
+	TotalFmt   string
+}
+
+type marginRow struct {
+	Email           string
+	Plan            string
+	Backend         string
+	StorageFmt      string
+	RevenueCents    int64
+	RevenueFmt      string
+	CostCents       int64
+	CostFmt         string
+	EgressCostCents int64
+	EgressCostFmt   string
+	MarginCents     int64
+	MarginFmt       string
+	IsNegative      bool
+}
+
+func HandleAdminCosts(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-costs")
+		withCSRF(r.Context(), data)
+
+		data["EstSpendFmt"] = "$0.00"
+		data["BlendedCOGSFmt"] = "$0.00/TB"
+		data["GrossMarginFmt"] = "0%"
+		data["NegativeMarginCount"] = 0
+		data["ProjectedSpendFmt"] = "$0.00"
+		data["ByBackend"] = []backendCostRow{}
+		data["MarginTable"] = []marginRow{}
+
+		if db != nil {
+			populateCosts(r.Context(), db, data, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin costs", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func populateCosts(ctx context.Context, db *sql.DB, data map[string]any, logger *zap.Logger) {
+	tenants := queryTenantCostData(ctx, db, logger)
+	if len(tenants) == 0 {
+		return
+	}
+
+	// Per-backend aggregation.
+	type backendAgg struct {
+		storageBytes int64
+		costCents    int64
+	}
+	backends := make(map[string]*backendAgg)
+
+	var margins []marginRow
+	var totalCostCents, totalRevenueCents int64
+	var totalStorageBytes int64
+	var negativeCount int
+
+	for _, t := range tenants {
+		backend := tierBackend(t.plan, t.tier)
+		perTB := backendCostPerTBCents[backend]
+		storageTB := float64(t.storageBytes) / bytesPerTBCost
+		storageCostCents := int64(math.Round(storageTB * float64(perTB)))
+
+		egressPerTB := egressCostPerTBCents[backend]
+		egressTB := float64(t.egressBytes) / bytesPerTBCost
+		egressCostCents := int64(math.Round(egressTB * float64(egressPerTB)))
+
+		costCents := storageCostCents + egressCostCents
+
+		var revenueCents int64
+		if t.tier == "standard" || t.tier == "performance" {
+			revenueCents = billing.AccruedCents(t.tier, t.storageBytes, t.egressBytes)
+		} else {
+			revenueCents = planMonthlyCents(t.plan)
+		}
+
+		marginCents := revenueCents - costCents
+		isNeg := marginCents < 0
+
+		if isNeg {
+			negativeCount++
+		}
+
+		totalCostCents += costCents
+		totalRevenueCents += revenueCents
+		totalStorageBytes += t.storageBytes
+
+		// Aggregate per backend.
+		agg, ok := backends[backend]
+		if !ok {
+			agg = &backendAgg{}
+			backends[backend] = agg
+		}
+		agg.storageBytes += t.storageBytes
+		agg.costCents += storageCostCents
+
+		displayPlan := t.plan
+		if t.tier == "standard" || t.tier == "performance" {
+			displayPlan = t.tier
+		}
+
+		margins = append(margins, marginRow{
+			Email:           t.email,
+			Plan:            displayPlan,
+			Backend:         backend,
+			StorageFmt:      formatBytes(t.storageBytes),
+			RevenueCents:    revenueCents,
+			RevenueFmt:      formatCents(revenueCents),
+			CostCents:       costCents,
+			CostFmt:         formatCents(costCents),
+			EgressCostCents: egressCostCents,
+			EgressCostFmt:   formatCents(egressCostCents),
+			MarginCents:     marginCents,
+			MarginFmt:       formatSignedCents(marginCents),
+			IsNegative:      isNeg,
+		})
+	}
+
+	// Add fixed costs.
+	totalCostCents += geyserFloorCents + gorillaFixedCents
+
+	// Build backend table rows.
+	backendOrder := []string{"geyser", "idrive", "hetzner", "onedrive", "gorilla", "local", "edge"}
+	var byBackend []backendCostRow
+	for _, name := range backendOrder {
+		agg := backends[name]
+		if agg == nil {
+			continue
+		}
+		storageTB := float64(agg.storageBytes) / bytesPerTBCost
+		fixedCents := int64(0)
+		if name == "geyser" {
+			fixedCents = geyserFloorCents
+		}
+		if name == "gorilla" {
+			fixedCents = gorillaFixedCents
+		}
+		totalCents := agg.costCents + fixedCents
+
+		byBackend = append(byBackend, backendCostRow{
+			Backend:    name,
+			StorageTB:  math.Round(storageTB*100) / 100,
+			StorageFmt: fmt.Sprintf("%.2f TB", storageTB),
+			CostCents:  agg.costCents,
+			CostFmt:    formatCents(agg.costCents),
+			FixedCents: fixedCents,
+			FixedFmt:   formatCents(fixedCents),
+			TotalCents: totalCents,
+			TotalFmt:   formatCents(totalCents),
+		})
+	}
+
+	// Cards.
+	data["EstSpendFmt"] = formatCents(totalCostCents)
+
+	totalTB := float64(totalStorageBytes) / bytesPerTBCost
+	if totalTB > 0 {
+		blended := float64(totalCostCents) / totalTB
+		data["BlendedCOGSFmt"] = fmt.Sprintf("$%.2f/TB", blended/100)
+	}
+
+	if totalRevenueCents > 0 {
+		marginPct := float64(totalRevenueCents-totalCostCents) / float64(totalRevenueCents) * 100
+		data["GrossMarginFmt"] = fmt.Sprintf("%.1f%%", marginPct)
+	}
+
+	data["NegativeMarginCount"] = negativeCount
+	data["ByBackend"] = byBackend
+	data["MarginTable"] = margins
+
+	// Projected month-end spend (linear from current day-of-month).
+	now := time.Now().UTC()
+	dayOfMonth := now.Day()
+	daysInMonth := daysInCurrentMonth(now)
+	if dayOfMonth > 0 {
+		projected := float64(totalCostCents) * float64(daysInMonth) / float64(dayOfMonth)
+		data["ProjectedSpendFmt"] = formatCents(int64(math.Round(projected)))
+	}
+}
+
+type tenantCostData struct {
+	email        string
+	plan         string
+	tier         string
+	storageBytes int64
+	egressBytes  int64
+}
+
+func queryTenantCostData(ctx context.Context, db *sql.DB, logger *zap.Logger) []tenantCostData {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.email, COALESCE(t.plan, ''),
+		       COALESCE(tq.tier, ''), COALESCE(tq.storage_used_bytes, 0),
+		       COALESCE(bw.egress, 0)
+		FROM tenants t
+		LEFT JOIN tenant_quotas tq ON tq.tenant_id = t.id
+		LEFT JOIN (
+			SELECT tenant_id, SUM(egress_bytes) AS egress
+			FROM bandwidth_usage_daily
+			WHERE date >= date_trunc('month', CURRENT_DATE)
+			GROUP BY tenant_id
+		) bw ON bw.tenant_id = t.id
+		WHERE t.subscription_status = 'active'
+		ORDER BY tq.storage_used_bytes DESC NULLS LAST`)
+	if err != nil {
+		logger.Debug("costs: query tenant data", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []tenantCostData
+	for rows.Next() {
+		var td tenantCostData
+		if err := rows.Scan(&td.email, &td.plan, &td.tier, &td.storageBytes, &td.egressBytes); err != nil {
+			logger.Debug("costs: scan tenant", zap.Error(err))
+			continue
+		}
+		result = append(result, td)
+	}
+	return result
+}
+
+func formatSignedCents(cents int64) string {
+	if cents < 0 {
+		return fmt.Sprintf("-$%.2f", float64(-cents)/100)
+	}
+	return fmt.Sprintf("$%.2f", float64(cents)/100)
+}
+
+func daysInCurrentMonth(t time.Time) int {
+	y, m, _ := t.Date()
+	return time.Date(y, m+1, 0, 0, 0, 0, 0, t.Location()).Day()
+}

--- a/internal/dashboard/handlers/admin_costs_test.go
+++ b/internal/dashboard/handlers/admin_costs_test.go
@@ -1,0 +1,301 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testCostsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Costs{{end}}` +
+			`{{define "content"}}` +
+			`<span class="spend">{{.EstSpendFmt}}</span>` +
+			`<span class="cogs">{{.BlendedCOGSFmt}}</span>` +
+			`<span class="margin">{{.GrossMarginFmt}}</span>` +
+			`<span class="neg-count">{{.NegativeMarginCount}}</span>` +
+			`<span class="projected">{{.ProjectedSpendFmt}}</span>` +
+			`{{range .ByBackend}}<span class="backend">{{.Backend}} {{.StorageFmt}} {{.CostFmt}} {{.FixedFmt}} {{.TotalFmt}}</span>{{end}}` +
+			`{{range .MarginTable}}<span class="tenant-margin{{if .IsNegative}} negative{{end}}">{{.Email}} {{.Plan}} {{.Backend}} {{.RevenueFmt}} {{.CostFmt}} {{.EgressCostFmt}} {{.MarginFmt}}</span>{{end}}` +
+			`{{if not .ByBackend}}<p>No backends</p>{{end}}` +
+			`{{if not .MarginTable}}<p>No margins</p>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func costsQueryRows(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
+	mock.ExpectQuery(`SELECT t.email, COALESCE\(t.plan, ''\)`).WillReturnRows(rows)
+}
+
+func TestCosts_PerBackendSpend(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	oneTB := int64(1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("alice@example.com", "vault5", "", oneTB, int64(0)).
+		AddRow("bob@example.com", "vault3", "", oneTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 2 TB on geyser at 155 cents/TB = 310 cents variable + 15500 fixed = 15810 total.
+	// Backend row: geyser 2.00 TB $3.10 $155.00 $158.10
+	assert.Contains(t, body, "geyser")
+	assert.Contains(t, body, "2.00 TB")
+	assert.Contains(t, body, "$3.10")
+	assert.Contains(t, body, "$155.00")
+	assert.Contains(t, body, "$158.10")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_MarginPerTenant(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	oneTB := int64(1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("alice@example.com", "vault5", "", oneTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// vault5 revenue = $9.99 (999 cents), geyser cost for 1TB = $1.55 (155 cents).
+	// Margin = 999 - 155 = 844 cents = $8.44
+	assert.Contains(t, body, "alice@example.com")
+	assert.Contains(t, body, "vault5")
+	assert.Contains(t, body, "$9.99") // revenue
+	assert.Contains(t, body, "$1.55") // cost
+	assert.Contains(t, body, "$8.44") // margin
+	assert.NotContains(t, body, "negative")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_NegativeMarginFlagged(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Vault18 at full 18TB fill: revenue=1799, cost=18*155=2790 → negative margin.
+	eighteenTB := int64(18 * 1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("whale@example.com", "vault18", "", eighteenTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// revenue=1799 cents=$17.99, cost=18*155=2790 cents=$27.90, margin=-991 cents=-$9.91
+	assert.Contains(t, body, "whale@example.com")
+	assert.Contains(t, body, "$17.99") // revenue
+	assert.Contains(t, body, "$27.90") // cost
+	assert.Contains(t, body, "-$9.91") // negative margin
+	assert.Contains(t, body, "negative")
+	assert.Contains(t, body, `<span class="neg-count">1</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_BlendedCOGS(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	twoTB := int64(2 * 1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("a@test.com", "vault5", "", twoTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 2TB on geyser: variable=310 cents + geyser floor 15500 + gorilla 0 = 15810 total
+	// Blended = 15810 / 2 = 7905 cents/TB = $79.05/TB
+	assert.Contains(t, body, "$79.05/TB")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_FixedCostsIncluded(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	oneTB := int64(1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("a@test.com", "vault5", "", oneTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 1TB geyser variable = 155 cents, geyser floor = 15500, gorilla = 0
+	// Total est spend = 155 + 15500 + 0 = 15655 = $156.55
+	assert.Contains(t, body, `<span class="spend">$156.55</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_ZeroState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="spend">$0.00</span>`)
+	assert.Contains(t, body, `<span class="cogs">$0.00/TB</span>`)
+	assert.Contains(t, body, `<span class="margin">0%</span>`)
+	assert.Contains(t, body, `<span class="neg-count">0</span>`)
+	assert.Contains(t, body, "No backends")
+	assert.Contains(t, body, "No margins")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCosts_NoSession(t *testing.T) {
+	handler := HandleAdminCosts(testCostsTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestCosts_NilDB(t *testing.T) {
+	handler := HandleAdminCosts(testCostsTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="spend">$0.00</span>`)
+	assert.Contains(t, body, `<span class="neg-count">0</span>`)
+}
+
+func TestBackendCostPerTB(t *testing.T) {
+	cases := []struct {
+		backend string
+		want    int64
+	}{
+		{"geyser", 155},
+		{"idrive", 330},
+		{"hetzner", 381},
+		{"onedrive", 0},
+		{"gorilla", 0},
+		{"local", 0},
+		{"edge", 0},
+	}
+	for _, tc := range cases {
+		got := backendCostPerTBCents[tc.backend]
+		assert.Equal(t, tc.want, got, "backend=%q", tc.backend)
+	}
+}
+
+func TestTierBackend(t *testing.T) {
+	cases := []struct {
+		plan string
+		tier string
+		want string
+	}{
+		{"vault1", "", "geyser"},
+		{"vault3", "", "geyser"},
+		{"vault5", "", "geyser"},
+		{"vault10", "", "geyser"},
+		{"vault18", "", "geyser"},
+		{"vault50", "", "geyser"},
+		{"vault100", "", "geyser"},
+		{"starter", "standard", "idrive"},
+		{"starter", "performance", "idrive"},
+		{"free", "", "local"},
+		{"", "", "local"},
+	}
+	for _, tc := range cases {
+		got := tierBackend(tc.plan, tc.tier)
+		assert.Equal(t, tc.want, got, "plan=%q tier=%q", tc.plan, tc.tier)
+	}
+}
+
+func TestProjectedCosts(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	oneTB := int64(1024 * 1024 * 1024 * 1024)
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
+		AddRow("a@test.com", "vault5", "", oneTB, int64(0)))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// ProjectedSpendFmt should exist and not be zero (projected from current day).
+	assert.Contains(t, body, `<span class="projected">$`)
+	assert.NotContains(t, body, `<span class="projected">$0.00</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDaysInCurrentMonth(t *testing.T) {
+	cases := []struct {
+		month int
+		year  int
+		want  int
+	}{
+		{1, 2026, 31},
+		{2, 2026, 28},
+		{2, 2024, 29}, // leap year
+		{4, 2026, 30},
+		{6, 2026, 30},
+		{12, 2026, 31},
+	}
+	for _, tc := range cases {
+		got := daysInCurrentMonth(
+			time.Date(tc.year, time.Month(tc.month), 15, 0, 0, 0, 0, time.UTC))
+		assert.Equal(t, tc.want, got, "month=%d year=%d", tc.month, tc.year)
+	}
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -262,6 +262,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/revenue.html",
 	))
+	costsTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/costs.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -285,6 +289,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Get("/waitlist", handlers.HandleAdminWaitlist(waitlistTmpl, deps.DB, deps.Logger))
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		ar.Get("/revenue", handlers.HandleAdminRevenue(revenueTmpl, deps.DB, deps.Logger))
+		ar.Get("/costs", handlers.HandleAdminCosts(costsTmpl, deps.DB, deps.Logger))
 		if deps.Engine != nil {
 			ar.Get("/backends", handlers.HandleAdminBackends(backendsTmpl, deps.Engine, deps.HealthChecker, deps.Logger))
 			ar.Post("/backends/{name}/primary", handlers.HandleSetPrimary(deps.Engine, deps.Logger))

--- a/internal/dashboard/templates/admin/costs.html
+++ b/internal/dashboard/templates/admin/costs.html
@@ -1,0 +1,104 @@
+{{define "title"}}Costs — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Backend Costs</h1>
+</div>
+
+<p class="text-muted" style="margin-bottom:1.5rem">Estimated from intended tier&rarr;backend mapping. Real costs apply once prod is on a configured backend (5.15.5).</p>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Est. Monthly Spend</div>
+        <div class="card-value">{{.EstSpendFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Blended COGS</div>
+        <div class="card-value">{{.BlendedCOGSFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Gross Margin</div>
+        <div class="card-value">{{.GrossMarginFmt}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Negative-Margin Tenants</div>
+        <div class="card-value"{{if gt .NegativeMarginCount 0}} style="color:#ef4444"{{end}}>{{.NegativeMarginCount}}</div>
+    </div>
+</div>
+
+<div class="card-grid" style="grid-template-columns:1fr">
+    <div class="card">
+        <div class="card-title">Projected Month-End Spend</div>
+        <div class="card-value">{{.ProjectedSpendFmt}}</div>
+    </div>
+</div>
+
+<div class="card" style="margin-bottom:1.5rem">
+    <div class="card-title" style="margin-bottom:0.75rem">Cost by Backend</div>
+    {{if .ByBackend}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Backend</th>
+                    <th style="text-align:right">Storage</th>
+                    <th style="text-align:right">Variable Cost</th>
+                    <th style="text-align:right">Fixed Cost</th>
+                    <th style="text-align:right">Total</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .ByBackend}}
+                <tr>
+                    <td><code>{{.Backend}}</code></td>
+                    <td style="text-align:right">{{.StorageFmt}}</td>
+                    <td style="text-align:right">{{.CostFmt}}</td>
+                    <td style="text-align:right">{{.FixedFmt}}</td>
+                    <td style="text-align:right">{{.TotalFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No backend usage data.</p>
+    {{end}}
+</div>
+
+<div class="card">
+    <div class="card-title" style="margin-bottom:0.75rem">Tenant Margins</div>
+    {{if .MarginTable}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Plan</th>
+                    <th>Backend</th>
+                    <th style="text-align:right">Storage</th>
+                    <th style="text-align:right">Revenue</th>
+                    <th style="text-align:right">Cost</th>
+                    <th style="text-align:right">Egress Cost</th>
+                    <th style="text-align:right">Margin</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .MarginTable}}
+                <tr{{if .IsNegative}} style="background:rgba(239,68,68,0.1)"{{end}}>
+                    <td>{{.Email}}</td>
+                    <td><code>{{.Plan}}</code></td>
+                    <td><code>{{.Backend}}</code></td>
+                    <td style="text-align:right">{{.StorageFmt}}</td>
+                    <td style="text-align:right">{{.RevenueFmt}}</td>
+                    <td style="text-align:right">{{.CostFmt}}</td>
+                    <td style="text-align:right">{{.EgressCostFmt}}</td>
+                    <td style="text-align:right{{if .IsNegative}};color:#ef4444;font-weight:600{{end}}">{{.MarginFmt}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No active tenants.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -24,6 +24,7 @@
                 <a href="/admin/audit" class="sidebar-link{{if eq .Page "admin-audit"}} sidebar-link--active{{end}}">Audit Log</a>
                 <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
                 <a href="/admin/revenue" class="sidebar-link{{if eq .Page "admin-revenue"}} sidebar-link--active{{end}}">Revenue</a>
+                <a href="/admin/costs" class="sidebar-link{{if eq .Page "admin-costs"}} sidebar-link--active{{end}}">Costs</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>


### PR DESCRIPTION
## Summary
- New admin page at `/admin/costs` showing estimated backend spend, per-tenant cost/margin analysis, and negative-margin alerts
- Extensible cost model: `backendCostPerTBCents` map (geyser=$1.55/TB, iDrive=$3.30/TB, Hetzner=~€3.81/TB, OneDrive/Gorilla/local/edge=$0) + fixed costs (Geyser $155/mo floor, Gorilla configurable)
- `tierBackend(plan, tier)` maps vault* → geyser, standard/performance → iDrive, free → local — estimates from intended mapping pre-launch
- Revenue side reuses `planMonthlyCents` (fixed plans) and `billing.AccruedCents` (metered tiers) from Phase 3.8
- Egress rendered as first-class column at $0 today — ready for BYOB/edge when they land
- Cards: Est. Monthly Spend, Blended COGS/TB, Gross Margin %, Negative-Margin Tenants count, Projected Month-End
- Tables: cost-by-backend (storage, variable, fixed, total) and per-tenant margin with negative margins highlighted red
- Vault18 at full 18TB fill correctly flags as negative margin (the overselling risk)
- Sidebar link added, admin.html layout updated

## Test plan
- [x] `TestCosts_PerBackendSpend` — 2TB geyser: $3.10 variable + $155 floor = $158.10
- [x] `TestCosts_MarginPerTenant` — vault5 at 1TB: $9.99 revenue, $1.55 cost, $8.44 margin
- [x] `TestCosts_NegativeMarginFlagged` — vault18 at 18TB: -$9.91 margin, highlighted
- [x] `TestCosts_BlendedCOGS` — blended COGS/TB includes fixed costs
- [x] `TestCosts_FixedCostsIncluded` — Geyser floor added to est. spend
- [x] `TestCosts_ZeroState` — empty DB renders $0 zero-state
- [x] `TestCosts_NoSession` — redirects to /login
- [x] `TestCosts_NilDB` — nil DB renders $0 zero-state
- [x] `TestBackendCostPerTB` — unit test for all backend cost constants
- [x] `TestTierBackend` — unit test for plan/tier → backend mapping
- [x] `TestProjectedCosts` — projected spend is non-zero and present
- [x] `TestDaysInCurrentMonth` — leap year and month-length edge cases
- [x] Full handler test suite passes with no regressions
- [x] `golangci-lint` clean