### PR TITLE
feat(engine): customer tier controls [Phase 7.5]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -158,6 +158,8 @@ JSON REST layer at `/api/v1/manage/` with JWT auth and per-tenant rate limiting.
 
 **Cursor pagination**: queries `LIMIT N+1`; if N+1 results → `has_more=true`, returns first N, `next_cursor` = last item's name/key.
 
+**Bucket tier preference** (Phase 7.5): `PUT /api/v1/manage/buckets/{name}/tier` (`handleMgmtSetBucketTier`) — sets the bucket's `tier_preference` column. Request body: `{"tier": "auto|performance|standard|archive"}`. Returns 400 for invalid tier, 404 for missing bucket, 200 with `tier_preference` in the response envelope.
+
 ## CDN Access Analytics (Phase 5.11.12)
 
 `CDNAnalyticsTracker` in `cdn_analytics.go` buffers CDN access events in memory and flushes them to `cdn_access_log` every 5 seconds (or at 100 events). Follows the same pattern as `BandwidthTracker`. Initialized in `NewServer()`, nil-safe throughout.

--- a/internal/api/management_routes.go
+++ b/internal/api/management_routes.go
@@ -31,6 +31,7 @@ func (s *Server) registerManagementRoutes() {
 		r.Delete("/buckets/{name}", s.handleMgmtDeleteBucket)
 
 		r.Get("/buckets/{name}/objects", s.handleMgmtListObjects)
+		r.Put("/buckets/{name}/tier", s.handleMgmtSetBucketTier)
 
 		r.Get("/keys", s.handleMgmtListKeys)
 		r.Post("/keys", s.handleMgmtCreateKey)
@@ -713,6 +714,68 @@ func (s *Server) handleMgmtCancelDeletion(w http.ResponseWriter, r *http.Request
 		"cancelled":  true,
 		"message":    "Account deletion has been cancelled.",
 		"request_id": getRequestID(w),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- Bucket Tier ---
+
+var validTierPreferences = map[string]bool{
+	"auto":        true,
+	"performance": true,
+	"standard":    true,
+	"archive":     true,
+}
+
+func (s *Server) handleMgmtSetBucketTier(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := r.Context().Value(tenantIDKey).(string)
+	if tenantID == "" {
+		writeManagementError(w, ErrTypeAuthentication, "missing_tenant", "tenant not found in token", "")
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+
+	if s.db == nil {
+		writeManagementError(w, ErrTypeAPI, "no_database", "database unavailable", "")
+		return
+	}
+
+	var req struct {
+		Tier string `json:"tier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_json", "request body must be valid JSON", "")
+		return
+	}
+
+	if !validTierPreferences[req.Tier] {
+		writeManagementError(w, ErrTypeInvalidRequest, "invalid_tier",
+			"tier must be one of: auto, performance, standard, archive", "tier")
+		return
+	}
+
+	result, err := s.db.ExecContext(r.Context(),
+		`UPDATE buckets SET tier_preference = $1, updated_at = NOW()
+		 WHERE tenant_id = $2 AND name = $3`,
+		req.Tier, tenantID, name)
+	if err != nil {
+		s.logger.Error("set bucket tier", zap.Error(err))
+		writeManagementError(w, ErrTypeAPI, "db_error", "failed to update tier preference", "")
+		return
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		writeManagementError(w, ErrTypeNotFound, "bucket_not_found", "bucket not found", "name")
+		return
+	}
+
+	resp := map[string]interface{}{
+		"object":          "bucket",
+		"name":            name,
+		"tier_preference": req.Tier,
+		"request_id":      getRequestID(w),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/management_test.go
+++ b/internal/api/management_test.go
@@ -88,6 +88,7 @@ func newMgmtTestServer(t *testing.T) (*Server, sqlmock.Sqlmock, func()) {
 		r.Get("/buckets/{name}", s.handleMgmtGetBucket)
 		r.Delete("/buckets/{name}", s.handleMgmtDeleteBucket)
 		r.Get("/buckets/{name}/objects", s.handleMgmtListObjects)
+		r.Put("/buckets/{name}/tier", s.handleMgmtSetBucketTier)
 		r.Get("/keys", s.handleMgmtListKeys)
 		r.Post("/keys", s.handleMgmtCreateKey)
 		r.Delete("/keys/{id}", s.handleMgmtDeleteKey)
@@ -510,6 +511,71 @@ func TestManagementKeys(t *testing.T) {
 	var delResp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &delResp))
 	assert.Equal(t, true, delResp["deleted"])
+}
+
+func TestMgmtSetBucketTier(t *testing.T) {
+	s, mock, cleanup := newMgmtTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`UPDATE buckets SET tier_preference`).
+		WithArgs("archive", "test-tenant", "my-bucket").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := bytes.NewBufferString(`{"tier":"archive"}`)
+	req := httptest.NewRequest("PUT", "/api/v1/manage/buckets/my-bucket/tier", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "bucket", resp["object"])
+	assert.Equal(t, "my-bucket", resp["name"])
+	assert.Equal(t, "archive", resp["tier_preference"])
+	assert.NotEmpty(t, resp["request_id"])
+}
+
+func TestMgmtSetBucketTier_InvalidTier(t *testing.T) {
+	s, _, cleanup := newMgmtTestServer(t)
+	defer cleanup()
+
+	body := bytes.NewBufferString(`{"tier":"bogus"}`)
+	req := httptest.NewRequest("PUT", "/api/v1/manage/buckets/my-bucket/tier", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	errBody := resp["error"].(map[string]interface{})
+	assert.Equal(t, "invalid_request_error", errBody["type"])
+	assert.Equal(t, "tier", errBody["param"])
+}
+
+func TestMgmtSetBucketTier_NotFound(t *testing.T) {
+	s, mock, cleanup := newMgmtTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`UPDATE buckets SET tier_preference`).
+		WithArgs("performance", "test-tenant", "ghost-bucket").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	body := bytes.NewBufferString(`{"tier":"performance"}`)
+	req := httptest.NewRequest("PUT", "/api/v1/manage/buckets/ghost-bucket/tier", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	errBody := resp["error"].(map[string]interface{})
+	assert.Equal(t, "not_found_error", errBody["type"])
 }
 
 func mkdirAll(path string) error {

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -588,6 +588,9 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 
 	storageClass := r.Header.Get("x-amz-storage-class")
+	if storageClass == "" {
+		storageClass = bucketTierStorageClass(r.Context(), a.db, t.ID, bucket)
+	}
 	putOpts := []engine.PutOption{engine.WithContentLength(size)}
 	if storageClass != "" {
 		putOpts = append(putOpts, engine.WithStorageClass(storageClass))
@@ -872,6 +875,26 @@ func bucketRegionDriver(ctx context.Context, db *sql.DB, eng engine.Engine, tena
 		return driverName
 	}
 	return ""
+}
+
+var tierPreferenceToStorageClass = map[string]string{
+	"performance": "STANDARD",
+	"standard":    "STANDARD",
+	"archive":     "GLACIER",
+}
+
+func bucketTierStorageClass(ctx context.Context, db *sql.DB, tenantID, bucket string) string {
+	if db == nil {
+		return ""
+	}
+	var pref string
+	err := db.QueryRowContext(ctx,
+		"SELECT tier_preference FROM buckets WHERE tenant_id = $1 AND name = $2",
+		tenantID, bucket).Scan(&pref)
+	if err != nil || pref == "auto" || pref == "" {
+		return ""
+	}
+	return tierPreferenceToStorageClass[pref]
 }
 
 func isBucketSSEEnabled(ctx context.Context, db *sql.DB, tenantID, bucket string) bool {

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -29,10 +29,10 @@ Shared helpers in `context.go`: `sessionData(sd, page)` builds the base template
 ## Bucket Settings (`bucket_settings.go`)
 
 Two handlers:
-- `HandleBucketSettings(tmpl, db, logger)` — GET renders bucket settings page: visibility toggle (private/public-read), CDN URL card with tabbed code examples, cache TTL, CORS origins, **region** (read-only card showing region + display name + EU badge). Checks `CanEnablePublicRead(tier)` for archive-tier restriction. Region data: `Region`, `RegionDisplay`, `IsEURegion`.
-- `HandleUpdateBucketSettings(tmpl, db, logger)` — POST updates visibility, CORS origins, and cache_max_age_secs in `buckets` table. Validates visibility enum, clamps cache to 0–86400, enforces archive-tier restriction via `auth.CanEnablePublicRead()`. Uses flash messages for feedback. Region is NOT updatable.
+- `HandleBucketSettings(tmpl, db, logger)` — GET renders bucket settings page: visibility toggle (private/public-read), CDN URL card with tabbed code examples, cache TTL, CORS origins, **region** (read-only card showing region + display name + EU badge), **storage tier** preference (auto/performance/standard/archive radio buttons). Checks `CanEnablePublicRead(tier)` for archive-tier restriction. Region data: `Region`, `RegionDisplay`, `IsEURegion`. Reads `tier_preference` from `buckets` and passes `TierPreference` to template.
+- `HandleUpdateBucketSettings(tmpl, db, logger)` — POST updates visibility, CORS origins, cache_max_age_secs, and `tier_preference` in `buckets` table. Validates visibility enum, clamps cache to 0–86400, enforces archive-tier restriction via `auth.CanEnablePublicRead()`. Validates `tier_preference` is one of auto/performance/standard/archive (invalid values fall back to auto). Uses flash messages for feedback. Region is NOT updatable.
 
-Template: `templates/customer/bucket_settings.html`. Routes: `GET/POST /dashboard/buckets/{name}/settings`.
+Template: `templates/customer/bucket_settings.html` — includes a "Storage Tier" card with 4 radio buttons (Auto, Performance, Standard, Archive) between Region and Visibility cards. Routes: `GET/POST /dashboard/buckets/{name}/settings`.
 
 ## API Key Management (`apikeys.go`)
 

--- a/internal/dashboard/handlers/bucket_settings.go
+++ b/internal/dashboard/handlers/bucket_settings.go
@@ -42,12 +42,13 @@ func HandleBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logge
 		cacheMaxAge := 3600
 		slug := ""
 		region := "us-west-1"
+		tierPref := "auto"
 
 		if db != nil {
 			_ = db.QueryRowContext(r.Context(),
-				`SELECT visibility, cors_origins, cache_max_age_secs, region
+				`SELECT visibility, cors_origins, cache_max_age_secs, region, tier_preference
 				 FROM buckets WHERE tenant_id = $1 AND name = $2`,
-				sd.TenantID, bucketName).Scan(&vis, &corsOrigins, &cacheMaxAge, &region)
+				sd.TenantID, bucketName).Scan(&vis, &corsOrigins, &cacheMaxAge, &region, &tierPref)
 
 			_ = db.QueryRowContext(r.Context(),
 				`SELECT COALESCE(slug, '') FROM tenants WHERE id = $1`,
@@ -70,6 +71,7 @@ func HandleBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap.Logge
 		data["CacheMaxAge"] = cacheMaxAge
 		data["Slug"] = slug
 		data["Region"] = region
+		data["TierPreference"] = tierPref
 		data["RegionDisplay"] = drivers.RegionDisplayName(region)
 		data["IsEURegion"] = drivers.IsEURegion(region)
 
@@ -111,6 +113,14 @@ func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			_ = tmpl.ExecuteTemplate(w, "base", data)
 			return
+		}
+
+		tierPref := r.FormValue("tier_preference")
+		if tierPref == "" {
+			tierPref = "auto"
+		}
+		if tierPref != "auto" && tierPref != "performance" && tierPref != "standard" && tierPref != "archive" {
+			tierPref = "auto"
 		}
 
 		corsOrigins := strings.TrimSpace(r.FormValue("cors_origins"))
@@ -155,9 +165,9 @@ func HandleUpdateBucketSettings(tmpl *template.Template, db *sql.DB, logger *zap
 
 		result, err := db.ExecContext(r.Context(),
 			`UPDATE buckets
-			 SET visibility = $1, cors_origins = $2, cache_max_age_secs = $3, updated_at = NOW()
-			 WHERE tenant_id = $4 AND name = $5`,
-			visibility, corsOrigins, cacheMaxAge, sd.TenantID, bucketName)
+			 SET visibility = $1, cors_origins = $2, cache_max_age_secs = $3, tier_preference = $4, updated_at = NOW()
+			 WHERE tenant_id = $5 AND name = $6`,
+			visibility, corsOrigins, cacheMaxAge, tierPref, sd.TenantID, bucketName)
 		if err != nil {
 			logger.Error("update bucket settings", zap.Error(err))
 			middleware.SetFlash(w, "error", "Failed to save settings.")

--- a/internal/dashboard/handlers/bucket_settings_test.go
+++ b/internal/dashboard/handlers/bucket_settings_test.go
@@ -31,6 +31,7 @@ func testBucketSettingsTemplate(t *testing.T) *template.Template {
 			`{{if .ArchiveReason}}<span class="reason">{{.ArchiveReason}}</span>{{end}}` +
 			`<span class="cors">{{.CORSOrigins}}</span>` +
 			`<span class="cache">{{.CacheMaxAge}}</span>` +
+			`<span class="tier">{{.TierPreference}}</span>` +
 			`{{if .FlashSuccess}}<span class="flash-ok">{{.FlashSuccess}}</span>{{end}}` +
 			`{{if .FlashError}}<span class="flash-err">{{.FlashError}}</span>{{end}}` +
 			`{{end}}`))
@@ -412,6 +413,131 @@ func TestHandleUpdateBucketSettings_CacheMaxAgeClamped(t *testing.T) {
 	err = db.QueryRow(`SELECT cache_max_age_secs FROM buckets WHERE tenant_id = 'test-dash-s7' AND name = 'clamp-bucket'`).Scan(&cache)
 	require.NoError(t, err)
 	assert.Equal(t, 86400, cache)
+}
+
+func TestHandleBucketSettings_TierPreference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-tp1', 'Tier Co', 'tier@test.com', 'VK-tp1', 'SK-tp1', 'tier-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility, tier_preference)
+		VALUES ('test-dash-tp1', 'archive-bucket', 'private', 'archive')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleBucketSettings(tmpl, db, zap.NewNop())
+
+	req := injectSessionWithTenant(
+		httptest.NewRequest("GET", "/dashboard/buckets/archive-bucket/settings", nil),
+		"test-dash-tp1")
+	req = injectBucketRoute(req, "archive-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="tier">archive</span>`)
+}
+
+func TestHandleUpdateBucketSettings_TierPreference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-tp2', 'Update Tier Co', 'utier@test.com', 'VK-tp2', 'SK-tp2', 'utier-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-tp2', 1099511627776, 0, 'starter')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility, tier_preference)
+		VALUES ('test-dash-tp2', 'tier-bucket', 'private', 'auto')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{
+		"visibility":      {"private"},
+		"tier_preference": {"performance"},
+	}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/tier-bucket/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-tp2")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "tier-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	var pref string
+	err = db.QueryRow(`SELECT tier_preference FROM buckets WHERE tenant_id = 'test-dash-tp2' AND name = 'tier-bucket'`).Scan(&pref)
+	require.NoError(t, err)
+	assert.Equal(t, "performance", pref)
+}
+
+func TestHandleUpdateBucketSettings_InvalidTier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires database")
+	}
+	db := testDashDB(t)
+	defer func() { _ = db.Close() }()
+	cleanupDashBucketData(t, db)
+	defer cleanupDashBucketData(t, db)
+
+	_, err := db.Exec(`INSERT INTO tenants (id, name, email, access_key, secret_key, slug)
+		VALUES ('test-dash-tp3', 'Bad Tier Co', 'btier@test.com', 'VK-tp3', 'SK-tp3', 'btier-co')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO tenant_quotas (tenant_id, storage_limit_bytes, storage_used_bytes, tier)
+		VALUES ('test-dash-tp3', 1099511627776, 0, 'starter')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO buckets (tenant_id, name, visibility, tier_preference)
+		VALUES ('test-dash-tp3', 'bad-tier-bucket', 'private', 'archive')
+		ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	tmpl := testBucketSettingsTemplate(t)
+	handler := HandleUpdateBucketSettings(tmpl, db, zap.NewNop())
+
+	form := url.Values{
+		"visibility":      {"private"},
+		"tier_preference": {"bogus"},
+	}
+	req := injectSessionWithTenant(
+		httptest.NewRequest("POST", "/dashboard/buckets/bad-tier-bucket/settings",
+			strings.NewReader(form.Encode())),
+		"test-dash-tp3")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = injectBucketRoute(req, "bad-tier-bucket")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+
+	var pref string
+	err = db.QueryRow(`SELECT tier_preference FROM buckets WHERE tenant_id = 'test-dash-tp3' AND name = 'bad-tier-bucket'`).Scan(&pref)
+	require.NoError(t, err)
+	assert.Equal(t, "auto", pref, "invalid tier should fall back to auto")
 }
 
 func TestHandleUpdateBucketSettings_BucketNotFound(t *testing.T) {

--- a/internal/dashboard/templates/customer/bucket_settings.html
+++ b/internal/dashboard/templates/customer/bucket_settings.html
@@ -33,6 +33,35 @@
     <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
     <div class="card">
+        <div class="card-title">Storage Tier</div>
+        <div class="toggle-group">
+            <label class="toggle-label">
+                <input type="radio" name="tier_preference" value="auto" {{if eq .TierPreference "auto"}}checked{{end}}>
+                <span class="toggle-option{{if eq .TierPreference "auto"}} toggle-active{{end}}">Auto</span>
+            </label>
+            <label class="toggle-label">
+                <input type="radio" name="tier_preference" value="performance" {{if eq .TierPreference "performance"}}checked{{end}}>
+                <span class="toggle-option{{if eq .TierPreference "performance"}} toggle-active{{end}}">Performance</span>
+            </label>
+            <label class="toggle-label">
+                <input type="radio" name="tier_preference" value="standard" {{if eq .TierPreference "standard"}}checked{{end}}>
+                <span class="toggle-option{{if eq .TierPreference "standard"}} toggle-active{{end}}">Standard</span>
+            </label>
+            <label class="toggle-label">
+                <input type="radio" name="tier_preference" value="archive" {{if eq .TierPreference "archive"}}checked{{end}}>
+                <span class="toggle-option{{if eq .TierPreference "archive"}} toggle-active{{end}}">Archive</span>
+            </label>
+        </div>
+        <div class="text-muted" style="margin-top: 0.5rem; font-size: 0.85rem;">
+            {{if eq .TierPreference "auto"}}Objects are automatically tiered based on access patterns.
+            {{else if eq .TierPreference "performance"}}Low-latency storage for frequently accessed data.
+            {{else if eq .TierPreference "standard"}}Balanced cost and performance.
+            {{else if eq .TierPreference "archive"}}Lowest cost for rarely accessed data.
+            {{end}}
+        </div>
+    </div>
+
+    <div class="card">
         <div class="card-title">Visibility</div>
         {{if .ArchiveRestricted}}
         <div class="alert alert-error" style="margin-top: 0.5rem;">

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -38,6 +38,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 046 | Admin notifications: `admin_notifications` table (type, message, tenant_id, read_at) — admin notification system with partial index on unread |
 | 047 | Abuse reports: `abuse_reports` table (reporter, tenant, bucket, key, type, description, status) — public abuse reporting + admin moderation queue |
 | 048 | Object location tracking: `object_locations` (durable backend routing), `tiering_policies` (age-based tiering config), `tenant_cost_daily` (per-tenant cost rollup); `last_accessed` column on `object_head_cache` |
+| 049 | Bucket tier preference: `tier_preference TEXT NOT NULL DEFAULT 'auto'` on `buckets` — pins a bucket to a specific storage tier (auto/performance/standard/archive) |
 
 ## Key Tables
 
@@ -48,7 +49,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **dashboard_sessions** — `id (VARCHAR 64)`, `user_id → users`, `tenant_id → tenants`, `email`, `role`, `ip_address`, `user_agent`, `created_at`, `last_active_at`, `expires_at`
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
-- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`, `cdn_force_download`
+- **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`, `cdn_force_download`, `tier_preference` (auto/performance/standard/archive, default auto)
 - **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`); `content_disposition` TEXT holds the stored Content-Disposition response header
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`

--- a/internal/database/migrations/049_bucket_tier_preference.sql
+++ b/internal/database/migrations/049_bucket_tier_preference.sql
@@ -1,0 +1,1 @@
+ALTER TABLE buckets ADD COLUMN IF NOT EXISTS tier_preference TEXT NOT NULL DEFAULT 'auto';

--- a/internal/engine/CLAUDE.md
+++ b/internal/engine/CLAUDE.md
@@ -30,7 +30,7 @@ Tables created in migration 048: `object_locations` (routing source of truth), `
 
 - `Start(ctx)` — background loop, default 1-hour interval. No-op if DB is nil.
 - `Stop()` — close(stop)
