### PR TITLE
feat(engine): chunking migration + dedup-aware upload pipeline [Phase 8.3-8.4]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -7,7 +7,8 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **server.go** — Server struct, router setup, middleware chain
 - **s3.go** — Request parsing, auth, routing to operation handlers
 - **s3_errors.go** — Error codes, messages, and response writing
-- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine
+- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects
+- **s3_chunking_test.go** — Integration tests for chunked upload, dedup, delete, and GCI operations
 - **s3_buckets.go** — CreateBucket (with region), DeleteBucket, ListBuckets, GetBucketLocation, HeadBucket
 - **s3_versioning.go** — Bucket versioning enable/suspend
 - **s3_lock.go** — Object Lock, retention, legal hold

--- a/internal/api/s3.go
+++ b/internal/api/s3.go
@@ -559,6 +559,7 @@ func (s *Server) handleS3Request(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetObject(w http.ResponseWriter, r *http.Request, req *S3Request) {
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
 	adapter.sseService = s.sseService
+	adapter.gci = s.gci
 
 	s.logger.Debug("S3 GET translating to engine",
 		zap.String("s3.bucket", req.Bucket),
@@ -679,6 +680,7 @@ func (s *Server) handlePutObject(w http.ResponseWriter, r *http.Request, req *S3
 
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
 	adapter.sseService = s.sseService
+	adapter.gci = s.gci
 
 	s.logger.Debug("S3 PUT translating to engine",
 		zap.String("s3.bucket", req.Bucket),
@@ -697,6 +699,7 @@ func (s *Server) handleDeleteObject(w http.ResponseWriter, r *http.Request, req 
 		return
 	}
 	adapter := NewS3ToEngine(s.engine, s.db, s.logger)
+	adapter.gci = s.gci
 	adapter.HandleDelete(w, r, req.Bucket, req.Object)
 }
 

--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -1,0 +1,423 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/crypto"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+)
+
+func setupChunkingFixture(t *testing.T) *adapterTestFixture {
+	t.Helper()
+	f := setupAdapterFixture(t)
+
+	f.adapter.gci = crypto.NewGlobalContentIndex(f.db)
+	// Use a low threshold (1 KB) so tests don't need 64 MB of data.
+	f.adapter.chunkingThreshold = 1024
+
+	t.Cleanup(func() {
+		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1::text::uuid", f.tenantID)
+		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1::text::uuid", f.tenantID)
+		_, _ = f.db.Exec("DELETE FROM global_content_index WHERE plaintext_hash LIKE 'test_%' OR plaintext_hash IN (SELECT plaintext_hash FROM tenant_chunk_refs WHERE tenant_id = $1::text::uuid)", f.tenantID)
+	})
+
+	return f
+}
+
+// generateTestData creates deterministic test data of the given size.
+func generateTestData(size int) []byte {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	return data
+}
+
+func TestHandlePut_ChunkedUpload(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024) // 8 KB — above 1 KB threshold
+	req := httptest.NewRequest("PUT", "/test-bucket/large-object.bin", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "large-object.bin")
+
+	require.Equal(t, http.StatusOK, w.Code, "PUT should succeed")
+	assert.NotEmpty(t, w.Header().Get("ETag"), "should have an ETag")
+
+	// Verify is_chunked = TRUE in object_head_cache
+	var isChunked bool
+	err := f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "large-object.bin").Scan(&isChunked)
+	require.NoError(t, err)
+	assert.True(t, isChunked, "object should be marked as chunked")
+
+	// Verify chunks exist in global_content_index
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+
+	var chunkCount int
+	err = f.db.QueryRow(`
+		SELECT COUNT(*) FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "large-object.bin").Scan(&chunkCount)
+	require.NoError(t, err)
+	assert.Greater(t, chunkCount, 0, "should have chunk references")
+
+	// Verify object_metadata was saved
+	var totalSize int64
+	var savedChunkCount int
+	err = f.db.QueryRow(`
+		SELECT total_size, chunk_count FROM object_metadata
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "large-object.bin").Scan(&totalSize, &savedChunkCount)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), totalSize)
+	assert.Equal(t, chunkCount, savedChunkCount)
+}
+
+func TestHandlePut_ChunkedDedup(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+
+	// First upload
+	req1 := httptest.NewRequest("PUT", "/test-bucket/dedup-obj-1.bin", bytes.NewReader(content))
+	req1.ContentLength = int64(len(content))
+	ctx1 := tenant.WithTenant(req1.Context(), f.tenant)
+	req1 = req1.WithContext(ctx1)
+	w1 := httptest.NewRecorder()
+	f.adapter.HandlePut(w1, req1, "test-bucket", "dedup-obj-1.bin")
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	// Get chunk hashes from first upload
+	tenantUUID, _ := uuid.Parse(f.tenantID)
+	var firstChunkCount int
+	err := f.db.QueryRow(`
+		SELECT COUNT(*) FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "dedup-obj-1.bin").Scan(&firstChunkCount)
+	require.NoError(t, err)
+
+	// Second upload with same content under a different key
+	req2 := httptest.NewRequest("PUT", "/test-bucket/dedup-obj-2.bin", bytes.NewReader(content))
+	req2.ContentLength = int64(len(content))
+	ctx2 := tenant.WithTenant(req2.Context(), f.tenant)
+	req2 = req2.WithContext(ctx2)
+	w2 := httptest.NewRecorder()
+	f.adapter.HandlePut(w2, req2, "test-bucket", "dedup-obj-2.bin")
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	// Verify ref_counts are 2 for all chunks (same content → same hashes)
+	rows, err := f.db.Query(`
+		SELECT gci.ref_count FROM global_content_index gci
+		INNER JOIN tenant_chunk_refs tcr ON tcr.plaintext_hash = gci.plaintext_hash
+		WHERE tcr.tenant_id = $1 AND tcr.bucket_name = $2 AND tcr.object_key = $3`,
+		tenantUUID, "test-bucket", "dedup-obj-1.bin")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var refCount int
+		require.NoError(t, rows.Scan(&refCount))
+		assert.Equal(t, 2, refCount, "each chunk should have ref_count=2 after dedup")
+	}
+	require.NoError(t, rows.Err())
+
+	// Verify ETags match (same content)
+	assert.Equal(t, w1.Header().Get("ETag"), w2.Header().Get("ETag"))
+}
+
+func TestHandlePut_SmallObjectSkipsChunking(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := []byte("small object under threshold")
+	req := httptest.NewRequest("PUT", "/test-bucket/small.txt", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	req.Header.Set("Content-Type", "text/plain")
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "small.txt")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var isChunked bool
+	err := f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "small.txt").Scan(&isChunked)
+	require.NoError(t, err)
+	assert.False(t, isChunked, "small object should NOT be chunked")
+}
+
+func TestHandlePut_EncryptedSkipsChunking(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024) // above threshold
+	req := httptest.NewRequest("PUT", "/test-bucket/encrypted-large.bin", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+
+	// Set SSE-C headers so the object is encrypted
+	key := generateSSECKey(t)
+	setSSECHeaders(t, req, key)
+
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "encrypted-large.bin")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var isChunked bool
+	err := f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "encrypted-large.bin").Scan(&isChunked)
+	require.NoError(t, err)
+	assert.False(t, isChunked, "encrypted object should NOT be chunked")
+}
+
+func TestHandleDelete_ChunkedObject(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+	putReq := httptest.NewRequest("PUT", "/test-bucket/to-delete.bin", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	ctx := tenant.WithTenant(putReq.Context(), f.tenant)
+	putReq = putReq.WithContext(ctx)
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "to-delete.bin")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	// Verify it's chunked
+	var isChunked bool
+	require.NoError(t, f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "to-delete.bin").Scan(&isChunked))
+	require.True(t, isChunked)
+
+	// Delete the chunked object
+	delReq := httptest.NewRequest("DELETE", "/test-bucket/to-delete.bin", nil)
+	ctx = tenant.WithTenant(delReq.Context(), f.tenant)
+	delReq = delReq.WithContext(ctx)
+	dw := httptest.NewRecorder()
+	f.adapter.HandleDelete(dw, delReq, "test-bucket", "to-delete.bin")
+
+	assert.Equal(t, http.StatusNoContent, dw.Code)
+
+	// Verify object_head_cache is deleted
+	var count int
+	err := f.db.QueryRow(`
+		SELECT COUNT(*) FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "to-delete.bin").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "object_head_cache should be cleared")
+
+	// Verify tenant_chunk_refs are deleted
+	tenantUUID, _ := uuid.Parse(f.tenantID)
+	err = f.db.QueryRow(`
+		SELECT COUNT(*) FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "to-delete.bin").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "tenant_chunk_refs should be cleared")
+
+	// Verify object_metadata is deleted
+	err = f.db.QueryRow(`
+		SELECT COUNT(*) FROM object_metadata
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "to-delete.bin").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "object_metadata should be cleared")
+
+	// Chunks should be marked_for_deletion (ref_count = 0), but still exist
+	err = f.db.QueryRow(`
+		SELECT COUNT(*) FROM global_content_index
+		WHERE marked_for_deletion = TRUE`).Scan(&count)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0, "chunks should be marked for deletion, not removed")
+}
+
+func TestHandleDelete_ChunkedDedup_PartialRefCount(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+
+	// Upload same content as two different keys
+	for _, key := range []string{"shared-1.bin", "shared-2.bin"} {
+		req := httptest.NewRequest("PUT", "/test-bucket/"+key, bytes.NewReader(content))
+		req.ContentLength = int64(len(content))
+		ctx := tenant.WithTenant(req.Context(), f.tenant)
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+		f.adapter.HandlePut(w, req, "test-bucket", key)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Delete only the first key
+	delReq := httptest.NewRequest("DELETE", "/test-bucket/shared-1.bin", nil)
+	ctx := tenant.WithTenant(delReq.Context(), f.tenant)
+	delReq = delReq.WithContext(ctx)
+	dw := httptest.NewRecorder()
+	f.adapter.HandleDelete(dw, delReq, "test-bucket", "shared-1.bin")
+	assert.Equal(t, http.StatusNoContent, dw.Code)
+
+	// Verify ref_counts are now 1 (not 0) because shared-2.bin still references them
+	tenantUUID, _ := uuid.Parse(f.tenantID)
+	rows, err := f.db.Query(`
+		SELECT gci.ref_count, gci.marked_for_deletion FROM global_content_index gci
+		INNER JOIN tenant_chunk_refs tcr ON tcr.plaintext_hash = gci.plaintext_hash
+		WHERE tcr.tenant_id = $1 AND tcr.bucket_name = $2 AND tcr.object_key = $3`,
+		tenantUUID, "test-bucket", "shared-2.bin")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var refCount int
+		var marked bool
+		require.NoError(t, rows.Scan(&refCount, &marked))
+		assert.Equal(t, 1, refCount, "ref_count should be 1 after deleting one of two references")
+		assert.False(t, marked, "chunk should NOT be marked for deletion while ref_count > 0")
+	}
+	require.NoError(t, rows.Err())
+}
+
+func TestBackendRegion_ChunkStorageKey(t *testing.T) {
+	hash := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	storageKey := "_chunks/" + hash
+	assert.Equal(t, "_chunks/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", storageKey)
+	assert.True(t, len(storageKey) > 0)
+	assert.Equal(t, "_chunks/", storageKey[:8])
+}
+
+func TestHandlePut_ChunkedUpload_NoGCI(t *testing.T) {
+	f := setupAdapterFixture(t)
+
+	// GCI is nil — large objects should use normal path
+	content := generateTestData(8 * 1024)
+	f.adapter.chunkingThreshold = 1024
+
+	req := httptest.NewRequest("PUT", "/test-bucket/no-gci-large.bin", bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	ctx := tenant.WithTenant(req.Context(), f.tenant)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", "no-gci-large.bin")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var isChunked bool
+	err := f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "no-gci-large.bin").Scan(&isChunked)
+	require.NoError(t, err)
+	assert.False(t, isChunked, "without GCI, object should NOT be chunked")
+}
+
+func TestGCI_IntegrationWithMigration(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	gci := crypto.NewGlobalContentIndex(f.db)
+	ctx := context.Background()
+
+	hash := "migration_test_hash_456789012345678901234567890123456789012345"
+	entry := &crypto.GCIEntry{
+		PlaintextHash: hash,
+		BackendID:     "local",
+		StorageKey:    "_chunks/" + hash,
+		SizeBytes:     4096,
+		RefCount:      1,
+	}
+
+	// Insert
+	require.NoError(t, gci.InsertChunk(ctx, entry))
+
+	// Lookup
+	result, err := gci.LookupChunk(ctx, hash)
+	require.NoError(t, err)
+	assert.True(t, result.Exists)
+	assert.Equal(t, "local", result.Entry.BackendID)
+
+	// Increment + decrement
+	require.NoError(t, gci.IncrementRef(ctx, hash))
+	newCount, err := gci.DecrementRef(ctx, hash)
+	require.NoError(t, err)
+	assert.Equal(t, 1, newCount)
+
+	// Decrement to 0
+	newCount, err = gci.DecrementRef(ctx, hash)
+	require.NoError(t, err)
+	assert.Equal(t, 0, newCount)
+
+	// Verify marked for deletion
+	var marked bool
+	require.NoError(t, f.db.QueryRow(
+		"SELECT marked_for_deletion FROM global_content_index WHERE plaintext_hash = $1",
+		hash).Scan(&marked))
+	assert.True(t, marked)
+
+	// Tenant chunk ref + object metadata
+	tenantUUID := uuid.New()
+	require.NoError(t, gci.AddTenantChunkRef(ctx, &crypto.TenantChunkRef{
+		TenantID:             tenantUUID,
+		BucketName:           "test-bucket",
+		ObjectKey:            "test-key",
+		ChunkIndex:           0,
+		ChunkOffset:          0,
+		PlaintextHash:        hash,
+		EncryptionKeyVersion: 1,
+	}))
+
+	contentType := "application/octet-stream"
+	physSize := int64(4096)
+	dedupRatio := float32(1.0)
+	require.NoError(t, gci.SaveObjectMetadata(ctx, &crypto.ObjectMeta{
+		TenantID:     tenantUUID,
+		BucketName:   "test-bucket",
+		ObjectKey:    "test-key",
+		TotalSize:    4096,
+		ChunkCount:   1,
+		ContentType:  &contentType,
+		LogicalSize:  4096,
+		PhysicalSize: &physSize,
+		DedupRatio:   &dedupRatio,
+	}))
+
+	meta, err := gci.GetObjectMetadata(ctx, tenantUUID, "test-bucket", "test-key")
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, int64(4096), meta.TotalSize)
+
+	// Dedup stats
+	stats, err := gci.GetTenantDedupStats(ctx, tenantUUID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4096), stats.BytesLogical)
+
+	// Cleanup
+	t.Cleanup(func() {
+		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1", tenantUUID)
+		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1", tenantUUID)
+		_, _ = f.db.Exec("DELETE FROM global_content_index WHERE plaintext_hash = $1", hash)
+	})
+}

