### PR TITLE
feat(dashboard): admin notifications system [Phase 3.10]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -101,6 +101,10 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/support` | GET | session + admin | Customer support search (email, tenant ID, access key, Stripe ID) |
 | `/admin/support/{id}` | GET | session + admin | Customer detail: info, timeline, S3 errors, notes, quick actions |
 | `/admin/support/{id}/notes` | POST | session + admin | Add internal admin note on a customer |
+| `/admin/notifications` | GET | session + admin | Notification list with unread badge and mark-read actions |
+| `/admin/notifications/read-all` | POST | session + admin | Mark all notifications as read (flash + redirect) |
+| `/admin/notifications/{id}/read` | POST | session + admin | Mark single notification read (htmx fragment response) |
+| `/admin/notifications/count` | GET | session + admin | Unread count badge fragment (htmx, loaded on every admin page) |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -214,6 +214,28 @@ Templates: `templates/admin/support.html` (search page),
 
 Migration: `045_admin_notes.sql` — `admin_notes` table (tenant_id, admin_user_id → users, note, created_at).
 
+## Admin Notifications (`admin_notifications.go`)
+
+Five functions for the admin notification system (Phase 3.10):
+- `HandleAdminNotifications(tmpl, db, logger)` — GET `/admin/notifications`: lists last 100
+  notifications (newest first), with unread count badge and "Mark all as read" button. Each row
+  shows a color-coded type badge, message, optional tenant link, relative time, and mark-read button.
+- `HandleMarkRead(db, logger)` — POST `/admin/notifications/{id}/read`: marks a single
+  notification as read and returns an htmx fragment (the updated row with dimmed "read" styling,
+  `hx-swap="outerHTML"`).
+- `HandleMarkAllRead(db, logger)` — POST `/admin/notifications/read-all`: marks all unread
+  notifications as read, flash message + redirect.
+- `HandleNotifCount(db, logger)` — GET `/admin/notifications/count`: returns a small HTML
+  fragment (`<span class="notif-badge">N</span>`) for the sidebar badge. Called via
+  `hx-trigger="load"` on every admin page.
+- `CreateNotification(ctx, db, notifType, message, tenantID)` — exported helper for other code
+  to insert notifications. Nil-DB safe. Not wired into event sources yet (Phase 3.10.1).
+
+Types: `notificationRow`. Helper: `notifBadgeClass` maps type to badge-success/danger/warning/info/default,
+`renderNotifRow` builds the htmx fragment HTML.
+
+Template: `templates/admin/notifications.html`. Migration: `046_admin_notifications.sql`.
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/admin_notifications.go
+++ b/internal/dashboard/handlers/admin_notifications.go
@@ -1,0 +1,232 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html"
+	"html/template"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"go.uber.org/zap"
+)
+
+type notificationRow struct {
+	ID         int64
+	Type       string
+	Message    string
+	TenantID   string
+	IsRead     bool
+	BadgeClass string
+	RelTime    string
+}
+
+func HandleAdminNotifications(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-notifications")
+		withCSRF(r.Context(), data)
+		withFlash(r.Context(), data)
+		data["Notifications"] = []notificationRow{}
+		data["UnreadCount"] = 0
+
+		if db != nil {
+			notifs, unread := queryAdminNotifications(r.Context(), db, logger)
+			data["Notifications"] = notifs
+			data["UnreadCount"] = unread
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin notifications", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func queryAdminNotifications(ctx context.Context, db *sql.DB, logger *zap.Logger) ([]notificationRow, int) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT id, type, message, tenant_id, read_at, created_at
+		 FROM admin_notifications ORDER BY created_at DESC LIMIT 100`)
+	if err != nil {
+		logger.Error("admin notifications query", zap.Error(err))
+		return nil, 0
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notifs []notificationRow
+	var unread int
+	for rows.Next() {
+		var id int64
+		var typ, message string
+		var tenantID sql.NullString
+		var readAt sql.NullTime
+		var createdAt time.Time
+		if err := rows.Scan(&id, &typ, &message, &tenantID, &readAt, &createdAt); err != nil {
+			logger.Error("admin notifications scan", zap.Error(err))
+			continue
+		}
+		isRead := readAt.Valid
+		if !isRead {
+			unread++
+		}
+		notifs = append(notifs, notificationRow{
+			ID:         id,
+			Type:       typ,
+			Message:    message,
+			TenantID:   tenantID.String,
+			IsRead:     isRead,
+			BadgeClass: notifBadgeClass(typ),
+			RelTime:    relativeTime(createdAt),
+		})
+	}
+	return notifs, unread
+}
+
+func HandleMarkRead(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dashauth.GetSession(r.Context()) == nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		_, err = db.ExecContext(r.Context(),
+			`UPDATE admin_notifications SET read_at = NOW() WHERE id = $1 AND read_at IS NULL`, id)
+		if err != nil {
+			logger.Error("mark notification read", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		var typ, message string
+		var tenantID sql.NullString
+		var createdAt time.Time
+		err = db.QueryRowContext(r.Context(),
+			`SELECT type, message, tenant_id, created_at FROM admin_notifications WHERE id = $1`, id).
+			Scan(&typ, &message, &tenantID, &createdAt)
+		if err != nil {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		renderNotifRow(w, id, typ, message, tenantID.String, createdAt, true)
+	}
+}
+
+func HandleMarkAllRead(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dashauth.GetSession(r.Context()) == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if db != nil {
+			_, err := db.ExecContext(r.Context(),
+				`UPDATE admin_notifications SET read_at = NOW() WHERE read_at IS NULL`)
+			if err != nil {
+				logger.Error("mark all notifications read", zap.Error(err))
+				middleware.SetFlash(w, "error", "Failed to mark notifications as read.")
+				http.Redirect(w, r, "/admin/notifications", http.StatusSeeOther)
+				return
+			}
+		}
+
+		middleware.SetFlash(w, "success", "All notifications marked as read.")
+		http.Redirect(w, r, "/admin/notifications", http.StatusSeeOther)
+	}
+}
+
+func HandleNotifCount(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dashauth.GetSession(r.Context()) == nil {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		var count int
+		if db != nil {
+			if err := db.QueryRowContext(r.Context(),
+				`SELECT COUNT(*) FROM admin_notifications WHERE read_at IS NULL`).Scan(&count); err != nil {
+				logger.Debug("notification count", zap.Error(err))
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if count > 0 {
+			_, _ = fmt.Fprintf(w, `<span class="notif-badge">%d</span>`, count)
+		}
+	}
+}
+
+// CreateNotification inserts an admin notification. Safe to call with nil db.
+func CreateNotification(ctx context.Context, db *sql.DB, notifType, message, tenantID string) error {
+	if db == nil {
+		return nil
+	}
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO admin_notifications (type, message, tenant_id) VALUES ($1, $2, NULLIF($3, ''))`,
+		notifType, message, tenantID)
+	return err
+}
+
+func notifBadgeClass(typ string) string {
+	switch typ {
+	case "signup":
+		return "success"
+	case "payment":
+		return "danger"
+	case "quota":
+		return "warning"
+	case "subscription":
+		return "info"
+	default:
+		return "default"
+	}
+}
+
+func renderNotifRow(w http.ResponseWriter, id int64, typ, message, tenantID string, createdAt time.Time, isRead bool) {
+	readClass := ""
+	if isRead {
+		readClass = " notif-row--read"
+	}
+	_, _ = fmt.Fprintf(w, `<div class="notif-row%s" id="notif-%d">`, readClass, id)
+	_, _ = fmt.Fprint(w, `<div style="display:flex;justify-content:space-between;align-items:start">`)
+	_, _ = fmt.Fprint(w, `<div>`)
+	_, _ = fmt.Fprintf(w, `<span class="badge badge-%s">%s</span>`, notifBadgeClass(typ), html.EscapeString(typ))
+	_, _ = fmt.Fprintf(w, `<span style="margin-left:0.5rem">%s</span>`, html.EscapeString(message))
+	if tenantID != "" {
+		_, _ = fmt.Fprintf(w, ` <a href="/admin/support/%s" style="font-size:0.85rem;color:#60a5fa">%s</a>`,
+			html.EscapeString(tenantID), html.EscapeString(tenantID))
+	}
+	_, _ = fmt.Fprint(w, `</div>`)
+	_, _ = fmt.Fprint(w, `<div style="display:flex;align-items:center;gap:0.75rem;white-space:nowrap">`)
+	_, _ = fmt.Fprintf(w, `<span style="font-size:0.85rem;color:#94a3b8">%s</span>`, relativeTime(createdAt))
+	if !isRead {
+		_, _ = fmt.Fprintf(w, `<button hx-post="/admin/notifications/%d/read" hx-target="#notif-%d" hx-swap="outerHTML" class="btn btn-sm">Mark read</button>`, id, id)
+	}
+	_, _ = fmt.Fprint(w, `</div></div></div>`)
+}

--- a/internal/dashboard/handlers/admin_notifications_test.go
+++ b/internal/dashboard/handlers/admin_notifications_test.go
@@ -1,0 +1,233 @@
+package handlers
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testNotificationsTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Notifications{{end}}` +
+			`{{define "content"}}` +
+			`{{range .Notifications}}<div class="notif">{{.Type}} {{.Message}}</div>{{end}}` +
+			`{{if not .Notifications}}<p>No notifications yet.</p>{{end}}` +
+			`<span class="unread">{{.UnreadCount}}</span>` +
+			`{{end}}`))
+	return tmpl
+}
+
+var notifCols = []string{"id", "type", "message", "tenant_id", "read_at", "created_at"}
+
+func TestHandleAdminNotifications_NoSession(t *testing.T) {
+	handler := HandleAdminNotifications(testNotificationsTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/notifications", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminNotifications_ListsNotifications(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(notifCols).
+		AddRow(1, "signup", "New user: alice@example.com", "t-1", nil, time.Now()).
+		AddRow(2, "payment", "Payment failed for tenant t-2", "t-2", time.Now(), time.Now().Add(-time.Hour))
+
+	mock.ExpectQuery(`SELECT id, type, message, tenant_id, read_at, created_at FROM admin_notifications`).
+		WillReturnRows(rows)
+
+	handler := HandleAdminNotifications(testNotificationsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/notifications", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "signup")
+	assert.Contains(t, body, "New user: alice@example.com")
+	assert.Contains(t, body, "payment")
+	assert.Contains(t, body, "Payment failed for tenant t-2")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminNotifications_EmptyState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT id, type, message, tenant_id, read_at, created_at FROM admin_notifications`).
+		WillReturnRows(sqlmock.NewRows(notifCols))
+
+	handler := HandleAdminNotifications(testNotificationsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/notifications", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "No notifications yet.")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleMarkRead_Valid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE admin_notifications SET read_at`).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectQuery(`SELECT type, message, tenant_id, created_at FROM admin_notifications`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"type", "message", "tenant_id", "created_at"}).
+			AddRow("signup", "New user signed up", "t-1", time.Now()))
+
+	handler := HandleMarkRead(db, zap.NewNop())
+	req := httptest.NewRequest("POST", "/admin/notifications/42/read", nil)
+	ctx := adminCtx(t)
+	ctx = withChiParam(ctx, "id", "42")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "notif-row--read")
+	assert.Contains(t, body, "signup")
+	assert.Contains(t, body, "New user signed up")
+	assert.Contains(t, body, "t-1")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleMarkAllRead(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE admin_notifications SET read_at`).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+
+	handler := HandleMarkAllRead(db, zap.NewNop())
+	req := httptest.NewRequest("POST", "/admin/notifications/read-all", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/notifications", w.Header().Get("Location"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleNotifCount_WithUnread(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
+	handler := HandleNotifCount(db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/notifications/count", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `notif-badge`)
+	assert.Contains(t, body, "5")
+}
+
+func TestHandleNotifCount_Zero(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	handler := HandleNotifCount(db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/notifications/count", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestCreateNotification_NilDB(t *testing.T) {
+	err := CreateNotification(t.Context(), nil, "signup", "test", "t-1")
+	assert.NoError(t, err)
+}
+
+func TestCreateNotification_Insert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO admin_notifications`).
+		WithArgs("signup", "New user", "t-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = CreateNotification(t.Context(), db, "signup", "New user", "t-1")
+	assert.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateNotification_EmptyTenantID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO admin_notifications`).
+		WithArgs("system", "System restarted", "").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = CreateNotification(t.Context(), db, "system", "System restarted", "")
+	assert.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleMarkRead_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE admin_notifications SET read_at`).
+		WithArgs(int64(999)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(`SELECT type, message, tenant_id, created_at FROM admin_notifications`).
+		WithArgs(int64(999)).
+		WillReturnError(sql.ErrNoRows)
+
+	handler := HandleMarkRead(db, zap.NewNop())
+	req := httptest.NewRequest("POST", "/admin/notifications/999/read", nil)
+	ctx := adminCtx(t)
+	ctx = withChiParam(ctx, "id", "999")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -274,6 +274,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/support_detail.html",
 	))
