### PR TITLE
feat(dashboard): abuse reporting and moderation queue [Phase 3.11]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -105,6 +105,11 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/notifications/read-all` | POST | session + admin | Mark all notifications as read (flash + redirect) |
 | `/admin/notifications/{id}/read` | POST | session + admin | Mark single notification read (htmx fragment response) |
 | `/admin/notifications/count` | GET | session + admin | Unread count badge fragment (htmx, loaded on every admin page) |
+| `/abuse` | GET | none | Public abuse report form |
+| `/abuse` | POST | none | Submit abuse report (rate-limited 5/min per IP) |
+| `/admin/abuse` | GET | session + admin | Abuse queue with status filter tabs |
+| `/admin/abuse/{id}` | GET | session + admin | Abuse report detail with action buttons |
+| `/admin/abuse/{id}/action` | POST | session + admin | Change abuse report status (reviewing/actioned/dismissed) |
 | `/admin/*` | GET | session + admin role | Admin panel |
 
 ## Auth Flow

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -236,6 +236,39 @@ Types: `notificationRow`. Helper: `notifBadgeClass` maps type to badge-success/d
 
 Template: `templates/admin/notifications.html`. Migration: `046_admin_notifications.sql`.
 
+## Public Abuse Report (`abuse_report.go`)
+
+Two handlers for the public abuse reporting form (Phase 3.11):
+- `HandleAbuseForm(tmpl, logger)` — GET `/abuse`: renders the public report form using the
+  "base" layout (no session required, same pattern as legal pages).
+- `HandleAbuseSubmit(tmpl, db, logger)` — POST `/abuse`: validates reporter email, report type
+  (one of 6 enum values), and description (non-empty, max 5000 chars). Inserts into
+  `abuse_reports` table and calls `CreateNotification` to alert admins. Rate-limited at 5/min
+  per IP via a dedicated `LoginRateLimiter` instance. Re-renders form with `.Error` on
+  validation failure; renders `.Submitted=true` confirmation on success.
+
+Helper: `validReportTypes` map for enum validation.
+
+Template: `templates/public/abuse.html`. Migration: `047_abuse_reports.sql`.
+
+## Admin Abuse Queue (`admin_abuse.go`)
+
+Three handlers for the admin abuse moderation queue (Phase 3.11):
+- `HandleAdminAbuse(tmpl, db, logger)` — GET `/admin/abuse`: lists abuse reports filtered by
+  status (default: "open") via `?status=` query param. Status tabs: Open, Reviewing, Actioned,
+  Dismissed, All. Page identifier "admin-abuse" for sidebar highlighting.
+- `HandleAdminAbuseDetail(tmpl, db, logger)` — GET `/admin/abuse/{id}`: full report view with
+  reporter info, description, URL, status badge, and action buttons. Links to tenant support
+  page if `tenant_id` is set.
+- `HandleAbuseAction(db, logger)` — POST `/admin/abuse/{id}/action`: validates action is one
+  of "reviewing"/"actioned"/"dismissed", updates status + resolved_by (admin email) + resolved_at.
+  Flash + redirect.
+
+Types: `abuseReportRow`, `abuseReportDetail`. Helper: `abuseBadgeClass` maps status to
+badge-warning/info/success/default.
+
+Templates: `templates/admin/abuse.html` (list), `templates/admin/abuse_detail.html` (detail).
+
 ## Legacy Handlers
 
 Files like `dashboard.go` etc. are stubs from before Phase 0 with inline terminal-style templates. They are NOT wired into the router. Remaining phases will rewrite them.

--- a/internal/dashboard/handlers/abuse_report.go
+++ b/internal/dashboard/handlers/abuse_report.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+var validReportTypes = map[string]bool{
+	"copyright":  true,
+	"csam":       true,
+	"malware":    true,
+	"spam":       true,
+	"harassment": true,
+	"other":      true,
+}
+
+// HandleAbuseForm renders the public abuse report form.
+func HandleAbuseForm(tmpl *template.Template, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "base", map[string]any{"Page": "abuse"}); err != nil {
+			logger.Error("render abuse form", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleAbuseSubmit processes a public abuse report submission.
+func HandleAbuseSubmit(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := strings.TrimSpace(r.FormValue("reporter_email"))
+		name := strings.TrimSpace(r.FormValue("reporter_name"))
+		reportType := strings.TrimSpace(r.FormValue("report_type"))
+		description := strings.TrimSpace(r.FormValue("description"))
+		url := strings.TrimSpace(r.FormValue("url"))
+
+		renderErr := func(msg string) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = tmpl.ExecuteTemplate(w, "base", map[string]any{
+				"Page":          "abuse",
+				"Error":         msg,
+				"ReporterEmail": email,
+				"ReporterName":  name,
+				"ReportType":    reportType,
+				"Description":   description,
+				"URL":           url,
+			})
+		}
+
+		if email == "" || !strings.Contains(email, "@") {
+			renderErr("A valid email address is required.")
+			return
+		}
+		if !validReportTypes[reportType] {
+			renderErr("Please select a report type.")
+			return
+		}
+		if description == "" {
+			renderErr("A description of the abuse is required.")
+			return
+		}
+		if len(description) > 5000 {
+			renderErr("Description is too long (max 5000 characters).")
+			return
+		}
+
+		if db == nil {
+			renderErr("Service temporarily unavailable.")
+			return
+		}
+
+		_, err := db.ExecContext(r.Context(),
+			`INSERT INTO abuse_reports (reporter_email, reporter_name, report_type, description, url)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			email, name, reportType, description, url)
+		if err != nil {
+			logger.Error("insert abuse report", zap.Error(err))
+			renderErr("Failed to submit report. Please try again.")
+			return
+		}
+
+		if notifErr := CreateNotification(r.Context(), db, "system", "New abuse report: "+reportType, ""); notifErr != nil {
+			logger.Error("create abuse notification", zap.Error(notifErr))
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = tmpl.ExecuteTemplate(w, "base", map[string]any{
+			"Page":      "abuse",
+			"Submitted": true,
+		})
+	}
+}

--- a/internal/dashboard/handlers/admin_abuse.go
+++ b/internal/dashboard/handlers/admin_abuse.go
@@ -1,0 +1,244 @@
+package handlers
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/FairForge/vaultaire/internal/dashboard/middleware"
+	"go.uber.org/zap"
+)
+
+type abuseReportRow struct {
+	ID            int64
+	ReporterEmail string
+	ReportType    string
+	URL           string
+	Status        string
+	TenantID      string
+	BadgeClass    string
+	RelTime       string
+}
+
+type abuseReportDetail struct {
+	ID            int64
+	ReporterEmail string
+	ReporterName  string
+	ReportType    string
+	Description   string
+	URL           string
+	Status        string
+	TenantID      string
+	Bucket        string
+	ObjectKey     string
+	ResolvedBy    string
+	ResolvedAt    string
+	BadgeClass    string
+	RelTime       string
+}
+
+var validAbuseActions = map[string]bool{
+	"reviewing": true,
+	"actioned":  true,
+	"dismissed": true,
+}
+
+func abuseBadgeClass(status string) string {
+	switch status {
+	case "open":
+		return "warning"
+	case "reviewing":
+		return "info"
+	case "actioned":
+		return "success"
+	case "dismissed":
+		return "default"
+	default:
+		return "default"
+	}
+}
+
+// HandleAdminAbuse lists abuse reports filtered by status.
+func HandleAdminAbuse(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-abuse")
+		withCSRF(r.Context(), data)
+		withFlash(r.Context(), data)
+
+		status := r.URL.Query().Get("status")
+		if status == "" {
+			status = "open"
+		}
+		data["FilterStatus"] = status
+		data["Reports"] = []abuseReportRow{}
+
+		if db != nil {
+			var rows *sql.Rows
+			var err error
+			if status == "all" {
+				rows, err = db.QueryContext(r.Context(),
+					`SELECT id, reporter_email, report_type, url, status, tenant_id, created_at
+					 FROM abuse_reports ORDER BY created_at DESC LIMIT 100`)
+			} else {
+				rows, err = db.QueryContext(r.Context(),
+					`SELECT id, reporter_email, report_type, url, status, tenant_id, created_at
+					 FROM abuse_reports WHERE status = $1 ORDER BY created_at DESC LIMIT 100`, status)
+			}
+			if err != nil {
+				logger.Error("query abuse reports", zap.Error(err))
+			} else {
+				defer func() { _ = rows.Close() }()
+				var reports []abuseReportRow
+				for rows.Next() {
+					var id int64
+					var reporterEmail, reportType, reportURL, reportStatus string
+					var tenantID sql.NullString
+					var createdAt time.Time
+					if err := rows.Scan(&id, &reporterEmail, &reportType, &reportURL,
+						&reportStatus, &tenantID, &createdAt); err != nil {
+						logger.Error("scan abuse report", zap.Error(err))
+						continue
+					}
+					reports = append(reports, abuseReportRow{
+						ID:            id,
+						ReporterEmail: reporterEmail,
+						ReportType:    reportType,
+						URL:           reportURL,
+						Status:        reportStatus,
+						TenantID:      tenantID.String,
+						BadgeClass:    abuseBadgeClass(reportStatus),
+						RelTime:       relativeTime(createdAt),
+					})
+				}
+				data["Reports"] = reports
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin abuse", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleAdminAbuseDetail renders a single abuse report with action buttons.
+func HandleAdminAbuseDetail(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		data := sessionData(sd, "admin-abuse")
+		withCSRF(r.Context(), data)
+		withFlash(r.Context(), data)
+
+		if db == nil {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		var report abuseReportDetail
+		var tenantID, bucket, objectKey, resolvedBy sql.NullString
+		var resolvedAt sql.NullTime
+		var createdAt time.Time
+
+		err = db.QueryRowContext(r.Context(),
+			`SELECT id, reporter_email, reporter_name, report_type, description, url,
+			        status, tenant_id, bucket, object_key, resolved_by, resolved_at, created_at
+			 FROM abuse_reports WHERE id = $1`, id).
+			Scan(&report.ID, &report.ReporterEmail, &report.ReporterName,
+				&report.ReportType, &report.Description, &report.URL,
+				&report.Status, &tenantID, &bucket, &objectKey,
+				&resolvedBy, &resolvedAt, &createdAt)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				http.Error(w, "Not Found", http.StatusNotFound)
+			} else {
+				logger.Error("query abuse report detail", zap.Error(err))
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+			return
+		}
+
+		report.TenantID = tenantID.String
+		report.Bucket = bucket.String
+		report.ObjectKey = objectKey.String
+		report.ResolvedBy = resolvedBy.String
+		if resolvedAt.Valid {
+			report.ResolvedAt = resolvedAt.Time.Format("Jan 2, 2006 15:04 UTC")
+		}
+		report.BadgeClass = abuseBadgeClass(report.Status)
+		report.RelTime = relativeTime(createdAt)
+
+		data["Report"] = report
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render abuse detail", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// HandleAbuseAction processes status changes on an abuse report.
+func HandleAbuseAction(db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		action := r.FormValue("action")
+		if !validAbuseActions[action] {
+			http.Error(w, "Bad Request: invalid action", http.StatusBadRequest)
+			return
+		}
+
+		if db == nil {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		_, err = db.ExecContext(r.Context(),
+			`UPDATE abuse_reports SET status = $1, resolved_by = $2, resolved_at = NOW()
+			 WHERE id = $3`, action, sd.Email, id)
+		if err != nil {
+			logger.Error("update abuse report", zap.Error(err))
+			middleware.SetFlash(w, "error", "Failed to update report.")
+			http.Redirect(w, r, "/admin/abuse/"+idStr, http.StatusSeeOther)
+			return
+		}
+
+		middleware.SetFlash(w, "success", "Report status updated to "+action+".")
+		http.Redirect(w, r, "/admin/abuse/"+idStr, http.StatusSeeOther)
+	}
+}

--- a/internal/dashboard/handlers/admin_abuse_test.go
+++ b/internal/dashboard/handlers/admin_abuse_test.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testAdminAbuseTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Abuse{{end}}` +
+			`{{define "content"}}` +
+			`{{range .Reports}}<div class="report">{{.ReporterEmail}} {{.ReportType}} {{.Status}}</div>{{end}}` +
+			`{{if not .Reports}}<p>No reports found.</p>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func testAbusePublicTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("base").Parse(
+		`{{define "base"}}` +
+			`{{if .Submitted}}<p>Thank you</p>{{end}}` +
+			`{{if .Error}}<p class="error">{{.Error}}</p>{{end}}` +
+			`{{if .ReporterEmail}}<span class="email">{{.ReporterEmail}}</span>{{end}}` +
+			`<form></form>` +
+			`{{end}}`))
+}
+
+var abuseCols = []string{"id", "reporter_email", "report_type", "url", "status", "tenant_id", "created_at"}
+
+func TestHandleAdminAbuse_NoSession(t *testing.T) {
+	handler := HandleAdminAbuse(testAdminAbuseTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/abuse", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminAbuse_ListsReports(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(abuseCols).
+		AddRow(1, "alice@test.com", "copyright", "https://example.com/file", "open", nil, time.Now()).
+		AddRow(2, "bob@test.com", "malware", "", "open", nil, time.Now())
+
+	mock.ExpectQuery(`SELECT id, reporter_email, report_type, url, status, tenant_id, created_at`).
+		WithArgs("open").
+		WillReturnRows(rows)
+
+	handler := HandleAdminAbuse(testAdminAbuseTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/abuse", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "alice@test.com")
+	assert.Contains(t, body, "bob@test.com")
+	assert.Contains(t, body, "copyright")
+	assert.Contains(t, body, "malware")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAbuse_EmptyState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(abuseCols)
+	mock.ExpectQuery(`SELECT id, reporter_email, report_type, url, status, tenant_id, created_at`).
+		WithArgs("open").
+		WillReturnRows(rows)
+
+	handler := HandleAdminAbuse(testAdminAbuseTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/abuse", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "No reports found.")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminAbuse_FilterByStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows(abuseCols).
+		AddRow(3, "charlie@test.com", "spam", "", "dismissed", nil, time.Now())
+
+	mock.ExpectQuery(`SELECT id, reporter_email, report_type, url, status, tenant_id, created_at`).
+		WithArgs("dismissed").
+		WillReturnRows(rows)
+
+	handler := HandleAdminAbuse(testAdminAbuseTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/abuse?status=dismissed", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "charlie@test.com")
+	assert.Contains(t, body, "dismissed")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAbuseAction_Valid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE abuse_reports SET status`).
+		WithArgs("actioned", "admin@stored.ge", int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	handler := HandleAbuseAction(db, zap.NewNop())
+	form := url.Values{"action": {"actioned"}}
+	req := httptest.NewRequest("POST", "/admin/abuse/42/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := adminCtx(t)
+	ctx = withChiParam(ctx, "id", "42")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/admin/abuse/42", w.Header().Get("Location"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAbuseAction_InvalidAction(t *testing.T) {
+	handler := HandleAbuseAction(nil, zap.NewNop())
+	form := url.Values{"action": {"nuke"}}
+	req := httptest.NewRequest("POST", "/admin/abuse/1/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := adminCtx(t)
+	ctx = withChiParam(ctx, "id", "1")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAbuseSubmit_Valid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`INSERT INTO abuse_reports`).
+		WithArgs("reporter@test.com", "Jane", "malware", "Found malware in bucket", "https://example.com").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectExec(`INSERT INTO admin_notifications`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	handler := HandleAbuseSubmit(testAbusePublicTemplate(t), db, zap.NewNop())
+	form := url.Values{
+		"reporter_email": {"reporter@test.com"},
+		"reporter_name":  {"Jane"},
+		"report_type":    {"malware"},
+		"description":    {"Found malware in bucket"},
+		"url":            {"https://example.com"},
+	}
+	req := httptest.NewRequest("POST", "/abuse", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Thank you")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAbuseSubmit_MissingFields(t *testing.T) {
+	handler := HandleAbuseSubmit(testAbusePublicTemplate(t), nil, zap.NewNop())
+
+	form := url.Values{
+		"reporter_email": {""},
+		"report_type":    {"malware"},
+		"description":    {"some description"},
+	}
+	req := httptest.NewRequest("POST", "/abuse", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "email")
+}
+
+func TestHandleAbuseForm_Renders(t *testing.T) {
+	handler := HandleAbuseForm(testAbusePublicTemplate(t), zap.NewNop())
+	req := httptest.NewRequest("GET", "/abuse", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "<form>")
+}

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -119,6 +119,13 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	r.Get("/compliance/gdpr", http.RedirectHandler("/legal/gdpr", http.StatusMovedPermanently).ServeHTTP)
 	r.Get("/compliance/data-act", http.RedirectHandler("/legal/data-act", http.StatusMovedPermanently).ServeHTTP)
 
+	// --- Public abuse report form ---
+	abusePubTmpl := template.Must(baseTmpl.Clone())
+	template.Must(abusePubTmpl.ParseFS(Templates, "templates/public/abuse.html"))
+	r.Get("/abuse", handlers.HandleAbuseForm(abusePubTmpl, deps.Logger))
+	abuseRL := middleware.NewLoginRateLimiter(5, 5)
+	r.Post("/abuse", abuseRL.Limit(handlers.HandleAbuseSubmit(abusePubTmpl, deps.DB, deps.Logger)).ServeHTTP)
+
 	// --- Customer dashboard (session required) ---
 	r.Route("/dashboard", func(dr chi.Router) {
 		dr.Use(middleware.Recovery(deps.Logger))
@@ -278,6 +285,14 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/notifications.html",
 	))
+	adminAbuseTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/abuse.html",
+	))
+	abuseDetailTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/abuse_detail.html",
+	))
 
 	r.Route("/admin", func(ar chi.Router) {
 		ar.Use(middleware.Recovery(deps.Logger))
@@ -307,6 +322,9 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Post("/notifications/read-all", handlers.HandleMarkAllRead(deps.DB, deps.Logger))
 		ar.Post("/notifications/{id}/read", handlers.HandleMarkRead(deps.DB, deps.Logger))
 		ar.Get("/notifications/count", handlers.HandleNotifCount(deps.DB, deps.Logger))
+		ar.Get("/abuse", handlers.HandleAdminAbuse(adminAbuseTmpl, deps.DB, deps.Logger))
+		ar.Get("/abuse/{id}", handlers.HandleAdminAbuseDetail(abuseDetailTmpl, deps.DB, deps.Logger))
+		ar.Post("/abuse/{id}/action", handlers.HandleAbuseAction(deps.DB, deps.Logger))
 		ar.Get("/support", handlers.HandleAdminSupport(supportTmpl, deps.DB, deps.Logger))
 		ar.Get("/support/{id}", handlers.HandleCustomerDetail(customerDetailTmpl, deps.DB, deps.Logger))
 		ar.Post("/support/{id}/notes", handlers.HandleAddNote(deps.DB, deps.Logger))

--- a/internal/dashboard/templates/admin/abuse.html
+++ b/internal/dashboard/templates/admin/abuse.html
@@ -1,0 +1,50 @@
+{{define "title"}}Abuse Queue — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Abuse Queue</h1>
+</div>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+<div style="display:flex;gap:0.5rem;margin-bottom:1.5rem;flex-wrap:wrap">
+    <a href="/admin/abuse?status=open" class="btn btn-sm{{if eq .FilterStatus "open"}} btn-primary{{end}}">Open</a>
+    <a href="/admin/abuse?status=reviewing" class="btn btn-sm{{if eq .FilterStatus "reviewing"}} btn-primary{{end}}">Reviewing</a>
+    <a href="/admin/abuse?status=actioned" class="btn btn-sm{{if eq .FilterStatus "actioned"}} btn-primary{{end}}">Actioned</a>
+    <a href="/admin/abuse?status=dismissed" class="btn btn-sm{{if eq .FilterStatus "dismissed"}} btn-primary{{end}}">Dismissed</a>
+    <a href="/admin/abuse?status=all" class="btn btn-sm{{if eq .FilterStatus "all"}} btn-primary{{end}}">All</a>
+</div>
+
+<div class="card">
+    {{if .Reports}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Reporter</th>
+                    <th>Type</th>
+                    <th>URL</th>
+                    <th>Status</th>
+                    <th>Time</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Reports}}
+                <tr>
+                    <td>{{.ReporterEmail}}</td>
+                    <td><span class="badge">{{.ReportType}}</span></td>
+                    <td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{.URL}}</td>
+                    <td><span class="badge badge-{{.BadgeClass}}">{{.Status}}</span></td>
+                    <td style="white-space:nowrap">{{.RelTime}}</td>
+                    <td><a href="/admin/abuse/{{.ID}}" class="btn btn-sm">View &rarr;</a></td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No reports found.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/admin/abuse_detail.html
+++ b/internal/dashboard/templates/admin/abuse_detail.html
@@ -1,0 +1,87 @@
+{{define "title"}}Report #{{.Report.ID}} — Abuse Queue{{end}}
+{{define "content"}}
+<div class="breadcrumb">
+    <a href="/admin/abuse">Abuse Queue</a> &rsaquo; Report #{{.Report.ID}}
+</div>
+
+{{if .FlashSuccess}}<div class="alert alert-success">{{.FlashSuccess}}</div>{{end}}
+{{if .FlashError}}<div class="alert alert-error">{{.FlashError}}</div>{{end}}
+
+<div class="dashboard-header">
+    <h1>Report #{{.Report.ID}}</h1>
+    <span class="badge badge-{{.Report.BadgeClass}}">{{.Report.Status}}</span>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Reporter</div>
+        <div class="card-value" style="font-size:1rem">{{.Report.ReporterEmail}}</div>
+        {{if .Report.ReporterName}}<div class="card-detail">{{.Report.ReporterName}}</div>{{end}}
+    </div>
+    <div class="card">
+        <div class="card-title">Type</div>
+        <div class="card-value" style="font-size:1rem">{{.Report.ReportType}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Submitted</div>
+        <div class="card-value" style="font-size:1rem">{{.Report.RelTime}}</div>
+    </div>
+    {{if .Report.TenantID}}
+    <div class="card">
+        <div class="card-title">Tenant</div>
+        <div class="card-value" style="font-size:0.85rem"><a href="/admin/support/{{.Report.TenantID}}" style="color:#60a5fa">{{.Report.TenantID}}</a></div>
+    </div>
+    {{end}}
+</div>
+
+{{if .Report.URL}}
+<div class="card">
+    <div class="card-title">Reported URL</div>
+    <div style="font-size:0.9rem;word-break:break-all"><a href="{{.Report.URL}}" target="_blank" rel="noopener noreferrer" style="color:#60a5fa">{{.Report.URL}}</a></div>
+</div>
+{{end}}
+
+<div class="card">
+    <div class="card-title">Description</div>
+    <div style="font-size:0.9rem;white-space:pre-wrap">{{.Report.Description}}</div>
+</div>
+
+{{if .Report.ResolvedBy}}
+<div class="card">
+    <div class="card-title">Resolution</div>
+    <div style="font-size:0.9rem">
+        Resolved by <strong>{{.Report.ResolvedBy}}</strong>
+        {{if .Report.ResolvedAt}} on {{.Report.ResolvedAt}}{{end}}
+    </div>
+</div>
+{{end}}
+
+<div class="card">
+    <div class="card-title">Actions</div>
+    <div style="display:flex;gap:0.75rem;flex-wrap:wrap">
+        {{if eq .Report.Status "open"}}
+        <form action="/admin/abuse/{{.Report.ID}}/action" method="POST" style="margin:0">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+            <input type="hidden" name="action" value="reviewing">
+            <button type="submit" class="btn btn-sm">Mark Reviewing</button>
+        </form>
+        {{end}}
+        {{if eq .Report.Status "reviewing"}}
+        <form action="/admin/abuse/{{.Report.ID}}/action" method="POST" style="margin:0">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+            <input type="hidden" name="action" value="actioned">
+            <button type="submit" class="btn btn-sm btn-primary">Action Taken</button>
+        </form>
+        <form action="/admin/abuse/{{.Report.ID}}/action" method="POST" style="margin:0">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+            <input type="hidden" name="action" value="dismissed">
+            <button type="submit" class="btn btn-sm">Dismiss</button>
+        </form>
+        {{end}}
+    </div>
+</div>
+
+<div class="dashboard-actions">
+    <a href="/admin/abuse" class="btn">Back to Abuse Queue</a>
+</div>
+{{end}}

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -27,6 +27,7 @@
                 <a href="/admin/revenue" class="sidebar-link{{if eq .Page "admin-revenue"}} sidebar-link--active{{end}}">Revenue</a>
                 <a href="/admin/costs" class="sidebar-link{{if eq .Page "admin-costs"}} sidebar-link--active{{end}}">Costs</a>
                 <a href="/admin/notifications" class="sidebar-link{{if eq .Page "admin-notifications"}} sidebar-link--active{{end}}">Notifications <span hx-get="/admin/notifications/count" hx-trigger="load" hx-swap="innerHTML"></span></a>
+                <a href="/admin/abuse" class="sidebar-link{{if eq .Page "admin-abuse"}} sidebar-link--active{{end}}">Abuse Queue</a>
             </nav>
             <div class="sidebar-footer">
                 <a href="/dashboard" class="sidebar-link">Back to dashboard</a>

--- a/internal/dashboard/templates/public/abuse.html
+++ b/internal/dashboard/templates/public/abuse.html
@@ -1,0 +1,51 @@
+{{define "title"}}Report Abuse — stored.ge{{end}}
+{{define "nav"}}{{end}}
+{{define "content"}}
+<div class="auth-page">
+    <div class="auth-card" style="max-width:540px">
+        <div class="auth-brand">stored.ge</div>
+        <h1>Report Abuse</h1>
+        {{if .Submitted}}
+        <div class="alert alert-success">
+            Thank you for your report. We'll review it within 24 hours.
+        </div>
+        <div class="auth-footer"><a href="/">Back to homepage</a></div>
+        {{else}}
+        <p class="auth-subtitle">If you believe content hosted on stored.ge violates our Acceptable Use Policy, please let us know.</p>
+        {{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}
+        <form method="POST" action="/abuse">
+            <div class="form-group">
+                <label>Your email <span style="color:var(--danger)">*</span></label>
+                <input type="email" name="reporter_email" value="{{.ReporterEmail}}" required>
+            </div>
+            <div class="form-group">
+                <label>Your name</label>
+                <input type="text" name="reporter_name" value="{{.ReporterName}}">
+            </div>
+            <div class="form-group">
+                <label>Report type <span style="color:var(--danger)">*</span></label>
+                <select name="report_type" required>
+                    <option value="">Select a type...</option>
+                    <option value="copyright"{{if eq .ReportType "copyright"}} selected{{end}}>Copyright / DMCA</option>
+                    <option value="csam"{{if eq .ReportType "csam"}} selected{{end}}>CSAM</option>
+                    <option value="malware"{{if eq .ReportType "malware"}} selected{{end}}>Malware</option>
+                    <option value="spam"{{if eq .ReportType "spam"}} selected{{end}}>Spam</option>
+                    <option value="harassment"{{if eq .ReportType "harassment"}} selected{{end}}>Harassment</option>
+                    <option value="other"{{if eq .ReportType "other"}} selected{{end}}>Other</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>URL of content</label>
+                <input type="url" name="url" value="{{.URL}}" placeholder="https://...">
+            </div>
+            <div class="form-group">
+                <label>Description <span style="color:var(--danger)">*</span></label>
+                <textarea name="description" rows="5" maxlength="5000" required placeholder="Describe the abuse you've encountered...">{{.Description}}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Submit Report</button>
+        </form>
+        <div class="auth-footer"><a href="/">Back to homepage</a></div>
+        {{end}}
+    </div>
+</div>
+{{end}}

--- a/internal/database/migrations/047_abuse_reports.sql
+++ b/internal/database/migrations/047_abuse_reports.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS abuse_reports (
+    id            BIGSERIAL PRIMARY KEY,
+    reporter_email TEXT NOT NULL,
+    reporter_name  TEXT NOT NULL DEFAULT '',
+    tenant_id     TEXT,
+    bucket        TEXT,
+    object_key    TEXT,
+    report_type   TEXT NOT NULL,
+    description   TEXT NOT NULL,
+    url           TEXT NOT NULL DEFAULT '',
+    status        TEXT NOT NULL DEFAULT 'open',
+    resolved_by   TEXT,
+    resolved_at   TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_abuse_reports_status
+    ON abuse_reports(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_abuse_reports_tenant
+    ON abuse_reports(tenant_id) WHERE tenant_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Public `/abuse` form for anyone to report abuse (copyright, CSAM, malware, spam, harassment, other) — rate-limited at 5/min per IP, no session required
- Admin `/admin/abuse` queue with status filter tabs (Open/Reviewing/Actioned/Dismissed/All), detail view with action buttons, and status transitions
- Migration `047_abuse_reports.sql` creates the `abuse_reports` table with status and tenant indexes
- New submissions trigger admin notifications via the existing notification bell system
- 9 tests covering auth gates, list/filter/empty states, action validation, public form submission, and form rendering

## Test plan
- [ ] `go test ./internal/dashboard/handlers/ -run TestHandleAbuse -v` — all 9 tests pass
- [ ] `go test ./internal/dashboard/handlers/ -run TestHandleAdminAbuse -v` — 4 admin tests pass
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] CI build-and-test passes
- [ ] Verify `/abuse` form renders without session
- [ ] Verify admin sidebar shows "Abuse Queue" link
- [ ] Verify status filter tabs work on `/admin/abuse`