--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/rand"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/crypto"
@@ -13,22 +15,45 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	_ "github.com/lib/pq"
 )
 
 func setupChunkingFixture(t *testing.T) *adapterTestFixture {
 	t.Helper()
-	f := setupAdapterFixture(t)
 
+	// Chunking requires UUID tenant IDs (GCI uses uuid.UUID).
+	// Override the text-based tenant ID from setupAdapterFixture with a real UUID.
+	f := setupAdapterFixture(t)
+	tenantUUID := uuid.New()
+	f.tenantID = tenantUUID.String()
+	f.tenant = &tenant.Tenant{
+		ID:        tenantUUID.String(),
+		Namespace: "tenant/" + tenantUUID.String() + "/",
+	}
+
+	// Re-create tenant row with UUID ID
+	_, err := f.db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, f.tenantID, "Chunking Test", "chunking@test.local", "AK-"+f.tenantID[:8], "SK-"+f.tenantID[:8])
+	require.NoError(t, err)
+
+	// Create the namespaced container directory
+	container := f.tenant.NamespaceContainer("test-bucket")
+	require.NoError(t, os.MkdirAll(filepath.Join(f.tempDir, container), 0755))
+
+	f.adapter = NewS3ToEngine(f.eng, f.db, zap.NewNop())
 	f.adapter.gci = crypto.NewGlobalContentIndex(f.db)
