### PR TITLE
perf(drivers): parallel multipart upload for S3-compatible backends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/cloudflare/circl v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60Qb
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16/go.mod h1:6cx7zqDENJDbBIIWX6P8s0h6hqHC8Avbjh9Dseo27ug=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 h1:UuSfcORqNSz/ey3VPRS8TcVH2Ikf0/sC+Hdj400QI6U=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23/go.mod h1:+G/OSGiOFnSOkYloKj/9M35s74LgVAdJBSD5lsFfqKg=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.7 h1:u8danF+A2Zv//pFZvj5V23v/6XG4AxuSVup5s6nxSnI=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.7/go.mod h1:uvLIvU8iJPEU5so7b6lLDNArWpOX6sRBfL5wBABmlfc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=

--- a/internal/drivers/CLAUDE.md
+++ b/internal/drivers/CLAUDE.md
@@ -52,6 +52,7 @@ Helpers: `IsValidRegion(region)`, `IsEURegion(region)` (true for `eu-*`), `Regio
 | File | Type | Purpose |
 |------|------|---------|
 | `transport.go` | `TunedHTTPClient` | Shared HTTP client factory with connection pooling (200 conns), 4MB I/O buffers, DNS caching, TLS session resumption. Used by all S3-compatible drivers (Lyve, Geyser, iDrive, S3, S3compat). Options: `WithInsecureTLS()`, `WithResponseHeaderTimeout()`, `WithHTTP1Only()`. Disable via `VAULTAIRE_TUNED_TRANSPORT=false`. OneDrive has its own transports (odGraphTransport, odCDNTransport). |
+| `s3upload.go` | `s3ParallelUpload` | Shared parallel multipart upload via the AWS SDK `manager.Uploader` (16 MiB parts, 8 concurrent). Large files upload as concurrent parts instead of one PutObject stream; small files still go as a single PutObject; no full-object buffering. Used by `s3compat.go` + `idrive.go` `Put`. Uses stable `feature/s3/manager` (v1) — not the pre-1.0 `transfermanager`. (OneDrive uploads are non-S3; parallel upload there is deferred to the EC layer.) |
 
 ### Resilience & Orchestration
 

--- a/internal/drivers/idrive.go
+++ b/internal/drivers/idrive.go
@@ -171,34 +171,12 @@ func (d *IDriveDriver) Put(ctx context.Context, container, artifact string, data
 	key := d.buildKey(tenantID, container, artifact)
 	options := engine.ApplyPutOptions(opts...)
 
-	if options.ContentLength > 0 {
-		cl := options.ContentLength
-		_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
-			Bucket:        aws.String(d.bucket),
-			Key:           aws.String(key),
-			Body:          data,
-			ContentLength: &cl,
-		})
-		if err != nil {
-			return fmt.Errorf("idrive put %s: %w", key, err)
-		}
-		return nil
-	}
-
-	body, contentLength, cleanup, err := materialize(data)
-	if err != nil {
-		return fmt.Errorf("idrive buffer %s: %w", key, err)
-	}
-	defer cleanup()
-
-	_, err = d.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:        aws.String(d.bucket),
-		Key:           aws.String(key),
-		Body:          body,
-		ContentLength: &contentLength,
-	})
-	if err != nil {
-		return fmt.Errorf("idrive put %s: %w", key, err)
+	// Parallel multipart upload: large files upload as concurrent parts. The
+	// uploader streams parts on the fly, so it also avoids the full-object
+	// buffering the old unknown-length path did via materialize. Small files
+	// still go as a single PutObject.
+	if err := s3ParallelUpload(ctx, d.client, d.bucket, key, options.ContentType, data); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/drivers/s3compat.go
+++ b/internal/drivers/s3compat.go
@@ -85,14 +85,12 @@ func (d *S3CompatDriver) Get(ctx context.Context, container, artifact string) (i
 // Put stores an artifact
 func (d *S3CompatDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...engine.PutOption) error {
 	key := d.buildKey(container, artifact)
+	options := engine.ApplyPutOptions(opts...)
 
-	_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(d.bucket),
-		Key:    aws.String(key),
-		Body:   data,
-	})
-	if err != nil {
-		return fmt.Errorf("put object %s: %w", key, err)
+	// Parallel multipart upload: large files upload as concurrent parts instead of
+	// a single PutObject stream; small files still go as one PutObject.
+	if err := s3ParallelUpload(ctx, d.client, d.bucket, key, options.ContentType, data); err != nil {
+		return err
 	}
 
 	d.logger.Debug("stored artifact in S3-compatible",

--- a/internal/drivers/s3upload.go
+++ b/internal/drivers/s3upload.go
@@ -1,0 +1,55 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// Parallel multipart upload tuning for S3-compatible backends.
+//
+// A plain PutObject streams an object over a single connection; for a large file
+// that caps throughput at one stream. manager.Uploader instead splits objects
+// larger than the part size into parts and uploads up to s3UploadConcurrency of
+// them in parallel, which materially speeds large single-file uploads. Objects
+// smaller than the part size still go as one PutObject. Parts are read on the fly,
+// so there is no full-object buffering.
+//
+// We deliberately use feature/s3/manager (stable v1, battle-tested) rather than
+// feature/s3/transfermanager, which is still pre-1.0 (v0.x) and too unstable for
+// the write path. The manager *module* carries a forward-looking deprecation
+// notice, but its symbols are not individually deprecated, so this is not flagged
+// by staticcheck.
+const (
+	s3UploadPartSize    = 16 << 20 // 16 MiB per part
+	s3UploadConcurrency = 8        // parallel parts in flight
+)
+
+// s3ParallelUpload uploads body to bucket/key using the SDK's parallel multipart
+// uploader. contentType is optional. client is the manager.UploadAPIClient
+// interface, which *s3.Client satisfies (and tests can mock). On any failure the
+// uploader aborts the multipart upload so no orphaned parts are billed.
+func s3ParallelUpload(ctx context.Context, client manager.UploadAPIClient, bucket, key, contentType string, body io.Reader) error {
+	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
+		u.PartSize = s3UploadPartSize
+		u.Concurrency = s3UploadConcurrency
+	})
+
+	in := &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   body,
+	}
+	if contentType != "" {
+		in.ContentType = aws.String(contentType)
+	}
+
+	if _, err := uploader.Upload(ctx, in); err != nil {
+		return fmt.Errorf("s3 parallel upload %s/%s: %w", bucket, key, err)
+	}
+	return nil
+}

--- a/internal/drivers/s3upload_test.go
+++ b/internal/drivers/s3upload_test.go
@@ -1,0 +1,129 @@
+package drivers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUploadClient implements manager.UploadAPIClient, recording calls and
+// capturing uploaded bytes so tests can verify integrity. Thread-safe because the
+// uploader calls UploadPart from parallel goroutines.
+type mockUploadClient struct {
+	mu sync.Mutex
+
+	putObjectCalls int
+	createCalls    int
+	uploadParts    int
+	completeCalls  int
+
+	putBody []byte
+	parts   map[int32][]byte
+	putErr  error
+}
+
+func newMockUploadClient() *mockUploadClient {
+	return &mockUploadClient{parts: make(map[int32][]byte)}
+}
+
+func (m *mockUploadClient) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	b, _ := io.ReadAll(in.Body)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.putObjectCalls++
+	m.putBody = b
+	if m.putErr != nil {
+		return nil, m.putErr
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockUploadClient) CreateMultipartUpload(_ context.Context, _ *s3.CreateMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createCalls++
+	return &s3.CreateMultipartUploadOutput{UploadId: aws.String("test-upload-id")}, nil
+}
+
+func (m *mockUploadClient) UploadPart(_ context.Context, in *s3.UploadPartInput, _ ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	b, _ := io.ReadAll(in.Body)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.uploadParts++
+	m.parts[*in.PartNumber] = b
+	return &s3.UploadPartOutput{ETag: aws.String(fmt.Sprintf("\"etag-%d\"", *in.PartNumber))}, nil
+}
+
+func (m *mockUploadClient) CompleteMultipartUpload(_ context.Context, _ *s3.CompleteMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.completeCalls++
+	return &s3.CompleteMultipartUploadOutput{}, nil
+}
+
+func (m *mockUploadClient) AbortMultipartUpload(_ context.Context, _ *s3.AbortMultipartUploadInput, _ ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error) {
+	return &s3.AbortMultipartUploadOutput{}, nil
+}
+
+// reassemble concatenates the multipart parts in part-number order.
+func (m *mockUploadClient) reassemble() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	nums := make([]int, 0, len(m.parts))
+	for n := range m.parts {
+		nums = append(nums, int(n))
+	}
+	sort.Ints(nums)
+	var out []byte
+	for _, n := range nums {
+		out = append(out, m.parts[int32(n)]...)
+	}
+	return out
+}
+
+func TestS3ParallelUpload_SmallFile_SinglePut(t *testing.T) {
+	data := bytes.Repeat([]byte("a"), 1<<20) // 1 MiB < 16 MiB part size
+	m := newMockUploadClient()
+
+	err := s3ParallelUpload(context.Background(), m, "bucket", "key", "text/plain", bytes.NewReader(data))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, m.putObjectCalls, "small file should be a single PutObject")
+	assert.Equal(t, 0, m.createCalls, "small file should not start a multipart upload")
+	assert.Equal(t, data, m.putBody, "uploaded bytes must match input")
+}
+
+func TestS3ParallelUpload_LargeFile_ParallelMultipart(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 40<<20) // 40 MiB > 16 MiB → 3 parts
+	m := newMockUploadClient()
+
+	err := s3ParallelUpload(context.Background(), m, "bucket", "key", "", bytes.NewReader(data))
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, m.putObjectCalls, "large file should not use a single PutObject")
+	assert.Equal(t, 1, m.createCalls)
+	assert.GreaterOrEqual(t, m.uploadParts, 3, "40 MiB / 16 MiB → at least 3 parts")
+	assert.Equal(t, 1, m.completeCalls)
+	assert.Equal(t, data, m.reassemble(), "reassembled parts must match input (integrity)")
+}
+
+func TestS3ParallelUpload_Error_Wrapped(t *testing.T) {
+	m := newMockUploadClient()
+	m.putErr = errors.New("backend down")
+
+	err := s3ParallelUpload(context.Background(), m, "bucket", "key", "", bytes.NewReader([]byte("small")))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "s3 parallel upload bucket/key")
+	assert.Contains(t, err.Error(), "backend down")
+}


### PR DESCRIPTION
## What
Large single-file uploads to S3-compatible backends previously used a **single `PutObject`** (one stream → one connection's throughput). This adds a shared **parallel multipart uploader** so large files split into **16 MiB parts uploaded 8-at-a-time**. Small files still go as one `PutObject`. Parts stream on the fly, so it also removes iDrive's full-object buffering (`materialize`) on the unknown-length path.

## Why (measured)
Benchmarks showed iDrive can hit **254 MB/s with 16 parallel parts** vs ~134 MB/s single-stream for a 64MB file — but the *driver* uploaded sequentially. This closes that gap for the production `Put` path (the engine calls `Put`, and `putMultipart` wasn't even in the interface).

## Scope (deliberately tight — write path)
- **New shared helper** `s3ParallelUpload` (`internal/drivers/s3upload.go`)
- **Adopted in the wired S3 backends:** `s3compat.go` + `idrive.go` `Put`
- **Deferred:** OneDrive (non-S3 — parallel upload belongs to the EC layer), Geyser (temp-file spill pattern), `s3.go` (unwired; only a Quotaless base, which overrides `Put`)

## Dependency choice
Uses stable **`feature/s3/manager` (v1, battle-tested)** rather than `feature/s3/transfermanager`, which is still **pre-1.0 (v0.x)** and too unstable for a write path. The `manager` *module* carries a forward-looking deprecation notice, but its *symbols* aren't individually deprecated — confirmed clean under golangci-lint (no SA1019).

## Tests
`s3upload_test.go` — mock `UploadAPIClient`: small file → single PutObject; large file (40 MiB) → multipart with **byte-for-byte reassembly integrity check**; error wrapping. Race-clean (uploader uploads parts from parallel goroutines). iDrive/s3compat integration tests are creds-gated (skip in CI) and unaffected. Full `-short` suite green; lint 0 issues.