-- `runScan(ctx)` — loads policies from `tiering_policies`, falls back to hardcoded default (90-day→geyser/GLACIER) if no policies exist. Finds candidates via `object_locations` WHERE `last_accessed < NOW() - min_age_days`. Processes up to 100 per policy per tick.
+- `runScan(ctx)` — loads policies from `tiering_policies`, falls back to hardcoded default (90-day→geyser/GLACIER) if no policies exist. Finds candidates via `object_locations` WHERE `last_accessed < NOW() - min_age_days`. Excludes objects in buckets with a non-auto `tier_preference` (`AND NOT EXISTS (SELECT 1 FROM buckets WHERE ... tier_preference != 'auto')`) so pinned buckets are never age-migrated. Processes up to 100 per policy per tick.
 - `migrateObject(...)` — crash-safe sequence: Get→Put→UpdateDB→UpdateSyncMap→Delete. Never deletes source until routing update succeeds. If put fails, source is untouched (safe).
 
 Integrated into CoreEngine: `tiering` field, created in `NewEngine()`, started via `StartTiering(ctx)` (call after drivers are registered), stopped in `Shutdown()`.
@@ -56,6 +56,10 @@ Integrated into CoreEngine: `tiering` field, created in `NewEngine()`, started v
 | `storage_class.go` | `ResolveStorageClass`, `BackendToStorageClass` | S3 storage class ↔ backend name mapping (STANDARD→idrive, GLACIER→geyser, etc.) |
 | `routing.go` | `LocationStore` | PostgreSQL-backed object location CRUD (RecordLocation, LookupBackend, RemoveLocation, CountByBackend, TouchLastAccessed) — nil-DB safe |
 | `tiering.go` | `TieringEngine` | Background age-based object migration between backends (1h interval, crash-safe Get→Put→UpdateDB→Delete) |