-	// Use a low threshold (1 KB) so tests don't need 64 MB of data.
 	f.adapter.chunkingThreshold = 1024
 
 	t.Cleanup(func() {
-		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1::text::uuid", f.tenantID)
-		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1::text::uuid", f.tenantID)
-		_, _ = f.db.Exec("DELETE FROM global_content_index WHERE plaintext_hash LIKE 'test_%' OR plaintext_hash IN (SELECT plaintext_hash FROM tenant_chunk_refs WHERE tenant_id = $1::text::uuid)", f.tenantID)
+		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1", tenantUUID)
+		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1", tenantUUID)
+		_, _ = f.db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", f.tenantID)
+		_, _ = f.db.Exec("DELETE FROM tenants WHERE id = $1", f.tenantID)
 	})
 
 	return f

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"strconv"
@@ -18,16 +19,19 @@ import (
 	"github.com/FairForge/vaultaire/internal/crypto"
 	"github.com/FairForge/vaultaire/internal/engine"
 	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
 // S3ToEngine adapts S3 requests to engine operations.
 type S3ToEngine struct {
-	engine     engine.Engine
-	db         *sql.DB
-	logger     *zap.Logger
-	notifySvc  *NotificationDispatcher
-	sseService *crypto.SSEService
+	engine            engine.Engine
+	db                *sql.DB
+	logger            *zap.Logger
+	notifySvc         *NotificationDispatcher
+	sseService        *crypto.SSEService
+	gci               *crypto.GlobalContentIndex
+	chunkingThreshold int64 // minimum object size for chunking (default 64 MB)
 }
 
 // NewS3ToEngine creates a new adapter
@@ -587,6 +591,25 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 	}
 
