### PR TITLE
feat(engine): object location tracking + tiering engine + cost tracking [Phase 7.1-7.4]

### DIFF
--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -233,6 +233,15 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 	}
 
+	if cacheHit && a.db != nil {
+		go func() {
+			_, _ = a.db.ExecContext(context.Background(), `
+				UPDATE object_head_cache SET last_accessed = NOW()
+				WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+				t.ID, bucket, artifact)
+		}()
+	}
+
 	if cacheHit {
 		if code := evaluateConditionalGET(r, cachedETag, cachedUpdatedAt); code == http.StatusNotModified {
 			writeNotModified(w, cachedETag, cachedUpdatedAt, "private, no-cache")

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -189,6 +189,12 @@ and per-tenant margin table with negative margins highlighted in red.
 Projected month-end: linear extrapolation from current day-of-month. Caption notes
 estimates are from intended tier→backend mapping, not live backend.
 
+**Actual Backend Distribution (Phase 7.4)**: `populateActualBackends` queries
+`object_locations` grouped by `backend_name` to show ground-truth object counts and
+storage per backend. Rendered as `ActualByBackend` (type `actualBackendRow`: Backend,
+ObjectCount, StorageFmt, StorageTB) in a separate "Storage by Backend (Actual)" card.
+Hidden when `object_locations` is empty. Complements the estimated ByBackend table.
+
 Template: `templates/admin/costs.html`. Nil-DB and empty-state both render 200
 with $0.00 zero-state.
 

--- a/internal/dashboard/handlers/admin_costs.go
+++ b/internal/dashboard/handlers/admin_costs.go
@@ -75,6 +75,13 @@ type backendCostRow struct {
 	TotalFmt   string
 }
 
+type actualBackendRow struct {
+	Backend     string
+	ObjectCount int64
+	StorageFmt  string
+	StorageTB   float64
+}
+
 type marginRow struct {
 	Email           string
 	Plan            string
@@ -109,9 +116,11 @@ func HandleAdminCosts(tmpl *template.Template, db *sql.DB, logger *zap.Logger) h
 		data["ProjectedSpendFmt"] = "$0.00"
 		data["ByBackend"] = []backendCostRow{}
 		data["MarginTable"] = []marginRow{}
+		data["ActualByBackend"] = []actualBackendRow{}
 
 		if db != nil {
 			populateCosts(r.Context(), db, data, logger)
+			populateActualBackends(r.Context(), db, data, logger)
 		}
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -309,6 +318,36 @@ func formatSignedCents(cents int64) string {
 		return fmt.Sprintf("-$%.2f", float64(-cents)/100)
 	}
 	return fmt.Sprintf("$%.2f", float64(cents)/100)
+}
+
+func populateActualBackends(ctx context.Context, db *sql.DB, data map[string]any, logger *zap.Logger) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT backend_name, COUNT(*), COALESCE(SUM(size_bytes), 0)
+		FROM object_locations GROUP BY backend_name
+		ORDER BY SUM(size_bytes) DESC`)
+	if err != nil {
+		logger.Debug("costs: query object_locations", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var actual []actualBackendRow
+	for rows.Next() {
+		var r actualBackendRow
+		var storageBytes int64
+		if err := rows.Scan(&r.Backend, &r.ObjectCount, &storageBytes); err != nil {
+			logger.Debug("costs: scan actual backend", zap.Error(err))
+			continue
+		}
+		storageTB := float64(storageBytes) / bytesPerTBCost
+		r.StorageTB = math.Round(storageTB*100) / 100
+		r.StorageFmt = formatBytes(storageBytes)
+		actual = append(actual, r)
+	}
+
+	if len(actual) > 0 {
+		data["ActualByBackend"] = actual
+	}
 }
 
 func daysInCurrentMonth(t time.Time) int {

--- a/internal/dashboard/handlers/admin_costs_test.go
+++ b/internal/dashboard/handlers/admin_costs_test.go
@@ -27,6 +27,7 @@ func testCostsTemplate(t *testing.T) *template.Template {
 			`<span class="projected">{{.ProjectedSpendFmt}}</span>` +
 			`{{range .ByBackend}}<span class="backend">{{.Backend}} {{.StorageFmt}} {{.CostFmt}} {{.FixedFmt}} {{.TotalFmt}}</span>{{end}}` +
 			`{{range .MarginTable}}<span class="tenant-margin{{if .IsNegative}} negative{{end}}">{{.Email}} {{.Plan}} {{.Backend}} {{.RevenueFmt}} {{.CostFmt}} {{.EgressCostFmt}} {{.MarginFmt}}</span>{{end}}` +
+			`{{range .ActualByBackend}}<span class="actual-backend">{{.Backend}} {{.ObjectCount}} {{.StorageFmt}}</span>{{end}}` +
 			`{{if not .ByBackend}}<p>No backends</p>{{end}}` +
 			`{{if not .MarginTable}}<p>No margins</p>{{end}}` +
 			`{{end}}`))
@@ -35,6 +36,11 @@ func testCostsTemplate(t *testing.T) *template.Template {
 
 func costsQueryRows(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
 	mock.ExpectQuery(`SELECT t.email, COALESCE\(t.plan, ''\)`).WillReturnRows(rows)
+}
+
+func emptyActualBackendRows(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT backend_name, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"backend_name", "count", "sum"}))
 }
 
 func TestCosts_PerBackendSpend(t *testing.T) {
@@ -46,6 +52,7 @@ func TestCosts_PerBackendSpend(t *testing.T) {
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("alice@example.com", "vault5", "", oneTB, int64(0)).
 		AddRow("bob@example.com", "vault3", "", oneTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -73,6 +80,7 @@ func TestCosts_MarginPerTenant(t *testing.T) {
 	oneTB := int64(1024 * 1024 * 1024 * 1024)
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("alice@example.com", "vault5", "", oneTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -102,6 +110,7 @@ func TestCosts_NegativeMarginFlagged(t *testing.T) {
 	eighteenTB := int64(18 * 1024 * 1024 * 1024 * 1024)
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("whale@example.com", "vault18", "", eighteenTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -129,6 +138,7 @@ func TestCosts_BlendedCOGS(t *testing.T) {
 	twoTB := int64(2 * 1024 * 1024 * 1024 * 1024)
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("a@test.com", "vault5", "", twoTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -152,6 +162,7 @@ func TestCosts_FixedCostsIncluded(t *testing.T) {
 	oneTB := int64(1024 * 1024 * 1024 * 1024)
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("a@test.com", "vault5", "", oneTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -173,6 +184,7 @@ func TestCosts_ZeroState(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -265,6 +277,7 @@ func TestProjectedCosts(t *testing.T) {
 	oneTB := int64(1024 * 1024 * 1024 * 1024)
 	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}).
 		AddRow("a@test.com", "vault5", "", oneTB, int64(0)))
+	emptyActualBackendRows(mock)
 
 	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
 	req := httptest.NewRequest("GET", "/admin/costs", nil)
@@ -298,4 +311,33 @@ func TestDaysInCurrentMonth(t *testing.T) {
 			time.Date(tc.year, time.Month(tc.month), 15, 0, 0, 0, 0, time.UTC))
 		assert.Equal(t, tc.want, got, "month=%d year=%d", tc.month, tc.year)
 	}
+}
+
+func TestAdminCosts_ActualBackendData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	costsQueryRows(mock, sqlmock.NewRows([]string{"email", "plan", "tier", "storage_used_bytes", "egress"}))
+
+	oneTB := int64(1024 * 1024 * 1024 * 1024)
+	mock.ExpectQuery(`SELECT backend_name, COUNT`).
+		WillReturnRows(sqlmock.NewRows([]string{"backend_name", "count", "sum"}).
+			AddRow("idrive", int64(500), oneTB).
+			AddRow("geyser", int64(200), int64(2)*oneTB))
+
+	handler := HandleAdminCosts(testCostsTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/costs", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "idrive")
+	assert.Contains(t, body, "500")
+	assert.Contains(t, body, "geyser")
+	assert.Contains(t, body, "200")
+	assert.Contains(t, body, "actual-backend")
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/dashboard/templates/admin/costs.html
+++ b/internal/dashboard/templates/admin/costs.html
@@ -64,6 +64,35 @@
     {{end}}
 </div>
 
+{{if .ActualByBackend}}
+<div class="card" style="margin-bottom:1.5rem">
+    <div class="card-title" style="margin-bottom:0.75rem">Storage by Backend (Actual)</div>
+    <p class="text-muted" style="margin-bottom:0.75rem;font-size:0.85rem">Ground truth from object location tracking.</p>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Backend</th>
+                    <th style="text-align:right">Objects</th>
+                    <th style="text-align:right">Storage</th>
+                    <th style="text-align:right">TB</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .ActualByBackend}}
+                <tr>
+                    <td><code>{{.Backend}}</code></td>
+                    <td style="text-align:right">{{.ObjectCount}}</td>
+                    <td style="text-align:right">{{.StorageFmt}}</td>
+                    <td style="text-align:right">{{printf "%.2f" .StorageTB}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}
+
 <div class="card">
     <div class="card-title" style="margin-bottom:0.75rem">Tenant Margins</div>
     {{if .MarginTable}}

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -36,6 +36,8 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 044 | Waitlist: `waitlist_signups` table (email UNIQUE, source, ip, user_agent) — pre-launch landing-page email capture |
 | 045 | Admin notes: `admin_notes` table (tenant_id, admin_user_id → users, note) — internal support notes on customer accounts |
 | 046 | Admin notifications: `admin_notifications` table (type, message, tenant_id, read_at) — admin notification system with partial index on unread |
+| 047 | Abuse reports: `abuse_reports` table (reporter, tenant, bucket, key, type, description, status) — public abuse reporting + admin moderation queue |
+| 048 | Object location tracking: `object_locations` (durable backend routing), `tiering_policies` (age-based tiering config), `tenant_cost_daily` (per-tenant cost rollup); `last_accessed` column on `object_head_cache` |
 
 ## Key Tables
 
@@ -65,6 +67,10 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **metered_usage_reports** — `id (BIGSERIAL PK)`, `tenant_id`, `meter`, `period_date`, `value`, `stripe_event_id`, `reported_at`, `UNIQUE(tenant_id, meter, period_date)` — daily Stripe Billing Meter reports; the unique constraint is the no-double-billing guard and also gates once-per-month spending-cap alerts (synthetic `alert:80`/`alert:95` meters)
 - **admin_notes** — `id (BIGSERIAL PK)`, `tenant_id`, `admin_user_id → users`, `note`, `created_at` — internal support notes on customer accounts, indexed by (tenant_id, created_at DESC)
 - **admin_notifications** — `id (BIGSERIAL PK)`, `type`, `message`, `tenant_id` (nullable), `read_at` (nullable), `created_at` — admin notification system; partial index on `(created_at DESC) WHERE read_at IS NULL` for fast unread count
+- **abuse_reports** — `id (BIGSERIAL PK)`, `reporter_email`, `reporter_name`, `tenant_id`, `bucket`, `object_key`, `report_type`, `description`, `url`, `status`, `resolved_by`, `resolved_at`, `created_at` — public abuse report intake + admin moderation
+- **object_locations** — `(tenant_id, bucket, object_key) PK`, `backend_name`, `storage_class`, `size_bytes`, `stored_at`, `last_accessed` — durable object-to-backend routing; source of truth for which backend holds each object
+- **tiering_policies** — `id (BIGSERIAL PK)`, `tenant_id`, `bucket`, `min_age_days`, `target_backend`, `target_class`, `enabled`, `created_at`, `UNIQUE(tenant_id, bucket, target_backend)` — age-based tier migration config (Phase 7.3)
+- **tenant_cost_daily** — `(tenant_id, date, backend_name) PK`, `storage_bytes`, `cost_microcents` — daily per-tenant storage cost rollup (Phase 7.4)
 
 ## Connection
 

--- a/internal/database/migrations/048_object_locations.sql
+++ b/internal/database/migrations/048_object_locations.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS object_locations (
+    tenant_id    TEXT NOT NULL,
+    bucket       TEXT NOT NULL,
+    object_key   TEXT NOT NULL,
+    backend_name TEXT NOT NULL,
+    storage_class TEXT NOT NULL DEFAULT 'STANDARD',
+    size_bytes   BIGINT NOT NULL DEFAULT 0,
+    stored_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_accessed TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, bucket, object_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_object_locations_backend
+    ON object_locations(backend_name);
+
+CREATE INDEX IF NOT EXISTS idx_object_locations_age
+    ON object_locations(last_accessed, backend_name);
+
+CREATE TABLE IF NOT EXISTS tiering_policies (
+    id          BIGSERIAL PRIMARY KEY,
+    tenant_id   TEXT,
+    bucket      TEXT,
+    min_age_days INT NOT NULL DEFAULT 30,
+    target_backend TEXT NOT NULL,
+    target_class   TEXT NOT NULL DEFAULT 'GLACIER',
+    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(tenant_id, bucket, target_backend)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_cost_daily (
+    tenant_id   TEXT NOT NULL,
+    date        DATE NOT NULL,
+    backend_name TEXT NOT NULL,
+    storage_bytes BIGINT NOT NULL DEFAULT 0,
+    cost_microcents BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, date, backend_name)
+);
+
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS last_accessed
+    TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/internal/engine/CLAUDE.md
+++ b/internal/engine/CLAUDE.md
@@ -24,6 +24,17 @@ Two-tier backend lookup: `objectBackends sync.Map` (L1, in-memory hot cache) →
 
 Tables created in migration 048: `object_locations` (routing source of truth), `tiering_policies` (Phase 7.3), `tenant_cost_daily` (Phase 7.4). Also adds `last_accessed` column to `object_head_cache`.
 
+## Tiering Engine (Phase 7.3)
+
+`TieringEngine` (`tiering.go`) runs a background goroutine that periodically scans `object_locations` for objects eligible for tier migration based on `tiering_policies`. Follows the BackendMonitor Start/Stop pattern (ticker + stop chan + ctx.Done select loop).
+
+- `Start(ctx)` — background loop, default 1-hour interval. No-op if DB is nil.
+- `Stop()` — close(stop)
+- `runScan(ctx)` — loads policies from `tiering_policies`, falls back to hardcoded default (90-day→geyser/GLACIER) if no policies exist. Finds candidates via `object_locations` WHERE `last_accessed < NOW() - min_age_days`. Processes up to 100 per policy per tick.
+- `migrateObject(...)` — crash-safe sequence: Get→Put→UpdateDB→UpdateSyncMap→Delete. Never deletes source until routing update succeeds. If put fails, source is untouched (safe).
+
+Integrated into CoreEngine: `tiering` field, created in `NewEngine()`, started via `StartTiering(ctx)` (call after drivers are registered), stopped in `Shutdown()`.
+
 ## Supporting Files
 
 | File | Type | Purpose |
@@ -44,6 +55,7 @@ Tables created in migration 048: `object_locations` (routing source of truth), `
 | `failover.go` | `FailoverManager`, `BackendCircuitBreaker` | Per-backend circuit breaker (5 failures/60s → open, 30s → half-open → probe) + ordered failover execution |
 | `storage_class.go` | `ResolveStorageClass`, `BackendToStorageClass` | S3 storage class ↔ backend name mapping (STANDARD→idrive, GLACIER→geyser, etc.) |
 | `routing.go` | `LocationStore` | PostgreSQL-backed object location CRUD (RecordLocation, LookupBackend, RemoveLocation, CountByBackend, TouchLastAccessed) — nil-DB safe |
+| `tiering.go` | `TieringEngine` | Background age-based object migration between backends (1h interval, crash-safe Get→Put→UpdateDB→Delete) |
 
 ## Per-Bucket Region Routing (Phase 5.14.7)
 

--- a/internal/engine/CLAUDE.md
+++ b/internal/engine/CLAUDE.md
@@ -16,9 +16,13 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 - **Delete**: failover.Execute against recorded backend (+ primary fallback) → remove from `objectBackends` → invalidate cache
 - **List**: delegates to primary driver only
 
-## Important: objectBackends is in-memory
+## Object Location Routing (Phase 7.1-7.2)
 
-`objectBackends sync.Map` maps object keys to backend names. Lost on restart — falls through to primary driver for objects written before the restart. Phase 7 (Smart Tiering) replaces this with PostgreSQL-backed `object_locations`.
+Two-tier backend lookup: `objectBackends sync.Map` (L1, in-memory hot cache) → `LocationStore` / `object_locations` table (L2, PostgreSQL durable). On sync.Map miss, the engine queries `object_locations` and seeds the sync.Map so subsequent GETs are fast. Put records to both layers. Delete removes from both.
+
+`LocationStore` (`routing.go`) wraps `*sql.DB` for object location CRUD. All methods are nil-DB safe (degrade to no-op). `last_accessed` is updated on every LookupBackend call (fire-and-forget goroutine) for tiering age tracking.
+
+Tables created in migration 048: `object_locations` (routing source of truth), `tiering_policies` (Phase 7.3), `tenant_cost_daily` (Phase 7.4). Also adds `last_accessed` column to `object_head_cache`.
 
 ## Supporting Files
 
@@ -39,6 +43,7 @@ Core orchestration layer — connects the API layer to storage drivers. This is 
 | `sla.go` | `SLAMonitor` | SLA compliance tracking, violation detection |
 | `failover.go` | `FailoverManager`, `BackendCircuitBreaker` | Per-backend circuit breaker (5 failures/60s → open, 30s → half-open → probe) + ordered failover execution |
 | `storage_class.go` | `ResolveStorageClass`, `BackendToStorageClass` | S3 storage class ↔ backend name mapping (STANDARD→idrive, GLACIER→geyser, etc.) |
+| `routing.go` | `LocationStore` | PostgreSQL-backed object location CRUD (RecordLocation, LookupBackend, RemoveLocation, CountByBackend, TouchLastAccessed) — nil-DB safe |
 
 ## Per-Bucket Region Routing (Phase 5.14.7)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -39,6 +39,7 @@ type CoreEngine struct {
 	intelligence *intelligence.AccessTracker
 	cache        *cache.TieredCache
 	locations    *LocationStore
+	tiering      *TieringEngine
 
 	// objectBackends records which backend each object was written to.
 	// Key: "container/artifact"  Value: backend name string
@@ -83,6 +84,7 @@ func NewEngine(db *sql.DB, logger *zap.Logger, config *Config) *CoreEngine {
 	}
 
 	e.locations = NewLocationStore(db, logger)
+	e.tiering = NewTieringEngine(db, e.drivers, e.locations, &e.objectBackends, logger)
 
 	if db != nil {
 		e.intelligence = intelligence.NewAccessTracker(db, logger)
@@ -660,9 +662,20 @@ func (e *CoreEngine) GetFailoverStatus() map[string]string {
 	return e.failover.GetAllStatuses()
 }
 
+// StartTiering launches the background tiering goroutine.
+// Call after all drivers are registered.
+func (e *CoreEngine) StartTiering(ctx context.Context) {
+	if e.tiering != nil {
+		go e.tiering.Start(ctx)
+	}
+}
+
 // Shutdown gracefully shuts down the engine
 func (e *CoreEngine) Shutdown(ctx context.Context) error {
 	e.logger.Info("shutting down engine")
+	if e.tiering != nil {
+		e.tiering.Stop()
+	}
 	if e.intelligence != nil {
 		e.intelligence.Flush()
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -38,6 +38,7 @@ type CoreEngine struct {
 
 	intelligence *intelligence.AccessTracker
 	cache        *cache.TieredCache
+	locations    *LocationStore
 
 	// objectBackends records which backend each object was written to.
 	// Key: "container/artifact"  Value: backend name string
@@ -80,6 +81,8 @@ func NewEngine(db *sql.DB, logger *zap.Logger, config *Config) *CoreEngine {
 		costOptimizer: NewCostOptimizer(),
 		failover:      NewFailoverManager(logger),
 	}
+
+	e.locations = NewLocationStore(db, logger)
 
 	if db != nil {
 		e.intelligence = intelligence.NewAccessTracker(db, logger)
@@ -213,6 +216,11 @@ func (e *CoreEngine) Get(ctx context.Context, container, artifact string) (io.Re
 		if name, ok := v.(string); ok && name != "" {
 			preferredBackend = name
 		}
+	} else if e.locations != nil {
+		if name, err := e.locations.LookupBackend(ctx, tenantID, container, artifact); err == nil && name != "" {
+			preferredBackend = name
+			e.objectBackends.Store(objectKey(container, artifact), name)
+		}
 	}
 
 	// Log what intelligence would have recommended (informational only).
@@ -343,6 +351,16 @@ func (e *CoreEngine) Put(ctx context.Context, container, artifact string, data i
 
 	e.objectBackends.Store(objectKey(container, artifact), usedBackend)
 
+	if e.locations != nil {
+		resolvedClass := options.StorageClass
+		if resolvedClass == "" {
+			resolvedClass = "STANDARD"
+		}
+		go func() {
+			_ = e.locations.RecordLocation(context.Background(), tenantID, container, artifact, usedBackend, resolvedClass, sizeReader.bytesRead)
+		}()
+	}
+
 	if e.cache != nil {
 		cacheKey := fmt.Sprintf("%s/%s/%s", tenantID, container, artifact)
 		_ = e.cache.Delete(cacheKey)
@@ -380,6 +398,10 @@ func (e *CoreEngine) Delete(ctx context.Context, container, artifact string) err
 	})
 
 	e.objectBackends.Delete(key)
+
+	if e.locations != nil {
+		_ = e.locations.RemoveLocation(ctx, tenantID, container, artifact)
+	}
 
 	if e.cache != nil {
 		cacheKey := fmt.Sprintf("%s/%s/%s", tenantID, container, artifact)

--- a/internal/engine/routing.go
+++ b/internal/engine/routing.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"context"
+	"database/sql"
+
+	"go.uber.org/zap"
+)
+
+type LocationStore struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+func NewLocationStore(db *sql.DB, logger *zap.Logger) *LocationStore {
+	return &LocationStore{db: db, logger: logger}
+}
+
+func (s *LocationStore) RecordLocation(ctx context.Context, tenant, bucket, key, backend, storageClass string, sizeBytes int64) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO object_locations (tenant_id, bucket, object_key, backend_name, storage_class, size_bytes, stored_at, last_accessed)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+		ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+			backend_name  = EXCLUDED.backend_name,
+			storage_class = EXCLUDED.storage_class,
+			size_bytes    = EXCLUDED.size_bytes,
+			stored_at     = NOW()`,
+		tenant, bucket, key, backend, storageClass, sizeBytes)
+	if err != nil {
+		s.logger.Error("failed to record object location",
+			zap.Error(err),
+			zap.String("tenant", tenant),
+			zap.String("bucket", bucket),
+			zap.String("key", key))
+	}
+	return err
+}
+
+func (s *LocationStore) LookupBackend(ctx context.Context, tenant, bucket, key string) (string, error) {
+	if s.db == nil {
+		return "", nil
+	}
+	var backend string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT backend_name FROM object_locations
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		tenant, bucket, key).Scan(&backend)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		_, _ = s.db.ExecContext(context.Background(), `
+			UPDATE object_locations SET last_accessed = NOW()
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			tenant, bucket, key)
+	}()
+	return backend, nil
+}
+
+func (s *LocationStore) RemoveLocation(ctx context.Context, tenant, bucket, key string) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM object_locations
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		tenant, bucket, key)
+	return err
+}
+
+func (s *LocationStore) CountByBackend(ctx context.Context) (map[string]int64, error) {
+	if s.db == nil {
+		return map[string]int64{}, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT backend_name, COUNT(*) FROM object_locations GROUP BY backend_name`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var name string
+		var count int64
+		if err := rows.Scan(&name, &count); err != nil {
+			return nil, err
+		}
+		counts[name] = count
+	}
+	return counts, rows.Err()
+}
+
+func (s *LocationStore) TouchLastAccessed(ctx context.Context, tenant, bucket, key string) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE object_locations SET last_accessed = NOW()
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		tenant, bucket, key)
+	return err
+}

--- a/internal/engine/routing_test.go
+++ b/internal/engine/routing_test.go
@@ -1,0 +1,190 @@
+package engine
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestLocationStore_RecordAndLookup(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewLocationStore(db, zap.NewNop())
+
+	mock.ExpectExec("INSERT INTO object_locations").
+		WithArgs("tenant1", "bucket1", "key1", "idrive", "STANDARD", int64(1024)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.RecordLocation(context.Background(), "tenant1", "bucket1", "key1", "idrive", "STANDARD", 1024)
+	require.NoError(t, err)
+
+	rows := sqlmock.NewRows([]string{"backend_name"}).AddRow("idrive")
+	mock.ExpectQuery("SELECT backend_name FROM object_locations").
+		WithArgs("tenant1", "bucket1", "key1").
+		WillReturnRows(rows)
+
+	backend, err := store.LookupBackend(context.Background(), "tenant1", "bucket1", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, "idrive", backend)
+}
+
+func TestLocationStore_LookupMiss(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewLocationStore(db, zap.NewNop())
+
+	mock.ExpectQuery("SELECT backend_name FROM object_locations").
+		WithArgs("tenant1", "bucket1", "missing").
+		WillReturnRows(sqlmock.NewRows([]string{"backend_name"}))
+
+	backend, err := store.LookupBackend(context.Background(), "tenant1", "bucket1", "missing")
+	require.NoError(t, err)
+	assert.Equal(t, "", backend)
+}
+
+func TestLocationStore_Remove(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewLocationStore(db, zap.NewNop())
+
+	mock.ExpectExec("DELETE FROM object_locations").
+		WithArgs("tenant1", "bucket1", "key1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.RemoveLocation(context.Background(), "tenant1", "bucket1", "key1")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLocationStore_Upsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewLocationStore(db, zap.NewNop())
+
+	mock.ExpectExec("INSERT INTO object_locations").
+		WithArgs("tenant1", "bucket1", "key1", "idrive", "STANDARD", int64(100)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO object_locations").
+		WithArgs("tenant1", "bucket1", "key1", "geyser", "GLACIER", int64(200)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.RecordLocation(context.Background(), "tenant1", "bucket1", "key1", "idrive", "STANDARD", 100)
+	require.NoError(t, err)
+	err = store.RecordLocation(context.Background(), "tenant1", "bucket1", "key1", "geyser", "GLACIER", 200)
+	require.NoError(t, err)
+
+	rows := sqlmock.NewRows([]string{"backend_name"}).AddRow("geyser")
+	mock.ExpectQuery("SELECT backend_name FROM object_locations").
+		WithArgs("tenant1", "bucket1", "key1").
+		WillReturnRows(rows)
+
+	backend, err := store.LookupBackend(context.Background(), "tenant1", "bucket1", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, "geyser", backend)
+}
+
+func TestLocationStore_CountByBackend(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewLocationStore(db, zap.NewNop())
+
+	rows := sqlmock.NewRows([]string{"backend_name", "count"}).
+		AddRow("idrive", int64(10)).
+		AddRow("geyser", int64(5))
+	mock.ExpectQuery("SELECT backend_name, COUNT").
+		WillReturnRows(rows)
+
+	counts, err := store.CountByBackend(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), counts["idrive"])
+	assert.Equal(t, int64(5), counts["geyser"])
+	assert.Len(t, counts, 2)
+}
+
+func TestLocationStore_NilDB(t *testing.T) {
+	store := NewLocationStore(nil, zap.NewNop())
+
+	err := store.RecordLocation(context.Background(), "t", "b", "k", "idrive", "STANDARD", 100)
+	assert.NoError(t, err)
+
+	backend, err := store.LookupBackend(context.Background(), "t", "b", "k")
+	assert.NoError(t, err)
+	assert.Equal(t, "", backend)
+
+	err = store.RemoveLocation(context.Background(), "t", "b", "k")
+	assert.NoError(t, err)
+
+	counts, err := store.CountByBackend(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, counts)
+
+	err = store.TouchLastAccessed(context.Background(), "t", "b", "k")
+	assert.NoError(t, err)
+}
+
+func TestEngine_PutRecordsLocation(t *testing.T) {
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, nil)
+
+	drv := &stubDriver{name: "primary", data: make(map[string][]byte), healthy: true}
+	eng.AddDriver("primary", drv)
+	eng.SetPrimary("primary")
+
+	backend, err := eng.Put(context.Background(), "bucket", "key", strings.NewReader("data"))
+	require.NoError(t, err)
+	assert.Equal(t, "primary", backend)
+
+	v, ok := eng.objectBackends.Load(objectKey("bucket", "key"))
+	assert.True(t, ok)
+	assert.Equal(t, "primary", v.(string))
+}
+
+func TestEngine_GetFallsBackToLocationStore(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	eng := NewEngine(nil, logger, nil)
+	eng.locations = NewLocationStore(db, logger)
+
+	drv := &stubDriver{name: "geyser", data: make(map[string][]byte), healthy: true}
+	drv.data["mybucket/myobj"] = []byte("archived-data")
+	eng.AddDriver("geyser", drv)
+
+	localDrv := &stubDriver{name: "local", data: make(map[string][]byte), healthy: true}
+	eng.AddDriver("local", localDrv)
+	eng.SetPrimary("local")
+
+	rows := sqlmock.NewRows([]string{"backend_name"}).AddRow("geyser")
+	mock.ExpectQuery("SELECT backend_name FROM object_locations").
+		WithArgs("default", "mybucket", "myobj").
+		WillReturnRows(rows)
+
+	reader, err := eng.Get(context.Background(), "mybucket", "myobj")
+	require.NoError(t, err)
+	defer func() { _ = reader.Close() }()
+
+	b, _ := io.ReadAll(reader)
+	assert.Equal(t, "archived-data", string(b))
+
+	v, ok := eng.objectBackends.Load(objectKey("mybucket", "myobj"))
+	assert.True(t, ok, "should seed sync.Map after DB lookup")
+	assert.Equal(t, "geyser", v.(string))
+}

--- a/internal/engine/tiering.go
+++ b/internal/engine/tiering.go
@@ -1,0 +1,254 @@
+package engine
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type TieringEngine struct {
+	db             *sql.DB
+	drivers        map[string]Driver
+	locations      *LocationStore
+	objectBackends *sync.Map
+	logger         *zap.Logger
+	interval       time.Duration
+	stop           chan struct{}
+}
+
+func NewTieringEngine(db *sql.DB, drivers map[string]Driver, locations *LocationStore, objectBackends *sync.Map, logger *zap.Logger) *TieringEngine {
+	return &TieringEngine{
+		db:             db,
+		drivers:        drivers,
+		locations:      locations,
+		objectBackends: objectBackends,
+		logger:         logger,
+		interval:       1 * time.Hour,
+		stop:           make(chan struct{}),
+	}
+}
+
+func (t *TieringEngine) Start(ctx context.Context) {
+	if t.db == nil {
+		return
+	}
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.runScan(ctx)
+		case <-t.stop:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *TieringEngine) Stop() {
+	close(t.stop)
+}
+
+type tieringPolicy struct {
+	id            int64
+	tenantID      *string
+	bucket        *string
+	minAgeDays    int
+	targetBackend string
+	targetClass   string
+}
+
+func (t *TieringEngine) runScan(ctx context.Context) {
+	policies, err := t.loadPolicies(ctx)
+	if err != nil {
+		t.logger.Error("tiering: load policies", zap.Error(err))
+		return
+	}
+
+	if len(policies) == 0 {
+		policies = t.defaultPolicy()
+	}
+
+	var migrated, skipped, failed int
+	for _, p := range policies {
+		if _, ok := t.drivers[p.targetBackend]; !ok {
+			t.logger.Debug("tiering: target backend not registered, skipping policy",
+				zap.String("target", p.targetBackend))
+			skipped++
+			continue
+		}
+
+		candidates, err := t.findCandidates(ctx, p)
+		if err != nil {
+			t.logger.Error("tiering: find candidates", zap.Error(err), zap.Int64("policy_id", p.id))
+			failed++
+			continue
+		}
+
+		for _, c := range candidates {
+			if err := t.migrateObject(ctx, c.tenantID, c.bucket, c.objectKey, c.backendName, p.targetBackend, p.targetClass, c.sizeBytes); err != nil {
+				t.logger.Warn("tiering: migrate failed",
+					zap.String("key", c.bucket+"/"+c.objectKey),
+					zap.Error(err))
+				failed++
+			} else {
+				migrated++
+			}
+		}
+	}
+
+	if migrated > 0 || failed > 0 {
+		t.logger.Info("tiering scan complete",
+			zap.Int("migrated", migrated),
+			zap.Int("skipped", skipped),
+			zap.Int("failed", failed))
+	}
+}
+
+func (t *TieringEngine) loadPolicies(ctx context.Context) ([]tieringPolicy, error) {
+	rows, err := t.db.QueryContext(ctx, `
+		SELECT id, tenant_id, bucket, min_age_days, target_backend, target_class
+		FROM tiering_policies WHERE enabled = TRUE`)
+	if err != nil {
+		return nil, fmt.Errorf("query tiering_policies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var policies []tieringPolicy
+	for rows.Next() {
+		var p tieringPolicy
+		if err := rows.Scan(&p.id, &p.tenantID, &p.bucket, &p.minAgeDays, &p.targetBackend, &p.targetClass); err != nil {
+			return nil, fmt.Errorf("scan tiering_policies: %w", err)
+		}
+		policies = append(policies, p)
+	}
+	return policies, rows.Err()
+}
+
+func (t *TieringEngine) defaultPolicy() []tieringPolicy {
+	if _, hasGeyser := t.drivers["geyser"]; !hasGeyser {
+		return nil
+	}
+	return []tieringPolicy{{
+		id:            0,
+		minAgeDays:    90,
+		targetBackend: "geyser",
+		targetClass:   "GLACIER",
+	}}
+}
+
+type migrationCandidate struct {
+	tenantID    string
+	bucket      string
+	objectKey   string
+	backendName string
+	sizeBytes   int64
+}
+
+func (t *TieringEngine) findCandidates(ctx context.Context, p tieringPolicy) ([]migrationCandidate, error) {
+	query := `
+		SELECT tenant_id, bucket, object_key, backend_name, size_bytes
+		FROM object_locations
+		WHERE last_accessed < NOW() - INTERVAL '1 day' * $1
+		  AND backend_name != $2`
+	args := []any{p.minAgeDays, p.targetBackend}
+
+	argIdx := 3
+	if p.tenantID != nil {
+		query += fmt.Sprintf(" AND tenant_id = $%d", argIdx)
+		args = append(args, *p.tenantID)
+		argIdx++
+	}
+	if p.bucket != nil {
+		query += fmt.Sprintf(" AND bucket = $%d", argIdx)
+		args = append(args, *p.bucket)
+	}
+	query += " LIMIT 100"
+
+	rows, err := t.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var candidates []migrationCandidate
+	for rows.Next() {
+		var c migrationCandidate
+		if err := rows.Scan(&c.tenantID, &c.bucket, &c.objectKey, &c.backendName, &c.sizeBytes); err != nil {
+			return nil, fmt.Errorf("scan candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	return candidates, rows.Err()
+}
+
+func (t *TieringEngine) migrateObject(ctx context.Context, tenant, bucket, key, source, target, targetClass string, sizeBytes int64) error {
+	srcDriver, ok := t.drivers[source]
+	if !ok {
+		return fmt.Errorf("source driver %q not registered", source)
+	}
+	dstDriver, ok := t.drivers[target]
+	if !ok {
+		return fmt.Errorf("target driver %q not registered", target)
+	}
+
+	reader, err := srcDriver.Get(ctx, bucket, key)
+	if err != nil {
+		return fmt.Errorf("get from %s: %w", source, err)
+	}
+
+	putErr := dstDriver.Put(ctx, bucket, key, reader)
+	closeErr := reader.Close()
+	if putErr != nil {
+		return fmt.Errorf("put to %s: %w", target, putErr)
+	}
+	if closeErr != nil {
+		t.logger.Warn("tiering: close source reader", zap.Error(closeErr))
+	}
+
+	if err := t.locations.RecordLocation(ctx, tenant, bucket, key, target, targetClass, sizeBytes); err != nil {
+		t.logger.Error("tiering: update location failed, object exists in both backends",
+			zap.String("key", bucket+"/"+key),
+			zap.Error(err))
+		return fmt.Errorf("update location: %w", err)
+	}
+
+	t.objectBackends.Store(objectKey(bucket, key), target)
+
+	if err := srcDriver.Delete(ctx, bucket, key); err != nil {
+		t.logger.Warn("tiering: delete from source failed, object duplicated (safe)",
+			zap.String("source", source),
+			zap.String("key", bucket+"/"+key),
+			zap.Error(err))
+	}
+
+	t.logger.Info("tiering: migrated object",
+		zap.String("tenant", tenant),
+		zap.String("key", bucket+"/"+key),
+		zap.String("from", source),
+		zap.String("to", target))
+
+	return nil
+}
+
+// MigrateObject is exported for testing.
+func (t *TieringEngine) MigrateObject(ctx context.Context, tenant, bucket, key, source, target, targetClass string, sizeBytes int64) error {
+	return t.migrateObject(ctx, tenant, bucket, key, source, target, targetClass, sizeBytes)
+}
+
+// RunScan is exported for testing.
+func (t *TieringEngine) RunScan(ctx context.Context) {
+	t.runScan(ctx)
+}
+
+// SetInterval overrides the default scan interval (for testing).
+func (t *TieringEngine) SetInterval(d time.Duration) {
+	t.interval = d
+}

--- a/internal/engine/tiering_test.go
+++ b/internal/engine/tiering_test.go
@@ -1,0 +1,299 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestTieringEngine_NilDB(t *testing.T) {
+	logger := zap.NewNop()
+	te := NewTieringEngine(nil, nil, nil, &sync.Map{}, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		te.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start with nil DB should return immediately")
+	}
+}
+
+func TestTieringEngine_MigrateObject(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	locations := NewLocationStore(db, logger)
+
+	src := &stubDriver{name: "idrive", data: map[string][]byte{
+		"mybucket/photo.jpg": []byte("image-data"),
+	}, healthy: true}
+	dst := &stubDriver{name: "geyser", data: make(map[string][]byte), healthy: true}
+
+	drivers := map[string]Driver{"idrive": src, "geyser": dst}
+	var backends sync.Map
+
+	te := NewTieringEngine(db, drivers, locations, &backends, logger)
+
+	mock.ExpectExec("INSERT INTO object_locations").
+		WithArgs("tenant1", "mybucket", "photo.jpg", "geyser", "GLACIER", int64(1024)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = te.MigrateObject(context.Background(), "tenant1", "mybucket", "photo.jpg", "idrive", "geyser", "GLACIER", 1024)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("image-data"), dst.data["mybucket/photo.jpg"])
+
+	v, ok := backends.Load("mybucket/photo.jpg")
+	assert.True(t, ok)
+	assert.Equal(t, "geyser", v)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTieringEngine_SkipsWhenTargetNotRegistered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	locations := NewLocationStore(db, logger)
+
+	src := &stubDriver{name: "idrive", data: map[string][]byte{
+		"mybucket/file.txt": []byte("data"),
+	}, healthy: true}
+
+	drivers := map[string]Driver{"idrive": src}
+	var backends sync.Map
+
+	te := NewTieringEngine(db, drivers, locations, &backends, logger)
+
+	mock.ExpectQuery("SELECT id, tenant_id, bucket, min_age_days, target_backend, target_class").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "bucket", "min_age_days", "target_backend", "target_class"}).
+			AddRow(1, nil, nil, 30, "geyser", "GLACIER"))
+
+	te.RunScan(context.Background())
+
+	_, ok := backends.Load("mybucket/file.txt")
+	assert.False(t, ok, "object should not have been migrated")
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTieringEngine_ScanWithPolicy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	locations := NewLocationStore(db, logger)
+
+	src := &stubDriver{name: "idrive", data: map[string][]byte{
+		"bucket1/old-file.bin": []byte("old-data"),
+	}, healthy: true}
+	dst := &stubDriver{name: "geyser", data: make(map[string][]byte), healthy: true}
+	drivers := map[string]Driver{"idrive": src, "geyser": dst}
+	var backends sync.Map
+
+	te := NewTieringEngine(db, drivers, locations, &backends, logger)
+
+	mock.ExpectQuery("SELECT id, tenant_id, bucket, min_age_days, target_backend, target_class").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "bucket", "min_age_days", "target_backend", "target_class"}).
+			AddRow(1, nil, nil, 30, "geyser", "GLACIER"))
+
+	mock.ExpectQuery("SELECT tenant_id, bucket, object_key, backend_name, size_bytes").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "bucket", "object_key", "backend_name", "size_bytes"}).
+			AddRow("t1", "bucket1", "old-file.bin", "idrive", 512))
+
+	mock.ExpectExec("INSERT INTO object_locations").
+		WithArgs("t1", "bucket1", "old-file.bin", "geyser", "GLACIER", int64(512)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	te.RunScan(context.Background())
+
+	assert.Equal(t, []byte("old-data"), dst.data["bucket1/old-file.bin"])
+
+	v, ok := backends.Load("bucket1/old-file.bin")
+	assert.True(t, ok)
+	assert.Equal(t, "geyser", v)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTieringEngine_StopCancels(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	locations := NewLocationStore(db, logger)
+	drivers := map[string]Driver{}
+	var backends sync.Map
+
+	te := NewTieringEngine(db, drivers, locations, &backends, logger)
+	te.SetInterval(50 * time.Millisecond)
+
+	mock.ExpectQuery("SELECT id, tenant_id, bucket, min_age_days, target_backend, target_class").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "bucket", "min_age_days", "target_backend", "target_class"}))
+
+	done := make(chan struct{})
+	go func() {
+		te.Start(context.Background())
+		close(done)
+	}()
+
+	time.Sleep(80 * time.Millisecond)
+	te.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Start should have returned after Stop")
+	}
+}
+
+func TestTieringEngine_MigrateObject_SourceNotRegistered(t *testing.T) {
+	logger := zap.NewNop()
+	drivers := map[string]Driver{}
+	var backends sync.Map
+
+	te := NewTieringEngine(nil, drivers, nil, &backends, logger)
+
+	err := te.MigrateObject(context.Background(), "t1", "b", "k", "missing-src", "geyser", "GLACIER", 100)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "source driver")
+}
+
+func TestTieringEngine_MigrateObject_TargetNotRegistered(t *testing.T) {
+	logger := zap.NewNop()
+	src := &stubDriver{name: "idrive", data: map[string][]byte{
+		"b/k": []byte("x"),
+	}, healthy: true}
+	drivers := map[string]Driver{"idrive": src}
+	var backends sync.Map
+
+	te := NewTieringEngine(nil, drivers, nil, &backends, logger)
+
+	err := te.MigrateObject(context.Background(), "t1", "b", "k", "idrive", "missing-dst", "GLACIER", 100)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "target driver")
+}
+
+// trackingStubDriver records calls for assertions.
+type trackingStubDriver struct {
+	stubDriver
+	getCalls    []string
+	putCalls    []string
+	deleteCalls []string
+}
+
+func (d *trackingStubDriver) Get(ctx context.Context, container, artifact string) (io.ReadCloser, error) {
+	d.getCalls = append(d.getCalls, container+"/"+artifact)
+	return d.stubDriver.Get(ctx, container, artifact)
+}
+
+func (d *trackingStubDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...PutOption) error {
+	d.putCalls = append(d.putCalls, container+"/"+artifact)
+	return d.stubDriver.Put(ctx, container, artifact, data, opts...)
+}
+
+func (d *trackingStubDriver) Delete(ctx context.Context, container, artifact string) error {
+	d.deleteCalls = append(d.deleteCalls, container+"/"+artifact)
+	return d.stubDriver.Delete(ctx, container, artifact)
+}
+
+func TestTieringEngine_MigrateObject_CallOrder(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	locations := NewLocationStore(db, logger)
+
+	src := &trackingStubDriver{
+		stubDriver: stubDriver{name: "idrive", data: map[string][]byte{
+			"bkt/obj": []byte("payload"),
+		}, healthy: true},
+	}
+	dst := &trackingStubDriver{
+		stubDriver: stubDriver{name: "geyser", data: make(map[string][]byte), healthy: true},
+	}
+
+	drivers := map[string]Driver{"idrive": src, "geyser": dst}
+	var backends sync.Map
+
+	te := NewTieringEngine(db, drivers, locations, &backends, logger)
+
+	mock.ExpectExec("INSERT INTO object_locations").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = te.MigrateObject(context.Background(), "t1", "bkt", "obj", "idrive", "geyser", "GLACIER", 7)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"bkt/obj"}, src.getCalls)
+	assert.Equal(t, []string{"bkt/obj"}, dst.putCalls)
+	assert.Equal(t, []string{"bkt/obj"}, src.deleteCalls)
+
+	assert.Equal(t, []byte("payload"), dst.data["bkt/obj"])
+}
+
+func TestTieringEngine_MigrateObject_PutFailsNoDelete(t *testing.T) {
+	logger := zap.NewNop()
+
+	src := &trackingStubDriver{
+		stubDriver: stubDriver{name: "idrive", data: map[string][]byte{
+			"b/k": []byte("data"),
+		}, healthy: true},
+	}
+	dst := &failingPutDriver{name: "geyser"}
+
+	drivers := map[string]Driver{"idrive": src, "geyser": dst}
+	var backends sync.Map
+
+	te := NewTieringEngine(nil, drivers, nil, &backends, logger)
+
+	err := te.MigrateObject(context.Background(), "t1", "b", "k", "idrive", "geyser", "GLACIER", 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "put to geyser")
+
+	assert.Empty(t, src.deleteCalls, "should NOT delete source when put fails")
+}
+
+type failingPutDriver struct {
+	name string
+}
+
+func (d *failingPutDriver) Name() string { return d.name }
+func (d *failingPutDriver) Get(ctx context.Context, container, artifact string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+func (d *failingPutDriver) Put(ctx context.Context, container, artifact string, data io.Reader, opts ...PutOption) error {
+	return io.ErrUnexpectedEOF
+}
+func (d *failingPutDriver) Delete(ctx context.Context, container, artifact string) error {
+	return nil
+}
+func (d *failingPutDriver) List(ctx context.Context, container, prefix string) ([]string, error) {
+	return nil, nil
+}
+func (d *failingPutDriver) Exists(ctx context.Context, container, artifact string) (bool, error) {
+	return false, nil
+}
+func (d *failingPutDriver) HealthCheck(ctx context.Context) error { return nil }

--- a/internal/usage/cost_tracker.go
+++ b/internal/usage/cost_tracker.go
@@ -1,0 +1,137 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// BackendCostPerTBCents maps backend names to their per-TB storage cost in cents.
+var BackendCostPerTBCents = map[string]int64{
+	"geyser":   155,
+	"idrive":   330,
+	"hetzner":  381,
+	"onedrive": 0,
+	"gorilla":  0,
+	"local":    0,
+	"edge":     0,
+}
+
+const bytesPerTB = 1024.0 * 1024 * 1024 * 1024
+
+type CostTracker struct {
+	db     *sql.DB
+	logger *zap.Logger
+	stop   chan struct{}
+}
+
+func NewCostTracker(db *sql.DB, logger *zap.Logger) *CostTracker {
+	return &CostTracker{
+		db:     db,
+		logger: logger,
+		stop:   make(chan struct{}),
+	}
+}
+
+func (c *CostTracker) Start(ctx context.Context) {
+	if c.db == nil {
+		return
+	}
+
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	// Run once on start.
+	c.aggregate(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			c.aggregate(ctx)
+		case <-c.stop:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *CostTracker) Stop() {
+	close(c.stop)
+}
+
+func (c *CostTracker) aggregate(ctx context.Context) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT tenant_id, backend_name, SUM(size_bytes)
+		FROM object_locations
+		GROUP BY tenant_id, backend_name`)
+	if err != nil {
+		c.logger.Error("cost_tracker: query object_locations", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var upserted int
+	for rows.Next() {
+		var tenantID, backendName string
+		var storageBytes int64
+		if err := rows.Scan(&tenantID, &backendName, &storageBytes); err != nil {
+			c.logger.Error("cost_tracker: scan row", zap.Error(err))
+			continue
+		}
+
+		costMicrocents := computeCostMicrocents(backendName, storageBytes)
+
+		_, err := c.db.ExecContext(ctx, `
+			INSERT INTO tenant_cost_daily (tenant_id, date, backend_name, storage_bytes, cost_microcents)
+			VALUES ($1, CURRENT_DATE, $2, $3, $4)
+			ON CONFLICT (tenant_id, date, backend_name) DO UPDATE SET
+				storage_bytes = EXCLUDED.storage_bytes,
+				cost_microcents = EXCLUDED.cost_microcents`,
+			tenantID, backendName, storageBytes, costMicrocents)
+		if err != nil {
+			c.logger.Error("cost_tracker: upsert tenant_cost_daily", zap.Error(err),
+				zap.String("tenant", tenantID),
+				zap.String("backend", backendName))
+			continue
+		}
+		upserted++
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("cost_tracker: rows iteration", zap.Error(err))
+	}
+
+	if upserted > 0 {
+		c.logger.Info("cost_tracker: aggregation complete", zap.Int("upserted", upserted))
+	}
+}
+
+func computeCostMicrocents(backend string, storageBytes int64) int64 {
+	perTBCents, ok := BackendCostPerTBCents[backend]
+	if !ok || perTBCents == 0 {
+		return 0
+	}
+	storageTB := float64(storageBytes) / bytesPerTB
+	centsF := storageTB * float64(perTBCents)
+	return int64(centsF * 10000)
+}
+
+// Aggregate is exported for testing.
+func (c *CostTracker) Aggregate(ctx context.Context) {
+	c.aggregate(ctx)
+}
+
+// ComputeCostMicrocents is exported for use by other packages.
+func ComputeCostMicrocents(backend string, storageBytes int64) int64 {
+	return computeCostMicrocents(backend, storageBytes)
+}
+
+// FormatMicrocents formats microcents as a dollar string.
+func FormatMicrocents(mc int64) string {
+	cents := float64(mc) / 10000
+	return fmt.Sprintf("$%.4f", cents/100)
+}

--- a/internal/usage/cost_tracker_test.go
+++ b/internal/usage/cost_tracker_test.go
@@ -1,0 +1,85 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCostTracker_NilDB(t *testing.T) {
+	logger := zap.NewNop()
+	ct := NewCostTracker(nil, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		ct.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start with nil DB should return immediately")
+	}
+}
+
+func TestCostTracker_Aggregate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	logger := zap.NewNop()
+	ct := NewCostTracker(db, logger)
+
+	mock.ExpectQuery("SELECT tenant_id, backend_name, SUM\\(size_bytes\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "backend_name", "sum"}).
+			AddRow("t1", "idrive", int64(1099511627776)). // 1 TB
+			AddRow("t1", "geyser", int64(2199023255552)). // 2 TB
+			AddRow("t2", "idrive", int64(549755813888)))  // 0.5 TB
+
+	mock.ExpectExec("INSERT INTO tenant_cost_daily").
+		WithArgs("t1", "idrive", int64(1099511627776), int64(3300000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec("INSERT INTO tenant_cost_daily").
+		WithArgs("t1", "geyser", int64(2199023255552), int64(3100000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec("INSERT INTO tenant_cost_daily").
+		WithArgs("t2", "idrive", int64(549755813888), int64(1650000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	ct.Aggregate(context.Background())
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestComputeCostMicrocents(t *testing.T) {
+	tests := []struct {
+		name     string
+		backend  string
+		bytes    int64
+		expected int64
+	}{
+		{"1 TB on idrive", "idrive", 1099511627776, 3300000},
+		{"1 TB on geyser", "geyser", 1099511627776, 1550000},
+		{"0 bytes", "idrive", 0, 0},
+		{"free backend", "local", 1099511627776, 0},
+		{"unknown backend", "unknown", 1099511627776, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeCostMicrocents(tt.backend, tt.bytes)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Phase 7.1-7.2**: PostgreSQL-backed `object_locations` table for durable object-to-backend routing. Two-tier lookup: `sync.Map` (L1) → `LocationStore` (L2). PUT records to both, GET seeds sync.Map on miss, DELETE removes from both. Migration 048 creates `object_locations`, `tiering_policies`, and `tenant_cost_daily` tables.
- **Phase 7.3**: Background `TieringEngine` scans `object_locations` hourly for objects older than policy thresholds and migrates them between backends. Crash-safe sequence: Get→Put→UpdateDB→UpdateSyncMap→Delete. Falls back to 90-day→geyser/GLACIER default if no policies configured.
- **Phase 7.4**: `CostTracker` aggregates per-tenant, per-backend storage costs into `tenant_cost_daily` (hourly, idempotent upsert). Admin costs dashboard gains a ground-truth "Storage by Backend (Actual)" card from `object_locations`.

## Test plan

- [x] `TestTieringEngine_NilDB` — Start returns immediately, no panic
- [x] `TestTieringEngine_MigrateObject` — Get from source, Put to target, location updated, source deleted
- [x] `TestTieringEngine_SkipsWhenTargetNotRegistered` — unregistered backend skipped
- [x] `TestTieringEngine_ScanWithPolicy` — policy + old object → migrated
- [x] `TestTieringEngine_StopCancels` — goroutine exits on Stop
- [x] `TestTieringEngine_MigrateObject_PutFailsNoDelete` — source NOT deleted on put failure
- [x] `TestCostTracker_NilDB` / `TestCostTracker_Aggregate` / `TestComputeCostMicrocents`
- [x] `TestAdminCosts_ActualBackendData` — object_locations query populates template
- [x] All existing admin_costs_test.go tests updated and passing
- [x] Full `go test ./internal/... -short -race` green, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)