### PR TITLE
fix(engine,api): harden failover + quota error mapping under load [Phase 5.15.2]

### DIFF
--- a/internal/api/s3_buckets.go
+++ b/internal/api/s3_buckets.go
@@ -130,23 +130,35 @@ func (s *Server) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		zap.String("tenant", tenantID))
 
 	if s.db != nil && tenantID != "default" {
-		var count int
+		// Idempotent re-creation: if the tenant already owns this bucket, skip
+		// the quota gate entirely. CreateBucket on a bucket you own is a no-op
+		// (BucketAlreadyOwnedByYou) in S3 — it must not 403 just because you're
+		// at the bucket limit, or `aws s3 mb`/terraform/rclone ensure-bucket
+		// calls break once a free-tier tenant has their one bucket.
+		var alreadyOwned bool
 		_ = s.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM buckets WHERE tenant_id = $1", tenantID).Scan(&count)
+			"SELECT EXISTS(SELECT 1 FROM buckets WHERE tenant_id = $1 AND name = $2)",
+			tenantID, bucket).Scan(&alreadyOwned)
 
-		const maxBucketsPerTenant = 1000
-		if count >= maxBucketsPerTenant {
-			WriteS3ErrorWithContext(w, ErrQuotaExceeded, r.URL.Path, generateRequestID(),
-				WithSuggestion(fmt.Sprintf("Maximum %d buckets per account", maxBucketsPerTenant)))
-			return
-		}
+		if !alreadyOwned {
+			var count int
+			_ = s.db.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM buckets WHERE tenant_id = $1", tenantID).Scan(&count)
 
-		if s.quotaManager != nil {
-			tier, _ := s.quotaManager.GetTier(ctx, tenantID)
-			if usage.IsFreeTier(tier) && count >= usage.FreeTierLimits.MaxBuckets {
+			const maxBucketsPerTenant = 1000
+			if count >= maxBucketsPerTenant {
 				WriteS3ErrorWithContext(w, ErrQuotaExceeded, r.URL.Path, generateRequestID(),
-					WithSuggestion(fmt.Sprintf("Free tier allows %d bucket. Upgrade at https://stored.ge/dashboard/billing", usage.FreeTierLimits.MaxBuckets)))
+					WithSuggestion(fmt.Sprintf("Maximum %d buckets per account", maxBucketsPerTenant)))
 				return
+			}
+
+			if s.quotaManager != nil {
+				tier, _ := s.quotaManager.GetTier(ctx, tenantID)
+				if usage.IsFreeTier(tier) && count >= usage.FreeTierLimits.MaxBuckets {
+					WriteS3ErrorWithContext(w, ErrQuotaExceeded, r.URL.Path, generateRequestID(),
+						WithSuggestion(fmt.Sprintf("Free tier allows %d bucket. Upgrade at https://stored.ge/dashboard/billing", usage.FreeTierLimits.MaxBuckets)))
+					return
+				}
 			}
 		}
 	}

--- a/internal/api/s3_buckets_test.go
+++ b/internal/api/s3_buckets_test.go
@@ -10,12 +10,49 @@ import (
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/FairForge/vaultaire/internal/usage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	_ "github.com/lib/pq"
 )