+	// Chunked upload path: objects above the threshold that are NOT encrypted
+	// are split into content-defined chunks and deduplicated via the GCI.
+	// Chunked objects skip the normal engine.Put — each chunk is stored
+	// individually. GET reassembly is Phase 8.5.
+	chunkThreshold := a.chunkingThreshold
+	if chunkThreshold <= 0 {
+		chunkThreshold = 64 * 1024 * 1024 // 64 MB default
+	}
+	if a.gci != nil && metadataSize > chunkThreshold && encryptionAlgorithm == "" {
+		if tenantUUID, parseErr := uuid.Parse(t.ID); parseErr == nil {
+			chunkErr := a.handleChunkedPut(r, w, t, tenantUUID, bucket, artifact, container, metadataSize, hashingBody, hasher)
+			if chunkErr == nil {
+				return
+			}
+			a.logger.Warn("chunked upload failed, falling through to normal path",
+				zap.Error(chunkErr))
+		}
+	}
+
 	storageClass := r.Header.Get("x-amz-storage-class")
 	if storageClass == "" {
 		storageClass = bucketTierStorageClass(r.Context(), a.db, t.ID, bucket)
@@ -659,8 +682,8 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	if a.db != nil {
 		_, dbErr := a.db.ExecContext(r.Context(), `
 			INSERT INTO object_head_cache
-				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, content_disposition, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, content_disposition, is_chunked, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, FALSE, NOW())
 			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
 				size_bytes            = EXCLUDED.size_bytes,
 				etag                  = EXCLUDED.etag,
@@ -669,6 +692,7 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 				metadata              = EXCLUDED.metadata,
 				encryption_algorithm  = EXCLUDED.encryption_algorithm,
 				content_disposition   = EXCLUDED.content_disposition,
+				is_chunked            = EXCLUDED.is_chunked,
 				updated_at            = NOW()
 		`, t.ID, bucket, artifact, metadataSize, etag, contentType, backendName, metaJSON, encryptionAlgorithm, contentDisposition)
 		if dbErr != nil {
@@ -734,6 +758,193 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	emitEvent(r.Context(), a.db, a.logger, "object.created", t.ID, map[string]interface{}{
 		"bucket": bucket, "key": object, "size": size, "etag": etag,
 	})
+}
+
+// handleChunkedPut splits a large object into content-defined chunks,
+// deduplicates via the Global Content Index, and stores each unique chunk
+// individually. Returns nil on success (response already written) or an
+// error to signal fallback to the normal path.
+func (a *S3ToEngine) handleChunkedPut(
+	r *http.Request, w http.ResponseWriter,
+	t *tenant.Tenant, tenantUUID uuid.UUID,
+	bucket, artifact, container string,
+	metadataSize int64,
+	hashingBody io.Reader,
+	hasher hash.Hash,
+) error {
+	ctx := r.Context()
+
+	plaintext, err := io.ReadAll(hashingBody)
+	if err != nil {
+		return fmt.Errorf("read body for chunking: %w", err)
+	}
+
+	chunker, err := crypto.DefaultFastCDCChunker()
+	if err != nil {
+		return fmt.Errorf("create chunker: %w", err)
+	}
+
+	chunks, err := chunker.ChunkBytes(plaintext)
+	if err != nil {
+		return fmt.Errorf("chunk bytes: %w", err)
+	}
+
+	hashes := make([]string, len(chunks))
+	for i, c := range chunks {
+		hashes[i] = c.Hash
+	}
+
+	lookups, err := a.gci.LookupChunks(ctx, hashes)
+	if err != nil {
+		return fmt.Errorf("lookup chunks: %w", err)
+	}
+
+	var physicalSize int64
+	backendName := "chunked"
+
+	for _, chunk := range chunks {
+		result := lookups[chunk.Hash]
+		storageKey := "_chunks/" + chunk.Hash
+
+		if result.IsNewChunk {
+			chunkOpts := []engine.PutOption{engine.WithContentLength(int64(chunk.Size))}
+			bn, putErr := a.engine.Put(ctx, container, storageKey, bytes.NewReader(chunk.Data), chunkOpts...)
+			if putErr != nil {
+				return fmt.Errorf("store chunk %s: %w", chunk.Hash[:16], putErr)
+			}
+			if backendName == "chunked" {
+				backendName = bn
+			}
+
+			if insertErr := a.gci.InsertChunk(ctx, &crypto.GCIEntry{
+				PlaintextHash: chunk.Hash,
+				BackendID:     bn,
+				StorageKey:    storageKey,
+				SizeBytes:     int64(chunk.Size),
+				RefCount:      1,
+			}); insertErr != nil {
+				return fmt.Errorf("insert chunk index %s: %w", chunk.Hash[:16], insertErr)
+			}
+			physicalSize += int64(chunk.Size)
+		} else {
+			if incErr := a.gci.IncrementRef(ctx, chunk.Hash); incErr != nil {
+				return fmt.Errorf("increment ref %s: %w", chunk.Hash[:16], incErr)
+			}
+		}
+
+		if refErr := a.gci.AddTenantChunkRef(ctx, &crypto.TenantChunkRef{
+			TenantID:             tenantUUID,
+			BucketName:           bucket,
+			ObjectKey:            artifact,
+			ChunkIndex:           chunk.Index,
+			ChunkOffset:          chunk.Offset,
+			PlaintextHash:        chunk.Hash,
+			EncryptionKeyVersion: 1,
+		}); refErr != nil {
+			return fmt.Errorf("add tenant chunk ref: %w", refErr)
+		}
+	}
+
+	if physicalSize == 0 {
+		physicalSize = metadataSize
+	}
+	dedupRatio := float32(1.0)
+	if physicalSize > 0 {
+		dedupRatio = float32(metadataSize) / float32(physicalSize)
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	if metaErr := a.gci.SaveObjectMetadata(ctx, &crypto.ObjectMeta{
+		TenantID:     tenantUUID,
+		BucketName:   bucket,
+		ObjectKey:    artifact,
+		TotalSize:    metadataSize,
+		ChunkCount:   len(chunks),
+		ContentType:  &contentType,
+		LogicalSize:  metadataSize,
+		PhysicalSize: &physicalSize,
+		DedupRatio:   &dedupRatio,
+	}); metaErr != nil {
+		return fmt.Errorf("save object metadata: %w", metaErr)
+	}
+
+	etag := fmt.Sprintf("%x", hasher.Sum(nil))
+
+	contentDisposition := sanitizeContentDisposition(r.Header.Get("Content-Disposition"))
+	userMeta := extractS3Metadata(r)
+	_ = validateMetadata(userMeta)
+	metaJSON, _ := json.Marshal(userMeta)
+
+	if a.db != nil {
+		_, _ = a.db.ExecContext(ctx, `
+			INSERT INTO object_head_cache
+				(tenant_id, bucket, object_key, size_bytes, etag, content_type, backend_name, metadata, encryption_algorithm, content_disposition, is_chunked, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '', $9, TRUE, NOW())
+			ON CONFLICT (tenant_id, bucket, object_key) DO UPDATE SET
+				size_bytes            = EXCLUDED.size_bytes,
+				etag                  = EXCLUDED.etag,
+				content_type          = EXCLUDED.content_type,
+				backend_name          = EXCLUDED.backend_name,
+				metadata              = EXCLUDED.metadata,
+				encryption_algorithm  = EXCLUDED.encryption_algorithm,
+				content_disposition   = EXCLUDED.content_disposition,
+				is_chunked            = EXCLUDED.is_chunked,
+				updated_at            = NOW()
+		`, t.ID, bucket, artifact, metadataSize, etag, contentType, backendName, metaJSON, contentDisposition)
+	}
+
+	versionID := ""
+	vStatus := getBucketVersioningStatus(ctx, a.db, t.ID, bucket)
+	if a.db != nil && (vStatus == "Enabled" || vStatus == "Suspended") {
+		if vStatus == "Enabled" {
+			versionID = generateVersionID()
+		} else {
+			versionID = "null"
+		}
+		_, _ = a.db.ExecContext(ctx, `
+			UPDATE object_versions SET is_latest = FALSE
+			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3 AND is_latest = TRUE`,
+			t.ID, bucket, artifact)
+		_, _ = a.db.ExecContext(ctx, `
+			INSERT INTO object_versions
+				(tenant_id, bucket, object_key, version_id, size_bytes, etag, content_type, is_latest, is_delete_marker, backend_name)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, FALSE, $8)
+			ON CONFLICT (tenant_id, bucket, object_key, version_id) DO UPDATE SET
+				size_bytes = EXCLUDED.size_bytes, etag = EXCLUDED.etag,
+				content_type = EXCLUDED.content_type, is_latest = TRUE,
+				is_delete_marker = FALSE, backend_name = EXCLUDED.backend_name`,
+			t.ID, bucket, artifact, versionID, metadataSize, etag, contentType, backendName)
+	}
+
+	applyObjectLockOnPut(ctx, a.db, t.ID, bucket, artifact, r)
+
+	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, etag))
+	w.Header().Set("x-amz-request-id", generateRequestID())
+	if versionID != "" {
+		w.Header().Set("x-amz-version-id", versionID)
+	}
+	w.WriteHeader(http.StatusOK)
+
+	a.logger.Info("chunked artifact stored",
+		zap.String("tenant_id", t.ID),
+		zap.String("s3.bucket", bucket),
+		zap.String("s3.object", artifact),
+		zap.String("backend", backendName),
+		zap.String("etag", etag),
+		zap.Int("chunks", len(chunks)),
+		zap.Float32("dedup_ratio", dedupRatio),
+		zap.Int64("size", metadataSize))
+
+	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:Put", artifact, metadataSize, etag)
+	emitEvent(ctx, a.db, a.logger, "object.created", t.ID, map[string]interface{}{
+		"bucket": bucket, "key": artifact, "size": metadataSize, "etag": etag, "chunked": true,
+	})
+
+	return nil
 }
 
 // HandleDelete processes S3 DELETE requests
@@ -824,18 +1035,41 @@ func (a *S3ToEngine) HandleDelete(w http.ResponseWriter, r *http.Request, bucket
 		return
 	}
 
-	if err := a.engine.Delete(r.Context(), container, object); err != nil {
-		if strings.Contains(err.Error(), "no such file or directory") ||
-			strings.Contains(err.Error(), "not found") {
-			w.WriteHeader(http.StatusNoContent)
+	// Chunked objects: decrement chunk ref counts via GCI instead of
+	// deleting from the backend. Actual chunk data stays until GC (Phase 8.7).
+	var isChunked bool
+	if a.db != nil {
+		_ = a.db.QueryRowContext(r.Context(),
+			`SELECT is_chunked FROM object_head_cache WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+			t.ID, bucket, object).Scan(&isChunked)
+	}
+
+	if isChunked && a.gci != nil {
+		if tenantUUID, parseErr := uuid.Parse(t.ID); parseErr == nil {
+			if delErr := a.gci.DeleteObjectChunks(r.Context(), tenantUUID, bucket, object); delErr != nil {
+				a.logger.Error("chunked delete failed",
+					zap.Error(delErr),
+					zap.String("tenant_id", t.ID),
+					zap.String("bucket", bucket),
+					zap.String("object", object))
+				WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+				return
+			}
+		}
+	} else {
+		if err := a.engine.Delete(r.Context(), container, object); err != nil {
+			if strings.Contains(err.Error(), "no such file or directory") ||
+				strings.Contains(err.Error(), "not found") {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			a.logger.Error("delete failed",
+				zap.String("container", container),
+				zap.String("artifact", object),
+				zap.Error(err))
+			WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
 			return
 		}
-		a.logger.Error("delete failed",
-			zap.String("container", container),
-			zap.String("artifact", object),
-			zap.Error(err))
-		WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
-		return
 	}
 
 	if a.db != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,6 +74,7 @@ type Server struct {
 	mfaService       *auth.MFAService
 	mfaPendingStore  *dashboard.MFAPendingStore
 	sseService       *crypto.SSEService
+	gci              *crypto.GlobalContentIndex
 	cdnRateLimiter   *RateLimiter
 	cdnAnalytics     *CDNAnalyticsTracker
 	accessLogTracker *S3AccessLogTracker
@@ -181,6 +182,11 @@ func NewServer(cfg *config.Config, logger *zap.Logger, eng *engine.CoreEngine, q
 			s.sseService = sseSvc
 			logger.Info("SSE-S3 encryption service initialized (ML-KEM-768+AES-256-GCM)")
 		}
+	}
+
+	if s.db != nil {
+		s.gci = crypto.NewGlobalContentIndex(s.db)
+		logger.Info("global content index initialized (chunking + dedup)")
 	}
 
 	s.auditLogger = auth.NewAuditLogger()

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -34,6 +34,31 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 - `postquantum.go` — cloudflare/circl (pipeline encryption, existing)
 - `sse_s3.go` — Go stdlib crypto/mlkem (SSE-S3, new)
 
+## Chunking + Dedup Architecture (Phase 8.3-8.4)
+
+**FastCDC chunking** splits large objects (>64 MB, unencrypted) into content-defined chunks. The **Global Content Index** (GCI) deduplicates chunks across all tenants — identical content is stored once.
+
+- **chunker.go** — FastCDC chunker (1 MB min / 4 MB avg / 16 MB max) using `restic/chunker`. `ChunkBytes()` for sync, `Chunk()` for streaming. SHA-256 per chunk.
+- **gci.go** — `GlobalContentIndex`: DB-backed dedup index with 100K-entry in-memory cache. Batch lookups (`LookupChunks`), ref counting (`IncrementRef`/`DecrementRef`), tenant chunk manifests (`AddTenantChunkRef`), object metadata (`SaveObjectMetadata`), transactional delete (`DeleteObjectChunks`).
+
+**PUT flow** (s3_engine_adapter.go `handleChunkedPut`):
+1. Gate: `gci != nil && size > threshold && no encryption`
+2. Parse tenant UUID (skip chunking if non-UUID tenant)
+3. `ReadAll` through MD5 hasher → `ChunkBytes` → batch `LookupChunks`
+4. For each chunk: if new → `engine.Put("_chunks/{sha256}")` + `InsertChunk`; if existing → `IncrementRef`
+5. `AddTenantChunkRef` per chunk, `SaveObjectMetadata`, `object_head_cache` with `is_chunked=TRUE`
+
+**DELETE flow** (s3_engine_adapter.go `HandleDelete`):
+1. Query `is_chunked` from `object_head_cache`
+2. If chunked → `gci.DeleteObjectChunks` (transactional: deletes refs, decrements counts, deletes object_metadata)
+3. Chunk data stays until GC (Phase 8.7) — `marked_for_deletion=TRUE` when `ref_count=0`
+
+**GET flow**: not yet wired — chunked objects are not retrievable until Phase 8.5 (download pipeline).
+
+**Constraints**: chunking is mutually exclusive with SSE-S3/SSE-C in this phase. Convergent encryption (Phase 10) will enable per-chunk encryption + dedup.
+
+**Tables**: `global_content_index`, `tenant_chunk_refs`, `object_metadata` (migration 051). `object_head_cache.is_chunked` flag.
+
 ## SSE-C Architecture (Phase 5.14.8)
 
 **Stateless** customer-provided key encryption. No DB, no key management — the customer sends a raw 256-bit AES key with each PUT/GET/HEAD request.

--- a/internal/database/CLAUDE.md
+++ b/internal/database/CLAUDE.md
@@ -39,6 +39,7 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 | 047 | Abuse reports: `abuse_reports` table (reporter, tenant, bucket, key, type, description, status) — public abuse reporting + admin moderation queue |
 | 048 | Object location tracking: `object_locations` (durable backend routing), `tiering_policies` (age-based tiering config), `tenant_cost_daily` (per-tenant cost rollup); `last_accessed` column on `object_head_cache` |
 | 049 | Bucket tier preference: `tier_preference TEXT NOT NULL DEFAULT 'auto'` on `buckets` — pins a bucket to a specific storage tier (auto/performance/standard/archive) |
+| 051 | Chunking + dedup: `global_content_index` (dedup hash→backend), `tenant_chunk_refs` (per-tenant chunk manifest), `object_metadata` (pipeline metadata); PL/pgSQL functions `increment_chunk_ref`, `decrement_chunk_ref`, `get_tenant_dedup_ratio`; `is_chunked BOOLEAN` on `object_head_cache` |
 
 ## Key Tables
 
@@ -50,7 +51,10 @@ All migrations are in `migrations/` and are idempotent (`CREATE IF NOT EXISTS`, 
 - **subscriptions** — Stripe subscription state tracking
 - **bandwidth_usage_daily** — per-tenant daily ingress/egress/requests (unique on tenant_id + date)
 - **buckets** — `(tenant_id, name) PK`, `visibility` (private/public-read), `cors_origins`, `cache_max_age_secs`, `bandwidth_budget_bytes`, `versioning_status`, `object_lock_enabled`, `default_retention_mode`, `default_retention_days`, `mfa_delete_enabled`, `logging_enabled`, `logging_target_bucket`, `logging_prefix`, `inventory_enabled`, `inventory_schedule`, `inventory_target_bucket`, `inventory_prefix`, `inventory_format`, `cdn_force_download`, `tier_preference` (auto/performance/standard/archive, default auto)
-- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`); `content_disposition` TEXT holds the stored Content-Disposition response header
+- **object_head_cache** — HEAD request cache (size, ETag, content-type, backend_name stored on PUT); `tags` JSONB holds per-object S3 tags (separate from `metadata`); `content_disposition` TEXT holds the stored Content-Disposition response header; `is_chunked` BOOLEAN (default FALSE) flags objects stored via content-defined chunking
+- **global_content_index** — `plaintext_hash (VARCHAR(64) PK)`, `backend_id`, `storage_key`, `size_bytes`, `compressed_size`, `compression_algo`, `ref_count` (default 1), `first_seen_at`, `last_accessed_at`, `marked_for_deletion` (default FALSE), `marked_at` — global dedup hash-to-backend mapping; partial index on `marked_for_deletion` for GC
+- **tenant_chunk_refs** — `id (UUID PK)`, `tenant_id (UUID)`, `bucket_name`, `object_key`, `chunk_index`, `chunk_offset`, `plaintext_hash` → `global_content_index`, `encryption_key_version`, `ciphertext_hash`, `created_at`; UNIQUE(tenant_id, bucket_name, object_key, chunk_index) — per-tenant chunk manifest
+- **object_metadata** — `id (UUID PK)`, `tenant_id (UUID)`, `bucket_name`, `object_key`, `total_size`, `chunk_count`, `content_hash`, `content_type`, `logical_size`, `physical_size`, `dedup_ratio`, `pipeline_config (JSONB)`, `created_at`, `updated_at`; UNIQUE(tenant_id, bucket_name, object_key) — pipeline metadata per chunked object
 - **user_mfa** — `user_id (PK)`, `secret`, `enabled`, `backup_codes` (JSON), `created_at`, `updated_at` — TOTP 2FA settings
 - **mfa_audit_log** — `id (SERIAL)`, `user_id`, `action`, `success`, `ip_address`, `user_agent`, `created_at`
 - **object_versions** — `(tenant_id, bucket, object_key, version_id) PK`, `size_bytes`, `etag`, `content_type`, `is_latest`, `is_delete_marker`, `backend_name`, `created_at`

--- a/internal/database/migrations/051_chunking_dedup.sql
+++ b/internal/database/migrations/051_chunking_dedup.sql
@@ -1,0 +1,115 @@
+-- Phase 8.3: Global Content Index tables for content-defined chunking + dedup
+
+-- 1. Global Content Index — the dedup index
+CREATE TABLE IF NOT EXISTS global_content_index (
+    plaintext_hash VARCHAR(64) PRIMARY KEY,
+    backend_id VARCHAR(255) NOT NULL,
+    storage_key VARCHAR(512) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    compressed_size BIGINT,
+    compression_algo VARCHAR(32),
+    ref_count INTEGER NOT NULL DEFAULT 1,
+    first_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_accessed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    marked_for_deletion BOOLEAN NOT NULL DEFAULT FALSE,
+    marked_at TIMESTAMP WITH TIME ZONE
+);
+
+-- 2. Tenant chunk references — per-tenant chunk manifest
+CREATE TABLE IF NOT EXISTS tenant_chunk_refs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    bucket_name VARCHAR(255) NOT NULL,
+    object_key VARCHAR(1024) NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    chunk_offset BIGINT NOT NULL,
+    plaintext_hash VARCHAR(64) NOT NULL,
+    encryption_key_version INTEGER NOT NULL DEFAULT 1,
+    ciphertext_hash VARCHAR(64),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE(tenant_id, bucket_name, object_key, chunk_index)
+);
+
+-- 3. Object metadata — object-level pipeline metadata
+CREATE TABLE IF NOT EXISTS object_metadata (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    bucket_name VARCHAR(255) NOT NULL,
+    object_key VARCHAR(1024) NOT NULL,
+    total_size BIGINT NOT NULL,
+    chunk_count INTEGER NOT NULL,
+    content_hash VARCHAR(64),
+    content_type VARCHAR(255),
+    logical_size BIGINT NOT NULL,
+    physical_size BIGINT,
+    dedup_ratio REAL,
+    pipeline_config JSONB,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE(tenant_id, bucket_name, object_key)
+);
+
+-- 4. Helper functions
+
+CREATE OR REPLACE FUNCTION increment_chunk_ref(p_hash VARCHAR(64))
+RETURNS VOID AS $$
+BEGIN
+    UPDATE global_content_index
+    SET ref_count = ref_count + 1,
+        last_accessed_at = NOW(),
+        marked_for_deletion = FALSE,
+        marked_at = NULL
+    WHERE plaintext_hash = p_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION decrement_chunk_ref(p_hash VARCHAR(64))
+RETURNS INTEGER AS $$
+DECLARE
+    new_count INTEGER;
+BEGIN
+    UPDATE global_content_index
+    SET ref_count = ref_count - 1
+    WHERE plaintext_hash = p_hash
+    RETURNING ref_count INTO new_count;
+
+    IF new_count = 0 THEN
+        UPDATE global_content_index
+        SET marked_for_deletion = TRUE,
+            marked_at = NOW()
+        WHERE plaintext_hash = p_hash;
+    END IF;
+
+    RETURN new_count;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_tenant_dedup_ratio(p_tenant_id UUID)
+RETURNS TABLE(logical_bytes BIGINT, physical_bytes BIGINT, ratio REAL) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        COALESCE(SUM(om.logical_size), 0)::BIGINT as logical_bytes,
+        COALESCE(SUM(om.physical_size), 0)::BIGINT as physical_bytes,
+        CASE
+            WHEN COALESCE(SUM(om.physical_size), 0) > 0
+            THEN (SUM(om.logical_size)::REAL / SUM(om.physical_size)::REAL)
+            ELSE 1.0
+        END as ratio
+    FROM object_metadata om
+    WHERE om.tenant_id = p_tenant_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. Indexes
+CREATE INDEX IF NOT EXISTS idx_tenant_chunk_refs_object
+    ON tenant_chunk_refs (tenant_id, bucket_name, object_key);
+CREATE INDEX IF NOT EXISTS idx_tenant_chunk_refs_hash
+    ON tenant_chunk_refs (plaintext_hash);
+CREATE INDEX IF NOT EXISTS idx_gci_marked_for_deletion
+    ON global_content_index (marked_for_deletion) WHERE marked_for_deletion = TRUE;
+CREATE INDEX IF NOT EXISTS idx_object_metadata_tenant_bucket
+    ON object_metadata (tenant_id, bucket_name);
+
+-- 6. Add is_chunked flag to object_head_cache
+ALTER TABLE object_head_cache ADD COLUMN IF NOT EXISTS is_chunked BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- **Migration 051**: Creates `global_content_index`, `tenant_chunk_refs`, `object_metadata` tables with PL/pgSQL helper functions (`increment_chunk_ref`, `decrement_chunk_ref`, `get_tenant_dedup_ratio`) and adds `is_chunked` flag to `object_head_cache`
- **Chunked PUT**: Objects >64 MB without encryption are split via FastCDC into content-defined chunks, deduplicated across tenants via the Global Content Index, and stored as `_chunks/{sha256}` keys in the backend
- **Chunked DELETE**: Decrements chunk ref counts via GCI instead of deleting from backend; chunks marked for deletion at ref_count=0 stay until GC (Phase 8.7)
- **GCI wiring**: `GlobalContentIndex` initialized on server startup, passed through `handleGetObject`, `handlePutObject`, `handleDeleteObject` to the `S3ToEngine` adapter

## Architecture notes
- 64 MB threshold means small objects (vast majority) are unaffected
- Chunking is mutually exclusive with SSE-S3/SSE-C — encrypted objects skip chunking (convergent encryption is Phase 10)
- GET is NOT modified — chunked objects won't be retrievable until Phase 8.5 (download pipeline)
- Chunk data stays in backends even after ref_count reaches 0 — GC with 7-day grace period is Phase 8.7
- `chunkingThreshold` field on `S3ToEngine` allows test override (tests use 1 KB threshold)

## Test plan
- [ ] `TestHandlePut_ChunkedUpload` — PUT >threshold, verify `is_chunked=TRUE`, chunks in GCI, refs in `tenant_chunk_refs`
- [ ] `TestHandlePut_ChunkedDedup` — PUT same content twice under different keys, verify `ref_count=2`
- [ ] `TestHandlePut_SmallObjectSkipsChunking` — PUT <threshold, verify `is_chunked=FALSE`
- [ ] `TestHandlePut_EncryptedSkipsChunking` — PUT with SSE-C >threshold, verify `is_chunked=FALSE`
- [ ] `TestHandleDelete_ChunkedObject` — PUT then DELETE chunked object, verify refs cleared, chunks marked for deletion
- [ ] `TestHandleDelete_ChunkedDedup_PartialRefCount` — PUT same content as two keys, DELETE one, verify `ref_count=1`
- [ ] `TestHandlePut_ChunkedUpload_NoGCI` — large object without GCI initialized, verify normal path
- [ ] `TestGCI_IntegrationWithMigration` — full GCI operations against migration schema
- [ ] `TestBackendRegion_ChunkStorageKey` — verify `_chunks/` prefix format
- [ ] CI: `make build`, `make test`, `make lint` all pass