+	notificationsTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/notifications.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -299,6 +303,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		ar.Get("/revenue", handlers.HandleAdminRevenue(revenueTmpl, deps.DB, deps.Logger))
 		ar.Get("/costs", handlers.HandleAdminCosts(costsTmpl, deps.DB, deps.Logger))
+		ar.Get("/notifications", handlers.HandleAdminNotifications(notificationsTmpl, deps.DB, deps.Logger))
+		ar.Post("/notifications/read-all", handlers.HandleMarkAllRead(deps.DB, deps.Logger))
+		ar.Post("/notifications/{id}/read", handlers.HandleMarkRead(deps.DB, deps.Logger))
+		ar.Get("/notifications/count", handlers.HandleNotifCount(deps.DB, deps.Logger))
 		ar.Get("/support", handlers.HandleAdminSupport(supportTmpl, deps.DB, deps.Logger))
 		ar.Get("/support/{id}", handlers.HandleCustomerDetail(customerDetailTmpl, deps.DB, deps.Logger))
 		ar.Post("/support/{id}/notes", handlers.HandleAddNote(deps.DB, deps.Logger))

--- a/internal/dashboard/static/css/style.css
+++ b/internal/dashboard/static/css/style.css
@@ -277,6 +277,21 @@ th {
 }
 .sidebar-link:hover { color: #fff; background: #334155; }
 .sidebar-link--active { color: #fff; background: #334155; font-weight: 600; }
+.notif-badge {
+    display: inline-block;
+    background: #ef4444;
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.25rem;
+    vertical-align: middle;
+}
+.badge-info { background: #eff6ff; color: #3b82f6; }
+.notif-row { padding: 0.75rem 0; border-bottom: 1px solid #1e293b; }
+.notif-row:last-child { border-bottom: none; }
+.notif-row--read { opacity: 0.5; }
 .sidebar-footer { padding: 0.5rem 0; border-top: 1px solid #334155; }
 .admin-main { flex: 1; padding: 2rem; }
 

--- a/internal/dashboard/templates/admin/notifications.html
+++ b/internal/dashboard/templates/admin/notifications.html
@@ -1,0 +1,39 @@
+{{define "title"}}Notifications — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Notifications{{if .UnreadCount}} <span class="notif-badge" style="font-size:0.9rem;padding:0.15rem 0.5rem">{{.UnreadCount}}</span>{{end}}</h1>
+    {{if .UnreadCount}}
+    <form action="/admin/notifications/read-all" method="POST" style="margin:0">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <button type="submit" class="btn btn-sm">Mark all as read</button>
+    </form>
+    {{end}}
+</div>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+<div class="card">
+    {{if .Notifications}}
+    {{range .Notifications}}
+    <div class="notif-row{{if .IsRead}} notif-row--read{{end}}" id="notif-{{.ID}}">
+        <div style="display:flex;justify-content:space-between;align-items:start">
+            <div>
+                <span class="badge badge-{{.BadgeClass}}">{{.Type}}</span>
+                <span style="margin-left:0.5rem">{{.Message}}</span>
+                {{if .TenantID}} <a href="/admin/support/{{.TenantID}}" style="font-size:0.85rem;color:#60a5fa">{{.TenantID}}</a>{{end}}
+            </div>
+            <div style="display:flex;align-items:center;gap:0.75rem;white-space:nowrap">
+                <span style="font-size:0.85rem;color:#94a3b8">{{.RelTime}}</span>
+                {{if not .IsRead}}
+                <button hx-post="/admin/notifications/{{.ID}}/read" hx-target="#notif-{{.ID}}" hx-swap="outerHTML" class="btn btn-sm">Mark read</button>
+                {{end}}
+            </div>
+        </div>
+    </div>
+    {{end}}
+    {{else}}
+    <p class="text-muted">No notifications yet.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -26,6 +26,7 @@
                 <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
                 <a href="/admin/revenue" class="sidebar-link{{if eq .Page "admin-revenue"}} sidebar-link--active{{end}}">Revenue</a>
                 <a href="/admin/costs" class="sidebar-link{{if eq .Page "admin-costs"}} sidebar-link--active{{end}}">Costs</a>
+                <a href="/admin/notifications" class="sidebar-link{{if eq .Page "admin-notifications"}} sidebar-link--active{{end}}">Notifications <span hx-get="/admin/notifications/count" hx-trigger="load" hx-swap="innerHTML"></span></a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -35,6 +35,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 043 | Metered billing: `metered_usage_reports` table (daily Stripe meter reports + idempotency guard); `spending_cap_cents BIGINT` (default 0) on `tenant_quotas` |
 | 044 | Waitlist: `waitlist_signups` table (email UNIQUE, source, ip, user_agent) — pre-launch landing-page email capture |
 | 045 | Admin notes: `admin_notes` table (tenant_id, admin_user_id → users, note) — internal support notes on customer accounts |
+| 046 | Admin notifications: `admin_notifications` table (type, message, tenant_id, read_at) — admin notification system with partial index on unread |
 
 ## Key Tables
 
@@ -63,6 +64,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **s3_access_log** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `object_key`, `operation`, `status_code`, `bytes_sent`, `bytes_received`, `source_ip`, `user_agent`, `request_id`, `error_code`, `logged_at` — buffered S3 access events, delivered as log objects to target buckets
 - **metered_usage_reports** — `id (BIGSERIAL PK)`, `tenant_id`, `meter`, `period_date`, `value`, `stripe_event_id`, `reported_at`, `UNIQUE(tenant_id, meter, period_date)` — daily Stripe Billing Meter reports; the unique constraint is the no-double-billing guard and also gates once-per-month spending-cap alerts (synthetic `alert:80`/`alert:95` meters)
 - **admin_notes** — `id (BIGSERIAL PK)`, `tenant_id`, `admin_user_id → users`, `note`, `created_at` — internal support notes on customer accounts, indexed by (tenant_id, created_at DESC)
+- **admin_notifications** — `id (BIGSERIAL PK)`, `type`, `message`, `tenant_id` (nullable), `read_at` (nullable), `created_at` — admin notification system; partial index on `(created_at DESC) WHERE read_at IS NULL` for fast unread count
 
 ## Connection
 

--- a/internal/database/migrations/046_admin_notifications.sql
+++ b/internal/database/migrations/046_admin_notifications.sql
@@ -1,0 +1,16 @@
+-- 046_admin_notifications.sql: Admin notification system.
+-- Idempotent — safe to re-run on every deploy.
+
+CREATE TABLE IF NOT EXISTS admin_notifications (
+    id         BIGSERIAL PRIMARY KEY,
+    type       TEXT NOT NULL,
+    message    TEXT NOT NULL,
+    tenant_id  TEXT,
+    read_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_notif_unread
+    ON admin_notifications(created_at DESC) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_admin_notif_created
+    ON admin_notifications(created_at DESC);


### PR DESCRIPTION
## Summary
- Admin notification system with sidebar unread badge (htmx `hx-trigger="load"` on every admin page), notifications list page, and mark-read actions
- Migration 046: `admin_notifications` table with partial index on unread rows for fast count queries
- 5 handler functions: list page, mark-read (htmx fragment), mark-all-read (flash+redirect), unread count badge, and `CreateNotification` exported helper for future event wiring
- 10 tests covering all handlers, CreateNotification helper, and edge cases (no session, not found, empty state, nil DB)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short -race ./internal/dashboard/...` — all pass
- [x] `golangci-lint run ./internal/dashboard/...` — 0 issues
- [x] Pre-commit hooks (fmt, test, lint) pass
- [ ] CI build-and-test workflow passes