+
+// TestCreateBucket_IdempotentReCreate_AtFreeTierLimit is the regression test for
+// the load-test finding: a free-tier tenant AT its 1-bucket limit must still be
+// able to re-create a bucket it already owns (S3 BucketAlreadyOwnedByYou), while
+// a genuinely new bucket beyond the limit is still rejected.
+func TestCreateBucket_IdempotentReCreate_AtFreeTierLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testS3DB(t)
+	defer func() { _ = db.Close() }()
+	cleanupS3BucketData(t, db)
+	defer cleanupS3BucketData(t, db)
+
+	const tid = "test-s3-idem"
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key) VALUES ($1,'Idem Co','idem@test.com','VK-idem','SK-idem') ON CONFLICT DO NOTHING`, tid)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, tier, storage_limit_bytes) VALUES ($1,'free',5368709120) ON CONFLICT (tenant_id) DO UPDATE SET tier='free'`, tid)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility) VALUES ($1,'owned-bucket','private') ON CONFLICT DO NOTHING`, tid)
+	require.NoError(t, err)
+
+	s := s3ServerWithDB(t, db)
+	s.quotaManager = usage.NewQuotaManager(db)
+	defer func() { _ = os.RemoveAll("/tmp/vaultaire/" + tid) }()
+
+	// Re-creating a bucket you already own must succeed even at the free-tier limit.
+	w := httptest.NewRecorder()
+	s.CreateBucket(w, withTenantCtx(httptest.NewRequest("PUT", "/owned-bucket", nil), tid))
+	assert.Equal(t, http.StatusOK, w.Code, "re-creating an owned bucket at the limit must succeed, not 403")
+
+	// A genuinely new bucket beyond the limit must still be rejected.
+	w2 := httptest.NewRecorder()
+	s.CreateBucket(w2, withTenantCtx(httptest.NewRequest("PUT", "/second-bucket", nil), tid))
+	assert.Equal(t, http.StatusForbidden, w2.Code, "a new bucket beyond the free-tier limit must still 403")
+}
 
 func testS3DB(t *testing.T) *sql.DB {
 	t.Helper()

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -610,10 +610,15 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		err = putErr
 	}
 	if err != nil {
-		if errors.Is(err, engine.ErrAllBackendsUnavailable) {
+		switch {
+		case errors.Is(err, engine.ErrAllBackendsUnavailable):
 			w.Header().Set("Retry-After", "30")
 			WriteS3Error(w, ErrServiceUnavailable, r.URL.Path, generateRequestID())
-		} else {
+		case errors.Is(err, engine.ErrQuotaExceeded):
+			// Quota exhaustion is a client condition, never a 500.
+			WriteS3ErrorWithContext(w, ErrQuotaExceeded, r.URL.Path, generateRequestID(),
+				WithSuggestion("Storage quota exceeded. Upgrade at https://stored.ge/dashboard/billing"))
+		default:
 			a.logger.Error("engine put failed",
 				zap.Error(err),
 				zap.String("container", container),

--- a/internal/engine/failover.go
+++ b/internal/engine/failover.go
@@ -2,7 +2,10 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -108,6 +111,45 @@ func (b *BackendCircuitBreaker) State() CircuitState {
 	return b.state
 }
 
+// isBackendFailure reports whether err indicates the backend itself is
+// unhealthy (timeout, connection refused, DNS failure, 5xx) rather than a
+// benign client-level outcome. Only the former should count toward opening a
+// circuit breaker. Client-level outcomes — object not found, quota exceeded,
+// invalid input, permission denied — are normal traffic and must never trip
+// the breaker; otherwise a 404 storm or a quota-capped tenant could DOS a
+// healthy single-backend deployment (all requests rejected for openDuration).
+func isBackendFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Object-not-found: os.Remove/Open on a missing path, or our own type.
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	var nf NotFoundError
+	if errors.As(err, &nf) {
+		return false
+	}
+	// Other client-level engine errors.
+	if errors.Is(err, ErrQuotaExceeded) || errors.Is(err, ErrInvalidInput) {
+		return false
+	}
+	var perr PermissionError
+	if errors.As(err, &perr) {
+		return false
+	}
+	// Precise string fallbacks for driver/SDK errors that don't wrap our
+	// sentinels. Kept narrow so real failures (e.g. "no such host",
+	// "connection refused") still trip the breaker.
+	msg := err.Error()
+	for _, s := range []string{"no such file or directory", "NoSuchKey", "status code: 404"} {
+		if strings.Contains(msg, s) {
+			return false
+		}
+	}
+	return true
+}
+
 type FailoverManager struct {
 	mu       sync.RWMutex
 	breakers map[string]*BackendCircuitBreaker
@@ -148,11 +190,18 @@ func (f *FailoverManager) Execute(ctx context.Context, backends []string, fn fun
 		}
 
 		if err := fn(backend); err != nil {
-			breaker.RecordFailure()
+			// Only genuine backend-health failures trip the circuit breaker.
+			// Benign client-level outcomes (object not found, quota exceeded,
+			// bad input, permission denied) must NOT — otherwise a burst of
+			// 404s or quota rejections would open the breaker and take a
+			// healthy single-backend deployment fully offline.
+			if isBackendFailure(err) {
+				breaker.RecordFailure()
+				f.logger.Warn("backend failed, trying next",
+					zap.String("backend", backend),
+					zap.Error(err))
+			}
 			lastErr = err
-			f.logger.Warn("backend failed, trying next",
-				zap.String("backend", backend),
-				zap.Error(err))
 			continue
 		}
 

--- a/internal/engine/failover_test.go
+++ b/internal/engine/failover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -388,4 +389,68 @@ func (d *mockDriver) Exists(_ context.Context, _, _ string) (bool, error) {
 
 func (d *mockDriver) HealthCheck(_ context.Context) error {
 	return nil
+}
+
+// TestIsBackendFailure_ClassifiesErrors documents which errors count toward
+// opening the circuit breaker. Client-level outcomes must not.
+func TestIsBackendFailure_ClassifiesErrors(t *testing.T) {
+	benign := []error{
+		os.ErrNotExist,
+		&os.PathError{Op: "remove", Path: "/x/y", Err: os.ErrNotExist},
+		NotFoundError{Container: "c", Artifact: "a"},
+		ErrQuotaExceeded,
+		ErrInvalidInput,
+		PermissionError{TenantID: "t", Action: "write"},
+		fmt.Errorf("remove /data/c/k: no such file or directory"),
+		fmt.Errorf("operation error S3: GetObject, NoSuchKey: key does not exist"),
+		fmt.Errorf("api error NotFound: ... https response error status code: 404"),
+		fmt.Errorf("all backends failed: %w", NotFoundError{Container: "c", Artifact: "a"}),
+	}
+	for _, err := range benign {
+		assert.False(t, isBackendFailure(err), "should NOT trip breaker: %v", err)
+	}
+
+	realFailures := []error{
+		fmt.Errorf("dial tcp: connection refused"),
+		fmt.Errorf("lookup e2-us-east-1.idrive.com: no such host"),
+		fmt.Errorf("context deadline exceeded"),
+		fmt.Errorf("https response error status code: 503"),
+		fmt.Errorf("unexpected EOF"),
+		ErrTimeout,
+	}
+	for _, err := range realFailures {
+		assert.True(t, isBackendFailure(err), "SHOULD trip breaker: %v", err)
+	}
+}
+
+// TestFailoverManager_NotFoundDoesNotOpenBreaker is the regression test for the
+// load-test finding: a burst of not-found deletes on a single backend must not
+// open its breaker (which would 503 every subsequent request for openDuration).
+func TestFailoverManager_NotFoundDoesNotOpenBreaker(t *testing.T) {
+	fm := NewFailoverManager(zap.NewNop())
+	fm.Register("local")
+
+	notFound := &os.PathError{Op: "remove", Path: "/data/load-test/k", Err: os.ErrNotExist}
+	for i := 0; i < 3*failureThreshold; i++ {
+		_, err := fm.Execute(context.Background(), []string{"local"}, func(string) error { return notFound })
+		require.Error(t, err) // caller still sees the not-found
+	}
+
+	// Breaker must still be CLOSED — a real op should be attempted, not rejected.
+	attempted := false
+	used, err := fm.Execute(context.Background(), []string{"local"}, func(string) error {
+		attempted = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, attempted, "breaker wrongly opened: real request was rejected after a 404 burst")
+	assert.Equal(t, "local", used)
+
+	// A genuine backend failure SHOULD still open it.
+	for i := 0; i < failureThreshold; i++ {
+		_, _ = fm.Execute(context.Background(), []string{"local"}, func(string) error {
+			return fmt.Errorf("connection refused")
+		})
+	}
+	assert.Equal(t, "open", fm.GetStatus("local"), "real failures must still open the breaker")
 }

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -55,8 +55,28 @@ go test ./tests/load/ -v -run TestLoad_ConcurrentPut -timeout 5m
 
 ## Results
 
-Paste before/after numbers here after running:
+**First run — 2026-06-02, local server (macOS, local-disk backend, PostgreSQL).**
+The run surfaced three production bugs (all fixed in the same change) before going green:
 
-```
-(pending — fill in after first run against local/SLC server)
-```
+| Bug | Symptom | Fix |
+|-----|---------|-----|
+| **Circuit breaker tripped on benign not-found** (critical) | A burst of 404/not-found deletes recorded 5 "failures" in 60s → breaker opened → **every** request 503'd for 30s. On a single-backend deploy = self-inflicted total outage. | `engine/failover.go`: `isBackendFailure()` — only genuine backend failures (timeout, conn refused, 5xx) trip the breaker; not-found/quota/permission/invalid-input never do. |
+| **CreateBucket 403 on idempotent re-create** | A free-tier tenant at its 1-bucket limit got `QuotaExceeded` when re-creating a bucket it already owned → broke `aws s3 mb`/terraform/rclone ensure-bucket. | `api/s3_buckets.go`: skip the quota gate when the tenant already owns the bucket. |
+| **Quota-exceeded PUT → 500** | Engine-level quota exhaustion mapped to `InternalError` (500) instead of `QuotaExceeded` (403). | `api/s3_engine_adapter.go`: map `engine.ErrQuotaExceeded` → 403. |
+
+Harness bug also fixed: `patternReader` was not seekable → SigV4 PUT failed client-side (`request stream is not seekable`); now implements `io.ReadSeeker`.
+
+**Clean run after fixes (fresh tenant, quota headroom):** all gates pass, 0 breaker trips.
+
+| Test | Throughput | p99 | Status |
+|------|-----------|-----|--------|
+| ConcurrentPut (100 × 1 MB) | 116 MB/s | 901 ms | 100/100 ✓ |
+| ConcurrentGet (100 readers) | 237 MB/s | 440 ms | 100/100 ✓ |
+| Multipart (50 × 100 MB) | 219 MB/s | — | 50/50 ✓ |
+| MixedReadWrite (100, 70/30) | 145 MB/s | 722 ms | 100/100 ✓ |
+| ManagementBurst (50 rapid) | — | 9 ms | 10×200 + 40×429 ✓ |
+
+Notes:
+- Numbers are **local-disk bound** (single SSD, synchronous writes). Prod backends (iDrive ~836 MB/s) and the write path will differ; this run validates *correctness and concurrency behavior*, not prod throughput.
+- The DB pool was already bumped to 50/25 (Phase 5.15.2) — no pool exhaustion observed at 100 concurrency.
+- **Setup gotcha:** the load tenant needs storage-quota headroom (free tier = 5 GB; the Multipart scenario alone writes 5 GB). Bump `tenant_quotas.storage_limit_bytes` for the test tenant, or use a paid-tier tenant. Do not hand-edit the quota row while the server is running — the QuotaManager upsert can race it.

--- a/tests/load/harness.go
+++ b/tests/load/harness.go
@@ -93,9 +93,13 @@ func newUploader(client *s3.Client) *manager.Uploader {
 	})
 }
 
-// patternReader produces size bytes from a repeating 4KB pattern.
+// patternReader produces size bytes from a repeating 4KB pattern. It implements
+// io.ReadSeeker (zero-alloc) because the AWS SDK must seek the body to compute
+// the SigV4 payload hash and to retry — a plain io.Reader fails PUT with
+// "request stream is not seekable".
 type patternReader struct {
 	pattern []byte
+	size    int64
 	remain  int64
 	pos     int
 }
@@ -105,7 +109,30 @@ func newPatternReader(size int64) *patternReader {
 	for i := range pat {
 		pat[i] = byte(i % 251) // prime avoids alignment artifacts
 	}
-	return &patternReader{pattern: pat, remain: size}
+	return &patternReader{pattern: pat, size: size, remain: size}
+}
+
+func (r *patternReader) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = (r.size - r.remain) + offset
+	case io.SeekEnd:
+		abs = r.size + offset
+	default:
+		return 0, fmt.Errorf("patternReader.Seek: invalid whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("patternReader.Seek: negative position %d", abs)
+	}
+	if abs > r.size {
+		abs = r.size
+	}
+	r.remain = r.size - abs
+	r.pos = int(abs % int64(len(r.pattern)))
+	return abs, nil
 }
 
 func (r *patternReader) Read(p []byte) (int, error) {


### PR DESCRIPTION
The 5.15.2 load harness, run against a live local server (the "run-diagnose-fix" half of the gate), surfaced **three production bugs** — one critical. All fixed here; after the fixes every load gate passes with zero breaker trips.

## Bugs found & fixed

### 1. 🚨 Circuit breaker self-DOS (critical)
`failover.Execute` recorded **benign not-found** errors as backend failures. A burst of 404/not-found deletes → 5 "failures" in 60s → breaker **opens** → every request 503s (`ErrAllBackendsUnavailable`) for 30s. On a single-backend deployment this is a self-inflicted **total outage** — any 404 storm (a scanner, a retrying client, deleting already-gone objects) takes the whole service down.

**Fix:** `engine/failover.go` `isBackendFailure()` — only genuine backend-health failures (timeout, connection refused, DNS, 5xx) count toward the breaker. Not-found / quota / permission / invalid-input never do. Narrow string matches so real failures (`no such host`, `connection refused`) still trip it.

### 2. CreateBucket 403 on idempotent re-create
A free-tier tenant at its 1-bucket limit got `QuotaExceeded` when re-creating a bucket **it already owned** — breaking `aws s3 mb`, terraform, rclone ensure-bucket. **Fix:** `api/s3_buckets.go` skips the quota gate when the tenant already owns the bucket (S3 `BucketAlreadyOwnedByYou`); new buckets beyond the limit still 403.

### 3. Quota-exceeded PUT → 500
Engine-level `ErrQuotaExceeded` mapped to `InternalError` (500) instead of `QuotaExceeded` (403) — real free-tier customers would get a 500 instead of a clean upgrade hint. **Fix:** `api/s3_engine_adapter.go` maps it to 403.

### Harness
`patternReader` wasn't seekable → SigV4 PUT failed client-side (`request stream is not seekable`). Now implements `io.ReadSeeker`.

## Tests
- `TestIsBackendFailure_ClassifiesErrors` + `TestFailoverManager_NotFoundDoesNotOpenBreaker` (regression for #1).
- `TestCreateBucket_IdempotentReCreate_AtFreeTierLimit` (regression for #2).
- Full clean load run after fixes: ConcurrentPut 116 MB/s, ConcurrentGet 237 MB/s, Multipart 219 MB/s, MixedReadWrite 145 MB/s, ManagementBurst 429s correct — **all gates pass, 0 breaker trips** (numbers local-disk bound; see `tests/load/README.md`).

CI-safe: the load tests remain env-gated (skip without `VAULTAIRE_LOAD_*`).