+
+## Bucket Tier Preference (Phase 7.5)
+
+`bucketTierStorageClass()` in `s3_engine_adapter.go` queries `tier_preference` from `buckets` and maps it to an S3 storage class: performance→STANDARD, standard→STANDARD, archive→GLACIER. Used in HandlePut when no explicit `x-amz-storage-class` header is present — does not override explicit headers. `auto` returns empty string (normal routing applies).
 
 ## Per-Bucket Region Routing (Phase 5.14.7)
 

--- a/internal/engine/tiering.go
+++ b/internal/engine/tiering.go
@@ -157,7 +157,13 @@ func (t *TieringEngine) findCandidates(ctx context.Context, p tieringPolicy) ([]
 		SELECT tenant_id, bucket, object_key, backend_name, size_bytes
 		FROM object_locations
 		WHERE last_accessed < NOW() - INTERVAL '1 day' * $1
-		  AND backend_name != $2`
+		  AND backend_name != $2
+		  AND NOT EXISTS (
+		      SELECT 1 FROM buckets
+		      WHERE buckets.tenant_id = object_locations.tenant_id
+		        AND buckets.name = object_locations.bucket
+		        AND buckets.tier_preference != 'auto'
+		  )`
 	args := []any{p.minAgeDays, p.targetBackend}
 
 	argIdx := 3


### PR DESCRIPTION
## Summary
- **Migration 049**: adds `tier_preference` column (auto/performance/standard/archive) to `buckets` table
- **Dashboard**: Storage Tier radio button card on bucket settings page — GET reads preference from DB, POST validates and persists it
- **Management API**: `PUT /api/v1/manage/buckets/{name}/tier` endpoint with Stripe-style JSON responses (400 invalid tier, 404 missing bucket)
- **PUT routing**: `bucketTierStorageClass()` maps tier preference to storage class (performance/standard→STANDARD, archive→GLACIER) when no explicit `x-amz-storage-class` header is present
- **Tiering engine**: `findCandidates` excludes buckets with non-auto tier_preference from age-based migration
- **6 new tests**: 3 dashboard (GET renders, POST updates, invalid→auto) + 3 management API (200/400/404)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short -race ./...` passes (all packages)
- [x] `golangci-lint run` — 0 issues
- [x] Management API tests verify 200/400/404 responses with sqlmock
- [x] Dashboard tests verify tier_preference read, write, and invalid-value fallback
- [ ] CI build-and-test workflow