### PR TITLE
feat(dashboard): admin customer support view [Phase 3.7]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The `engine.Driver` interface (in `internal/engine/interface.go`) is the sacred 
 
 Registration persists to **four tables in order**: `users` -> `tenants` -> `api_keys` -> `tenant_quotas`. Missing any causes failures. S3 auth queries `tenants` first (primary key, full access), then falls back to `api_keys` for scoped VLT_ keys, then `sts_tokens` for ASIA-prefixed temporary credentials.
 
-Other critical tables (36 migrations through `036_account_deletion.sql`):
+Other critical tables (45 migrations through `045_admin_notes.sql`):
 - `object_head_cache` — HEAD/GET metadata cache (~1ms), content-type, ETag, metadata JSONB
 - `buckets` — bucket registry with visibility, CORS, cache TTL, metadata JSONB, slug
 - `multipart_uploads`, `multipart_parts` — in-progress multipart state

--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -98,6 +98,9 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/waitlist/export` | GET | session + admin | Download all waitlist signups as CSV |
 | `/admin/revenue` | GET | session + admin | Revenue dashboard: MRR, tier breakdown, churn, top customers |
 | `/admin/costs` | GET | session + admin | Cost dashboard: backend spend, per-tenant margin, negative-margin alerts |
+| `/admin/support` | GET | session + admin | Customer support search (email, tenant ID, access key, Stripe ID) |
+| `/admin/support/{id}` | GET | session + admin | Customer detail: info, timeline, S3 errors, notes, quick actions |
+| `/admin/support/{id}/notes` | POST | session + admin | Add internal admin note on a customer |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -192,6 +192,28 @@ estimates are from intended tier→backend mapping, not live backend.
 Template: `templates/admin/costs.html`. Nil-DB and empty-state both render 200
 with $0.00 zero-state.
 
+## Admin Customer Support (`admin_support.go`)
+
+Three handlers for the admin customer support view (Phase 3.7):
+- `HandleAdminSupport(tmpl, db, logger)` — GET `/admin/support`: unified customer search
+  across `tenants.email` (ILIKE), `tenants.id`, `tenants.access_key`, and
+  `tenants.stripe_customer_id` (exact match). Returns up to 50 results.
+- `HandleCustomerDetail(tmpl, db, logger)` — GET `/admin/support/{id}`: full customer
+  context page. Reuses `loadTenantDetail` for the info card + bandwidth, then adds:
+  **Timeline** (UNION ALL of `events` + `stripe_events`, last 50), **S3 Error Log**
+  (status_code >= 400 from `s3_access_log`, last 20), **Internal Notes** (`admin_notes`
+  JOIN `users`), and **Quick Actions** (link to tenant management).
+- `HandleAddNote(db, logger)` — POST `/admin/support/{id}/notes`: inserts into
+  `admin_notes`, validates non-empty + max 2000 chars, flash + redirect.
+
+Helper functions: `searchCustomers`, `queryTimeline`, `queryS3Errors`, `queryNotes`.
+Types: `supportResult`, `timelineEvent`, `errorLogEntry`, `adminNote`.
+
+Templates: `templates/admin/support.html` (search page),
+`templates/admin/support_detail.html` (customer detail).
+
+Migration: `045_admin_notes.sql` — `admin_notes` table (tenant_id, admin_user_id → users, note, created_at).
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/admin_support.go
+++ b/internal/dashboard/handlers/admin_support.go
@@ -1,0 +1,295 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"go.uber.org/zap"
+)
+
+type supportResult struct {
+	ID          string
+	Name        string
+	Email       string
+	Plan        string
+	Status      string
+	StatusClass string
+}
+
+type timelineEvent struct {
+	Type    string
+	Summary string
+	RelTime string
+}
+
+type errorLogEntry struct {
+	Operation  string
+	Bucket     string
+	Key        string
+	StatusCode int
+	ErrorCode  string
+	SourceIP   string
+	RelTime    string
+}
+
+type adminNote struct {
+	Note       string
+	AdminEmail string
+	RelTime    string
+}
+
+// HandleAdminSupport renders the customer support search page.
+func HandleAdminSupport(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-support")
+		withCSRF(r.Context(), data)
+		data["Results"] = []supportResult{}
+
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
+		data["Query"] = q
+		data["Searched"] = q != ""
+
+		if q != "" && db != nil {
+			data["Results"] = searchCustomers(r.Context(), db, q, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin support", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func searchCustomers(ctx context.Context, db *sql.DB, q string, logger *zap.Logger) []supportResult {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.id, t.name, t.email, COALESCE(t.plan, 'starter'),
+		       t.subscription_status, t.suspended_at
+		FROM tenants t
+		WHERE t.email ILIKE $1 OR t.id = $2 OR t.access_key = $2
+		      OR t.stripe_customer_id = $2
+		ORDER BY t.name LIMIT 50
+	`, "%"+q+"%", q)
+	if err != nil {
+		logger.Error("support search", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []supportResult
+	for rows.Next() {
+		var id, name, email, plan, subStatus string
+		var suspendedAt sql.NullTime
+		if err := rows.Scan(&id, &name, &email, &plan, &subStatus, &suspendedAt); err != nil {
+			logger.Error("support search scan", zap.Error(err))
+			continue
+		}
+		status, statusClass := tenantStatus(subStatus, suspendedAt.Valid)
+		results = append(results, supportResult{
+			ID: id, Name: name, Email: email, Plan: plan,
+			Status: status, StatusClass: statusClass,
+		})
+	}
+	return results
+}
+
+// HandleCustomerDetail renders the customer detail support page.
+func HandleCustomerDetail(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		if db == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		data := sessionData(sd, "admin-support")
+		withCSRF(r.Context(), data)
+		withFlash(r.Context(), data)
+
+		if !loadTenantDetail(r.Context(), db, tenantID, data, logger) {
+			http.NotFound(w, r)
+			return
+		}
+
+		var stripeCustomerID sql.NullString
+		_ = db.QueryRowContext(r.Context(),
+			`SELECT stripe_customer_id FROM tenants WHERE id = $1`, tenantID).Scan(&stripeCustomerID)
+		if stripeCustomerID.Valid {
+			data["StripeCustomerID"] = stripeCustomerID.String
+		}
+
+		data["Timeline"] = queryTimeline(r.Context(), db, tenantID, logger)
+		data["Errors"] = queryS3Errors(r.Context(), db, tenantID, logger)
+		data["Notes"] = queryNotes(r.Context(), db, tenantID, logger)
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render customer detail", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func queryTimeline(ctx context.Context, db *sql.DB, tenantID string, logger *zap.Logger) []timelineEvent {
+	rows, err := db.QueryContext(ctx, `
+		(SELECT type, data::TEXT, created_at FROM events WHERE tenant_id = $1)
+		UNION ALL
+		(SELECT event_type, COALESCE(data::TEXT, ''), processed_at FROM stripe_events WHERE tenant_id = $1)
+		ORDER BY created_at DESC LIMIT 50`, tenantID)
+	if err != nil {
+		logger.Debug("support timeline query", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []timelineEvent
+	for rows.Next() {
+		var typ, dataStr string
+		var createdAt time.Time
+		if err := rows.Scan(&typ, &dataStr, &createdAt); err != nil {
+			logger.Debug("support timeline scan", zap.Error(err))
+			continue
+		}
+		summary := dataStr
+		if len(summary) > 80 {
+			summary = summary[:80] + "…"
+		}
+		events = append(events, timelineEvent{
+			Type:    typ,
+			Summary: summary,
+			RelTime: relativeTime(createdAt),
+		})
+	}
+	return events
+}
+
+func queryS3Errors(ctx context.Context, db *sql.DB, tenantID string, logger *zap.Logger) []errorLogEntry {
+	rows, err := db.QueryContext(ctx, `
+		SELECT operation, bucket, object_key, status_code, error_code, source_ip, logged_at
+		FROM s3_access_log
+		WHERE tenant_id = $1 AND status_code >= 400
+		ORDER BY logged_at DESC LIMIT 20`, tenantID)
+	if err != nil {
+		logger.Debug("support s3 errors query", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []errorLogEntry
+	for rows.Next() {
+		var op, bucket, key, errCode, ip string
+		var statusCode int
+		var loggedAt time.Time
+		if err := rows.Scan(&op, &bucket, &key, &statusCode, &errCode, &ip, &loggedAt); err != nil {
+			logger.Debug("support s3 errors scan", zap.Error(err))
+			continue
+		}
+		entries = append(entries, errorLogEntry{
+			Operation: op, Bucket: bucket, Key: key,
+			StatusCode: statusCode, ErrorCode: errCode, SourceIP: ip,
+			RelTime: relativeTime(loggedAt),
+		})
+	}
+	return entries
+}
+
+func queryNotes(ctx context.Context, db *sql.DB, tenantID string, logger *zap.Logger) []adminNote {
+	rows, err := db.QueryContext(ctx, `
+		SELECT n.note, u.email, n.created_at
+		FROM admin_notes n
+		JOIN users u ON u.id = n.admin_user_id
+		WHERE n.tenant_id = $1
+		ORDER BY n.created_at DESC`, tenantID)
+	if err != nil {
+		logger.Debug("support notes query", zap.Error(err))
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notes []adminNote
+	for rows.Next() {
+		var note, adminEmail string
+		var createdAt time.Time
+		if err := rows.Scan(&note, &adminEmail, &createdAt); err != nil {
+			logger.Debug("support notes scan", zap.Error(err))
+			continue
+		}
+		notes = append(notes, adminNote{
+			Note: note, AdminEmail: adminEmail, RelTime: relativeTime(createdAt),
+		})
+	}
+	return notes
+}
+
+// HandleAddNote inserts an admin note and redirects back to the customer detail page.
+func HandleAddNote(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		tenantID := chi.URLParam(r, "id")
+		if tenantID == "" {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		note := strings.TrimSpace(r.FormValue("note"))
+		if note == "" {
+			middleware.SetFlash(w, "error", "Note cannot be empty.")
+			http.Redirect(w, r, "/admin/support/"+tenantID, http.StatusSeeOther)
+			return
+		}
+		if len(note) > 2000 {
+			middleware.SetFlash(w, "error", "Note is too long (max 2000 characters).")
+			http.Redirect(w, r, "/admin/support/"+tenantID, http.StatusSeeOther)
+			return
+		}
+
+		if db == nil {
+			middleware.SetFlash(w, "error", "Database not available.")
+			http.Redirect(w, r, "/admin/support/"+tenantID, http.StatusSeeOther)
+			return
+		}
+
+		_, err := db.ExecContext(r.Context(),
+			`INSERT INTO admin_notes (tenant_id, admin_user_id, note) VALUES ($1, $2, $3)`,
+			tenantID, sd.UserID, note)
+		if err != nil {
+			logger.Error("add admin note", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to save note.")
+			http.Redirect(w, r, "/admin/support/"+tenantID, http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Note added.")
+		http.Redirect(w, r, "/admin/support/"+tenantID, http.StatusSeeOther)
+	}
+}

--- a/internal/dashboard/handlers/admin_support_test.go
+++ b/internal/dashboard/handlers/admin_support_test.go
@@ -1,0 +1,265 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testSupportTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("admin").Parse(
+		`{{define "admin"}}` +
+			`<span class="query">{{.Query}}</span>` +
+			`{{if .Searched}}` +
+			`{{if .Results}}{{range .Results}}<span class="result">{{.Email}} {{.Name}} {{.Plan}} {{.Status}}</span>{{end}}` +
+			`{{else}}<p>No customers found.</p>{{end}}` +
+			`{{else}}<p>Search for a customer</p>{{end}}` +
+			`{{end}}`))
+}
+
+func testCustomerDetailTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("admin").Parse(
+		`{{define "admin"}}` +
+			`<h1>{{.TenantName}}</h1>` +
+			`<span class="email">{{.TenantEmail}}</span>` +
+			`{{range .Timeline}}<span class="event">{{.Type}}</span>{{end}}` +
+			`{{range .Errors}}<span class="error">{{.Operation}} {{.StatusCode}}</span>{{end}}` +
+			`{{range .Notes}}<span class="note">{{.Note}}</span>{{end}}` +
+			`{{if .FlashSuccess}}<span class="flash-ok">{{.FlashSuccess}}</span>{{end}}` +
+			`{{if .FlashError}}<span class="flash-err">{{.FlashError}}</span>{{end}}` +
+			`{{end}}`))
+}
+
+// --- Search tests ---
+
+func TestHandleAdminSupport_NoSession(t *testing.T) {
+	h := HandleAdminSupport(testSupportTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/support", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminSupport_NoQuery(t *testing.T) {
+	h := HandleAdminSupport(testSupportTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/support", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Search for a customer")
+}
+
+func TestHandleAdminSupport_SearchByEmail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t.id, t.name, t.email`).
+		WithArgs("%alice%", "alice").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "email", "plan", "subscription_status", "suspended_at"}).
+			AddRow("t-1", "Alice Corp", "alice@example.com", "vault3", "active", nil))
+
+	h := HandleAdminSupport(testSupportTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/support?q=alice", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "alice@example.com")
+	assert.Contains(t, body, "Alice Corp")
+	assert.Contains(t, body, "vault3")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminSupport_SearchByTenantID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t.id, t.name, t.email`).
+		WithArgs("%t-exact-123%", "t-exact-123").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "email", "plan", "subscription_status", "suspended_at"}).
+			AddRow("t-exact-123", "Exact Match", "exact@example.com", "starter", "", nil))
+
+	h := HandleAdminSupport(testSupportTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/support?q=t-exact-123", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "exact@example.com")
+	assert.Contains(t, body, "Exact Match")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminSupport_NoResults(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t.id, t.name, t.email`).
+		WithArgs("%nobody%", "nobody").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "email", "plan", "subscription_status", "suspended_at"}))
+
+	h := HandleAdminSupport(testSupportTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/support?q=nobody", nil).WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "No customers found.")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- Customer detail tests ---
+
+func mockTenantDetailQueries(mock sqlmock.Sqlmock, tenantID string) {
+	mock.ExpectQuery(`SELECT t.name, t.email`).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"name", "email", "plan", "subscription_status", "stripe_customer_id", "stripe_subscription_id", "suspended_at", "created_at"}).
+			AddRow("Test Tenant", "test@example.com", "vault3", "active", nil, nil, nil, time.Now()))
+
+	mock.ExpectQuery(`SELECT COALESCE\(storage_used_bytes`).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"used", "limit", "tier"}).
+			AddRow(int64(1024), int64(1099511627776), "vault3"))
+
+	mock.ExpectQuery(`SELECT COALESCE\(SUM\(ingress_bytes\)`).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"ingress", "egress", "requests"}).
+			AddRow(int64(0), int64(0), int64(0)))
+
+	mock.ExpectQuery(`SELECT bandwidth_limit_bytes`).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"bandwidth_limit_bytes"}).
+			AddRow(nil))
+
+	mock.ExpectQuery(`SELECT date, COALESCE\(ingress_bytes`).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"date", "ingress", "egress"}))
+}
+
+func TestHandleCustomerDetail_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t.name, t.email`).
+		WithArgs("t-bad").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "email", "plan", "subscription_status", "stripe_customer_id", "stripe_subscription_id", "suspended_at", "created_at"}))
+
+	h := HandleCustomerDetail(testCustomerDetailTemplate(t), db, zap.NewNop())
+	ctx := withChiParam(adminCtx(t), "id", "t-bad")
+	req := httptest.NewRequest("GET", "/admin/support/t-bad", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleCustomerDetail_LoadsTimeline(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mockTenantDetailQueries(mock, "t-1")
+
+	mock.ExpectQuery(`SELECT stripe_customer_id FROM tenants`).
+		WithArgs("t-1").
+		WillReturnRows(sqlmock.NewRows([]string{"stripe_customer_id"}).
+			AddRow("cus_test123"))
+
+	mock.ExpectQuery(`SELECT type, data::TEXT, created_at FROM events`).
+		WithArgs("t-1").
+		WillReturnRows(sqlmock.NewRows([]string{"type", "data", "created_at"}).
+			AddRow("object.created", `{"key":"photo.jpg"}`, time.Now()).
+			AddRow("bucket.created", `{"bucket":"my-bucket"}`, time.Now()))
+
+	mock.ExpectQuery(`SELECT operation, bucket, object_key, status_code`).
+		WithArgs("t-1").
+		WillReturnRows(sqlmock.NewRows([]string{"operation", "bucket", "object_key", "status_code", "error_code", "source_ip", "logged_at"}).
+			AddRow("GetObject", "test-bucket", "missing.txt", 404, "NoSuchKey", "10.0.0.1", time.Now()))
+
+	mock.ExpectQuery(`SELECT n.note, u.email, n.created_at`).
+		WithArgs("t-1").
+		WillReturnRows(sqlmock.NewRows([]string{"note", "email", "created_at"}).
+			AddRow("Customer contacted about billing", "admin@stored.ge", time.Now()))
+
+	h := HandleCustomerDetail(testCustomerDetailTemplate(t), db, zap.NewNop())
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	req := httptest.NewRequest("GET", "/admin/support/t-1", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Test Tenant")
+	assert.Contains(t, body, "object.created")
+	assert.Contains(t, body, "bucket.created")
+	assert.Contains(t, body, "GetObject 404")
+	assert.Contains(t, body, "Customer contacted about billing")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- Add note tests ---
+
+func TestHandleAddNote_Valid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO admin_notes`).
+		WithArgs("t-1", "admin-1", "Test note content").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	h := HandleAddNote(db, zap.NewNop())
+	form := url.Values{"note": {"Test note content"}, "csrf_token": {"fake"}}
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	req := httptest.NewRequest("POST", "/admin/support/t-1/notes", strings.NewReader(form.Encode())).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/support/t-1", w.Header().Get("Location"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAddNote_Empty(t *testing.T) {
+	h := HandleAddNote(nil, zap.NewNop())
+	form := url.Values{"note": {""}, "csrf_token": {"fake"}}
+	ctx := withChiParam(adminCtx(t), "id", "t-1")
+	req := httptest.NewRequest("POST", "/admin/support/t-1/notes", strings.NewReader(form.Encode())).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/support/t-1", w.Header().Get("Location"))
+	cookies := w.Result().Cookies()
+	var flashCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "flash" {
+			flashCookie = c
+		}
+	}
+	require.NotNil(t, flashCookie, "flash cookie should be set")
+	assert.Contains(t, flashCookie.Value, "error")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -266,6 +266,14 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/costs.html",
 	))
+	supportTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/support.html",
+	))
+	customerDetailTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/support_detail.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -273,6 +281,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Use(dashauth.RequireAdmin(deps.Sessions))
 		ar.Use(middleware.CSRF)
 		ar.Use(middleware.RequireAdminMFA(deps.Auth))
+		ar.Use(middleware.Flash)
 		ar.NotFound(handlers.HandleNotFound(deps.Logger))
 		ar.Get("/", handlers.HandleAdminOverview(adminTmpl, deps.DB, deps.Logger))
 		ar.Get("/tenants", handlers.HandleTenantList(tenantListTmpl, deps.DB, deps.Logger))
@@ -290,6 +299,9 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		ar.Get("/revenue", handlers.HandleAdminRevenue(revenueTmpl, deps.DB, deps.Logger))
 		ar.Get("/costs", handlers.HandleAdminCosts(costsTmpl, deps.DB, deps.Logger))
+		ar.Get("/support", handlers.HandleAdminSupport(supportTmpl, deps.DB, deps.Logger))
+		ar.Get("/support/{id}", handlers.HandleCustomerDetail(customerDetailTmpl, deps.DB, deps.Logger))
+		ar.Post("/support/{id}/notes", handlers.HandleAddNote(deps.DB, deps.Logger))
 		if deps.Engine != nil {
 			ar.Get("/backends", handlers.HandleAdminBackends(backendsTmpl, deps.Engine, deps.HealthChecker, deps.Logger))
 			ar.Post("/backends/{name}/primary", handlers.HandleSetPrimary(deps.Engine, deps.Logger))

--- a/internal/dashboard/templates/admin/support.html
+++ b/internal/dashboard/templates/admin/support.html
@@ -1,0 +1,55 @@
+{{define "title"}}Customer Support — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Customer Support</h1>
+</div>
+
+<div class="card" style="margin-bottom:1.5rem">
+    <form action="/admin/support" method="GET" style="display:flex;gap:0.75rem;align-items:end">
+        <div style="flex:1">
+            <label style="display:block;font-size:0.85rem;color:#94a3b8;margin-bottom:0.25rem">Search customers</label>
+            <input type="text" name="q" value="{{.Query}}" placeholder="Email, tenant ID, access key, or Stripe customer ID" style="width:100%;padding:0.4rem 0.6rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem">
+        </div>
+        <button type="submit" class="btn btn-sm">Search</button>
+    </form>
+</div>
+
+{{if .Searched}}
+{{if .Results}}
+<div class="card">
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Name</th>
+                    <th>Plan</th>
+                    <th>Status</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Results}}
+                <tr>
+                    <td>{{.Email}}</td>
+                    <td>{{.Name}}</td>
+                    <td><span class="badge">{{.Plan}}</span></td>
+                    <td><span class="badge badge-{{.StatusClass}}">{{.Status}}</span></td>
+                    <td><a href="/admin/support/{{.ID}}" class="btn btn-sm">View &rarr;</a></td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{else}}
+<div class="card">
+    <p class="text-muted">No customers found.</p>
+</div>
+{{end}}
+{{else}}
+<div class="card">
+    <p class="text-muted">Search for a customer by email, tenant ID, access key, or Stripe customer ID.</p>
+</div>
+{{end}}
+{{end}}

--- a/internal/dashboard/templates/admin/support_detail.html
+++ b/internal/dashboard/templates/admin/support_detail.html
@@ -1,0 +1,143 @@
+{{define "title"}}{{.TenantName}} — Support{{end}}
+{{define "content"}}
+<div class="breadcrumb">
+    <a href="/admin/support">Support</a> &rsaquo; {{.TenantName}}
+</div>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+<div class="dashboard-header">
+    <h1>{{.TenantName}}</h1>
+    <span class="badge badge-{{.StatusClass}}">{{.Status}}</span>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Email</div>
+        <div class="card-value" style="font-size:1rem">{{.TenantEmail}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Plan / Tier</div>
+        <div class="card-value" style="font-size:1rem">{{.Plan}} ({{.Tier}})</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Registered</div>
+        <div class="card-value" style="font-size:1rem">{{.CreatedFmt}}</div>
+    </div>
+    {{if .StripeCustomerID}}
+    <div class="card">
+        <div class="card-title">Stripe Customer</div>
+        <div class="card-value" style="font-size:0.85rem;font-family:monospace">{{.StripeCustomerID}}</div>
+    </div>
+    {{end}}
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Storage</div>
+        <div class="card-value" style="font-size:1rem">{{.StorageUsedFmt}} / {{.StorageLimitFmt}}</div>
+        <div class="usage-bar">
+            <div class="usage-bar-fill {{.StorageBarClass}}" style="width: {{.StoragePercent}}%"></div>
+        </div>
+        <div class="card-detail">{{.StoragePercent}}% used</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Bandwidth (Month)</div>
+        <div class="card-value" style="font-size:1rem">{{.IngressFmt}} in / {{.EgressFmt}} out</div>
+        <div class="card-detail">{{.RequestsCount}} requests</div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Timeline (Last 50 Events)</div>
+    {{if .Timeline}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Summary</th>
+                    <th>Time</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Timeline}}
+                <tr>
+                    <td><code>{{.Type}}</code></td>
+                    <td style="max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{.Summary}}</td>
+                    <td style="white-space:nowrap">{{.RelTime}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No events yet.</p>
+    {{end}}
+</div>
+
+<div class="card">
+    <div class="card-title">S3 Error Log (Last 20)</div>
+    {{if .Errors}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Operation</th>
+                    <th>Bucket</th>
+                    <th>Key</th>
+                    <th>Status</th>
+                    <th>Error</th>
+                    <th>IP</th>
+                    <th>Time</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Errors}}
+                <tr>
+                    <td><code>{{.Operation}}</code></td>
+                    <td>{{.Bucket}}</td>
+                    <td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{.Key}}</td>
+                    <td>{{.StatusCode}}</td>
+                    <td><code>{{.ErrorCode}}</code></td>
+                    <td style="font-family:monospace;font-size:0.85rem">{{.SourceIP}}</td>
+                    <td style="white-space:nowrap">{{.RelTime}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No recent errors.</p>
+    {{end}}
+</div>
+
+<div class="card">
+    <div class="card-title">Internal Notes</div>
+    {{if .Notes}}
+    {{range .Notes}}
+    <div style="border-bottom:1px solid #1e293b;padding:0.75rem 0">
+        <div style="font-size:0.9rem">{{.Note}}</div>
+        <div style="font-size:0.8rem;color:#94a3b8;margin-top:0.25rem">{{.AdminEmail}} &mdash; {{.RelTime}}</div>
+    </div>
+    {{end}}
+    {{end}}
+    <form action="/admin/support/{{.TenantID}}/notes" method="POST" style="margin-top:1rem">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <textarea name="note" rows="3" maxlength="2000" placeholder="Add a note..." style="width:100%;padding:0.5rem;border:1px solid #334155;border-radius:6px;background:#0f172a;color:#e2e8f0;font-size:0.9rem;resize:vertical;box-sizing:border-box"></textarea>
+        <button type="submit" class="btn btn-sm btn-primary" style="margin-top:0.5rem">Add Note</button>
+    </form>
+</div>
+
+<div class="card">
+    <div class="card-title">Quick Actions</div>
+    <div style="display:flex;gap:0.75rem;flex-wrap:wrap">
+        <a href="/admin/tenants/{{.TenantID}}" class="btn btn-sm">Tenant Management</a>
+    </div>
+</div>
+
+<div class="dashboard-actions">
+    <a href="/admin/support" class="btn">Back to Support</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -19,6 +19,7 @@
             <nav class="sidebar-nav">
                 <a href="/admin" class="sidebar-link{{if eq .Page "admin-overview"}} sidebar-link--active{{end}}">Overview</a>
                 <a href="/admin/tenants" class="sidebar-link{{if eq .Page "admin-tenants"}} sidebar-link--active{{end}}">Tenants</a>
+                <a href="/admin/support" class="sidebar-link{{if eq .Page "admin-support"}} sidebar-link--active{{end}}">Support</a>
                 <a href="/admin/system" class="sidebar-link{{if eq .Page "admin-system"}} sidebar-link--active{{end}}">System</a>
                 <a href="/admin/backends" class="sidebar-link{{if eq .Page "admin-backends"}} sidebar-link--active{{end}}">Backends</a>
                 <a href="/admin/audit" class="sidebar-link{{if eq .Page "admin-audit"}} sidebar-link--active{{end}}">Audit Log</a>

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -34,6 +34,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 042 | Content-Disposition: `content_disposition TEXT` (default `''`) on `object_head_cache` — stored response header; `cdn_force_download BOOLEAN` (default FALSE) on `buckets` — CDN force-attachment toggle |
 | 043 | Metered billing: `metered_usage_reports` table (daily Stripe meter reports + idempotency guard); `spending_cap_cents BIGINT` (default 0) on `tenant_quotas` |
 | 044 | Waitlist: `waitlist_signups` table (email UNIQUE, source, ip, user_agent) — pre-launch landing-page email capture |
+| 045 | Admin notes: `admin_notes` table (tenant_id, admin_user_id → users, note) — internal support notes on customer accounts |
 
 ## Key Tables
 
@@ -61,6 +62,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **account_exports** — `id (UUID PK)`, `user_id → users`, `tenant_id`, `status` (pending/processing/completed/failed), `format`, `file_path`, `file_size_bytes`, `error_message`, `created_at`, `completed_at`, `expires_at` — GDPR data export tracking
 - **s3_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `operation`, `status_code`, `bytes_sent`, `bytes_received`, `source_ip`, `user_agent`, `request_id`, `error_code`, `logged_at` — buffered S3 access events, delivered as log objects to target buckets
 - **metered_usage_reports** — `id (BIGSERIAL PK)`, `tenant_id`, `meter`, `period_date`, `value`, `stripe_event_id`, `reported_at`, `UNIQUE(tenant_id, meter, period_date)` — daily Stripe Billing Meter reports; the unique constraint is the no-double-billing guard and also gates once-per-month spending-cap alerts (synthetic `alert:80`/`alert:95` meters)
+- **admin_notes** — `id (BIGSERIAL PK)`, `tenant_id`, `admin_user_id → users`, `note`, `created_at` — internal support notes on customer accounts, indexed by (tenant_id, created_at DESC)
 
 ## Connection
 

--- a/internal/database/migrations/045_admin_notes.sql
+++ b/internal/database/migrations/045_admin_notes.sql
@@ -1,0 +1,12 @@
+-- 045_admin_notes.sql: Internal admin notes on customer accounts.
+-- Idempotent — safe to re-run on every deploy.
+
+CREATE TABLE IF NOT EXISTS admin_notes (
+    id            BIGSERIAL PRIMARY KEY,
+    tenant_id     TEXT NOT NULL,
+    admin_user_id UUID NOT NULL REFERENCES users(id),
+    note          TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_notes_tenant ON admin_notes(tenant_id, created_at DESC);


### PR DESCRIPTION
## Summary

- **Customer support search** (`/admin/support`): unified lookup across email (ILIKE), tenant ID, access key, and Stripe customer ID — up to 50 results
- **Customer detail** (`/admin/support/{id}`): info card (reuses `loadTenantDetail`), Stripe customer ID, timeline (UNION ALL of `events` + `stripe_events`, last 50), S3 error log (status >= 400, last 20), internal admin notes with add-note form, quick-action link to tenant management
- **Admin notes** (`POST /admin/support/{id}/notes`): validated (non-empty, max 2000 chars), flash + redirect
- **Migration 045**: `admin_notes` table with tenant_id index
- **Sidebar**: "Support" link added between Tenants and System
- **Flash middleware**: added to admin subrouter for note confirmation messages

## Test plan

- [x] 9 new tests in `admin_support_test.go` (all passing):
  - Search: no session redirect, empty query, email ILIKE match, exact tenant ID match, no results
  - Detail: 404 for bad tenant ID, loads timeline + errors + notes
  - Notes: valid insert + redirect, empty note rejected with flash
- [x] Full test suite (`go test ./... -short`) — zero failures
- [x] `golangci-lint` — 0 issues
- [x] Pre-commit hooks (fmt, test, lint) — all passed
- [ ] CI `build-and-test` — pending