### PR TITLE
feat(engine): dedup-aware download pipeline for chunked objects [Phase 8.5]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -7,7 +7,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **server.go** — Server struct, router setup, middleware chain
 - **s3.go** — Request parsing, auth, routing to operation handlers
 - **s3_errors.go** — Error codes, messages, and response writing
-- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects
+- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects, `handleChunkedGet` reassembles chunked objects on GET (buffers full object, supports range; falls through to normal path on failure)
 - **s3_chunking_test.go** — Integration tests for chunked upload, dedup, delete, and GCI operations
 - **s3_buckets.go** — CreateBucket (with region), DeleteBucket, ListBuckets, GetBucketLocation, HeadBucket
 - **s3_versioning.go** — Bucket versioning enable/suspend

--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/crypto"
@@ -19,6 +22,172 @@ import (
 
 	_ "github.com/lib/pq"
 )
+
+// putChunkedObject is a helper that uploads content above the chunking
+// threshold via the adapter and returns the resulting ETag.
+func putChunkedObject(t *testing.T, f *adapterTestFixture, key string, content []byte, contentType string) string {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/test-bucket/"+key, bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req = req.WithContext(tenant.WithTenant(req.Context(), f.tenant))
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", key)
+	require.Equal(t, http.StatusOK, w.Code, "chunked PUT should succeed")
+	return w.Header().Get("ETag")
+}
+
+func TestHandleGet_ChunkedObject(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024) // 8 KB — above 1 KB threshold
+	putETag := putChunkedObject(t, f, "chunked-get.bin", content, "application/octet-stream")
+
+	// Sanity: the object is actually stored chunked.
+	var isChunked bool
+	require.NoError(t, f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "chunked-get.bin").Scan(&isChunked))
+	require.True(t, isChunked, "object should be chunked for this test to be meaningful")
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/chunked-get.bin", nil)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "chunked-get.bin")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content, body, "reassembled body must match uploaded content")
+	assert.Equal(t, strconv.Itoa(len(content)), gw.Header().Get("Content-Length"))
+	assert.Equal(t, putETag, gw.Header().Get("ETag"), "ETag must match the PUT ETag")
+	assert.Equal(t, "application/octet-stream", gw.Header().Get("Content-Type"))
+}
+
+func TestHandleGet_ChunkedObject_RangeRequest(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+	putChunkedObject(t, f, "range.bin", content, "application/octet-stream")
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/range.bin", nil)
+	getReq.Header.Set("Range", "bytes=0-99")
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "range.bin")
+
+	require.Equal(t, http.StatusPartialContent, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content[0:100], body, "range slice must match")
+	assert.Equal(t, "100", gw.Header().Get("Content-Length"))
+	assert.Equal(t, fmt.Sprintf("bytes 0-99/%d", len(content)), gw.Header().Get("Content-Range"))
+}
+
+func TestHandleGet_ChunkedDedup_SharedContent(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+	keys := []string{"dup-a.bin", "dup-b.bin"}
+	for _, key := range keys {
+		putChunkedObject(t, f, key, content, "application/octet-stream")
+	}
+
+	bodies := make([][]byte, 0, len(keys))
+	for _, key := range keys {
+		getReq := httptest.NewRequest("GET", "/test-bucket/"+key, nil)
+		getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+		gw := httptest.NewRecorder()
+		f.adapter.HandleGet(gw, getReq, "test-bucket", key)
+		require.Equal(t, http.StatusOK, gw.Code)
+		b, _ := io.ReadAll(gw.Body)
+		bodies = append(bodies, b)
+	}
+
+	assert.Equal(t, content, bodies[0])
+	assert.Equal(t, content, bodies[1])
+	assert.Equal(t, bodies[0], bodies[1], "deduplicated objects must return identical content")
+}
+
+func TestHandleGet_SmallObject_NotChunked(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := []byte("small object below the chunking threshold")
+	putReq := httptest.NewRequest("PUT", "/test-bucket/small-get.txt", bytes.NewReader(content))
+	putReq.ContentLength = int64(len(content))
+	putReq.Header.Set("Content-Type", "text/plain")
+	putReq = putReq.WithContext(tenant.WithTenant(putReq.Context(), f.tenant))
+	pw := httptest.NewRecorder()
+	f.adapter.HandlePut(pw, putReq, "test-bucket", "small-get.txt")
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	var isChunked bool
+	require.NoError(t, f.db.QueryRow(`
+		SELECT is_chunked FROM object_head_cache
+		WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
+		f.tenantID, "test-bucket", "small-get.txt").Scan(&isChunked))
+	require.False(t, isChunked, "small object should use the normal path")
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/small-get.txt", nil)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "small-get.txt")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content, body)
+	assert.Equal(t, "text/plain", gw.Header().Get("Content-Type"))
+}
+
+func TestHandleHead_ChunkedObject(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+	putETag := putChunkedObject(t, f, "head-chunked.bin", content, "application/octet-stream")
+
+	srv := &Server{db: f.db, logger: zap.NewNop()}
+	headReq := httptest.NewRequest("HEAD", "/test-bucket/head-chunked.bin", nil)
+	headReq = headReq.WithContext(tenant.WithTenant(headReq.Context(), f.tenant))
+	hw := httptest.NewRecorder()
+	srv.handleHeadObject(hw, headReq, &S3Request{Bucket: "test-bucket", Object: "head-chunked.bin"})
+
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, strconv.Itoa(len(content)), hw.Header().Get("Content-Length"),
+		"HEAD should report the plaintext size")
+	assert.Equal(t, putETag, hw.Header().Get("ETag"))
+	body, _ := io.ReadAll(hw.Body)
+	assert.Empty(t, body, "HEAD must not return a body")
+}
+
+func TestChunkedRoundTrip_PutDeletePut(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(8 * 1024)
+	key := "roundtrip.bin"
+
+	etag1 := putChunkedObject(t, f, key, content, "application/octet-stream")
+
+	// DELETE the chunked object (decrements chunk refs; data stays until GC).
+	delReq := httptest.NewRequest("DELETE", "/test-bucket/"+key, nil)
+	delReq = delReq.WithContext(tenant.WithTenant(delReq.Context(), f.tenant))
+	dw := httptest.NewRecorder()
+	f.adapter.HandleDelete(dw, delReq, "test-bucket", key)
+	require.Equal(t, http.StatusNoContent, dw.Code)
+
+	// PUT the same content again — chunks are re-referenced from the index.
+	etag2 := putChunkedObject(t, f, key, content, "application/octet-stream")
+	assert.Equal(t, etag1, etag2, "same content must yield the same ETag")
+
+	// GET and verify the data round-trips intact.
+	getReq := httptest.NewRequest("GET", "/test-bucket/"+key, nil)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", key)
+	require.Equal(t, http.StatusOK, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content, body, "data must survive PUT → DELETE → PUT round-trip")
+}
 
 func setupChunkingFixture(t *testing.T) *adapterTestFixture {
 	t.Helper()

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -217,13 +217,14 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	var cachedEncAlgo string
 	var cachedTags []byte
 	var cachedContentDisposition string
+	var cachedIsChunked bool
 	var cacheHit bool
 	if a.db != nil {
 		err := a.db.QueryRowContext(r.Context(), `
-			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}'), COALESCE(content_disposition, '')
+			SELECT content_type, size_bytes, etag, updated_at, COALESCE(metadata, '{}'), COALESCE(backend_name, ''), COALESCE(encryption_algorithm, ''), COALESCE(tags, '{}'), COALESCE(content_disposition, ''), is_chunked
 			FROM object_head_cache
 			WHERE tenant_id = $1 AND bucket = $2 AND object_key = $3`,
-			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo, &cachedTags, &cachedContentDisposition)
+			t.ID, bucket, artifact).Scan(&cachedContentType, &cachedSize, &cachedETag, &cachedUpdatedAt, &cachedMetadata, &cachedBackendName, &cachedEncAlgo, &cachedTags, &cachedContentDisposition, &cachedIsChunked)
 		if err == nil {
 			cacheHit = true
 		}
@@ -259,6 +260,24 @@ func (a *S3ToEngine) HandleGet(w http.ResponseWriter, r *http.Request, bucket, o
 	contentType := cachedContentType
 	if contentType == "" {
 		contentType = a.detectContentType(artifact)
+	}
+
+	// Chunked objects are reassembled from their individual chunk storage keys
+	// rather than fetched as a single artifact. On any failure we fall through
+	// to the normal path (which will surface NoSuchKey, since no whole-object
+	// blob exists at this key). The full object is buffered before any response
+	// bytes are written, so fallthrough is always safe.
+	if cacheHit && cachedIsChunked && a.gci != nil {
+		chunkErr := a.handleChunkedGet(w, r, t, bucket, artifact,
+			cachedSize, cachedETag, cachedContentType, cachedUpdatedAt,
+			cachedMetadata, cachedTags, cachedContentDisposition, cachedBackendName)
+		if chunkErr == nil {
+			return
+		}
+		a.logger.Warn("chunked get failed, falling through to normal path",
+			zap.Error(chunkErr),
+			zap.String("bucket", bucket),
+			zap.String("artifact", artifact))
 	}
 
 	reader, err := a.engine.Get(r.Context(), container, artifact)
@@ -942,6 +961,160 @@ func (a *S3ToEngine) handleChunkedPut(
 	a.notifySvc.Fire(t.ID, bucket, "s3:ObjectCreated:Put", artifact, metadataSize, etag)
 	emitEvent(ctx, a.db, a.logger, "object.created", t.ID, map[string]interface{}{
 		"bucket": bucket, "key": artifact, "size": metadataSize, "etag": etag, "chunked": true,
+	})
+
+	return nil
+}
+
+// handleChunkedGet reassembles a chunked object from its individual chunk
+// storage keys and serves it. The object was stored by handleChunkedPut as an
+// ordered sequence of content-defined chunks under "_chunks/{sha256}" keys,
+// deduplicated through the GCI. Chunks are concatenated in chunk_index order so
+// the result is byte-identical to the original upload (its plaintext ETag).
+//
+// The full object is buffered in memory before any response bytes are written:
+// every error path returns before the first header is set, so the caller can
+// safely fall through to the normal GET path. SSE-C/SSE-S3 decryption is not
+// handled — chunking is mutually exclusive with encryption by construction in
+// HandlePut, so chunked objects are never encrypted.
+func (a *S3ToEngine) handleChunkedGet(
+	w http.ResponseWriter, r *http.Request,
+	t *tenant.Tenant,
+	bucket, artifact string,
+	cachedSize int64,
+	cachedETag string,
+	cachedContentType string,
+	cachedUpdatedAt time.Time,
+	cachedMetadata []byte,
+	cachedTags []byte,
+	cachedContentDisposition string,
+	cachedBackendName string,
+) error {
+	ctx := r.Context()
+
+	tenantUUID, err := uuid.Parse(t.ID)
+	if err != nil {
+		return fmt.Errorf("parse tenant UUID: %w", err)
+	}
+
+	container := t.NamespaceContainer(bucket)
+
+	refs, err := a.gci.GetObjectChunks(ctx, tenantUUID, bucket, artifact)
+	if err != nil {
+		return fmt.Errorf("get object chunks: %w", err)
+	}
+	if len(refs) == 0 {
+		return fmt.Errorf("no chunk references for %s/%s", bucket, artifact)
+	}
+
+	// Reassemble in chunk_index order (GetObjectChunks sorts ASC). Sequential
+	// fetch is fine for launch — typical chunked objects have 4-16 chunks.
+	// Parallel prefetch is a future optimization.
+	var buf bytes.Buffer
+	if cachedSize > 0 {
+		buf.Grow(int(cachedSize))
+	}
+	for _, ref := range refs {
+		lookup, lookupErr := a.gci.LookupChunk(ctx, ref.PlaintextHash)
+		if lookupErr != nil {
+			return fmt.Errorf("lookup chunk %s: %w", ref.PlaintextHash[:16], lookupErr)
+		}
+		storageKey := "_chunks/" + ref.PlaintextHash
+		if lookup != nil && lookup.Entry != nil && lookup.Entry.StorageKey != "" {
+			storageKey = lookup.Entry.StorageKey
+		}
+
+		chunkReader, getErr := a.engine.Get(ctx, container, storageKey)
+		if getErr != nil {
+			return fmt.Errorf("fetch chunk %s: %w", ref.PlaintextHash[:16], getErr)
+		}
+		_, copyErr := io.Copy(&buf, chunkReader)
+		_ = chunkReader.Close()
+		if copyErr != nil {
+			return fmt.Errorf("read chunk %s: %w", ref.PlaintextHash[:16], copyErr)
+		}
+	}
+
+	data := buf.Bytes()
+
+	contentType := cachedContentType
+	if contentType == "" {
+		contentType = a.detectContentType(artifact)
+	}
+
+	// Content-Disposition: ?response-content-disposition overrides the stored
+	// value (part of the signed request). Set before the range branch so both
+	// 200 and 206 responses carry it. From here on every path writes a response,
+	// so no caller fallthrough occurs.
+	disposition := r.URL.Query().Get("response-content-disposition")
+	if disposition == "" {
+		disposition = cachedContentDisposition
+	}
+	if disposition = sanitizeContentDisposition(disposition); disposition != "" {
+		w.Header().Set("Content-Disposition", disposition)
+	}
+
+	// Range requests: serve a slice of the already-materialized object.
+	rangeHeader := r.Header.Get("Range")
+	if rangeHeader != "" && cachedSize > 0 {
+		rng, parseErr := parseRangeHeader(rangeHeader, cachedSize)
+		if parseErr != nil {
+			writeRangeNotSatisfiable(w, cachedSize)
+			return nil
+		}
+		w.Header().Set("x-amz-request-id", generateRequestID())
+		if w.Header().Get("x-amz-version-id") == "" {
+			w.Header().Set("x-amz-version-id", "null")
+		}
+		if serveErr := serveRange(w, bytes.NewReader(data), rng, cachedSize, contentType); serveErr != nil {
+			a.logger.Error("chunked range serve failed",
+				zap.Error(serveErr),
+				zap.String("container", container),
+				zap.String("artifact", artifact))
+		}
+		return nil
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("x-amz-request-id", generateRequestID())
+	if w.Header().Get("x-amz-version-id") == "" {
+		w.Header().Set("x-amz-version-id", "null")
+	}
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Cache-Control", "private, no-cache")
+	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(cachedBackendName))
+	if cachedSize > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
+	}
+	if cachedETag != "" {
+		w.Header().Set("ETag", fmt.Sprintf(`"%s"`, cachedETag))
+	}
+	if !cachedUpdatedAt.IsZero() {
+		w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
+	}
+	setS3MetadataHeaders(w, cachedMetadata)
+	if n := tagCount(cachedTags); n > 0 {
+		w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
+	}
+
+	written, err := io.Copy(w, bytes.NewReader(data))
+	if err != nil {
+		a.logger.Error("failed to stream chunked artifact",
+			zap.Error(err),
+			zap.String("container", container),
+			zap.String("artifact", artifact))
+		return nil
+	}
+
+	a.logger.Info("chunked artifact retrieved",
+		zap.String("s3.bucket", bucket),
+		zap.String("s3.object", artifact),
+		zap.String("engine.container", container),
+		zap.Int("chunks", len(refs)),
+		zap.Int64("bytes", written))
+
+	emitEvent(ctx, a.db, a.logger, "object.downloaded", t.ID, map[string]interface{}{
+		"bucket": bucket, "key": artifact, "size": written, "chunked": true,
 	})
 
 	return nil

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -53,7 +53,11 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 2. If chunked → `gci.DeleteObjectChunks` (transactional: deletes refs, decrements counts, deletes object_metadata)
 3. Chunk data stays until GC (Phase 8.7) — `marked_for_deletion=TRUE` when `ref_count=0`
 
-**GET flow**: not yet wired — chunked objects are not retrievable until Phase 8.5 (download pipeline).
+**GET flow** (s3_engine_adapter.go `handleChunkedGet`, Phase 8.5):
+1. `HandleGet` reads `is_chunked` from `object_head_cache`; if set and `gci != nil`, branches before the normal `engine.Get`
+2. `GetObjectChunks` → ordered manifest; per chunk `LookupChunk` → `_chunks/{sha256}` storage key
+3. Sequential `engine.Get` per chunk, concatenated into a buffer in `chunk_index` order (byte-identical to upload → plaintext ETag matches)
+4. Serves with full headers + range support (range = slice of the buffered object). On any pre-write failure, falls through to the normal path (→ NoSuchKey). HEAD needs no chunk-aware logic — `object_head_cache` already holds plaintext size/ETag.
 
 **Constraints**: chunking is mutually exclusive with SSE-S3/SSE-C in this phase. Convergent encryption (Phase 10) will enable per-chunk encryption + dedup.
 


### PR DESCRIPTION
## Phase 8.5: Dedup-Aware Download Pipeline

Completes the chunking round-trip from Phase 8.3-8.4 (#300). Chunked objects
uploaded via the content-defined chunking pipeline are now retrievable —
`HandleGet` detects them and reassembles them from their individual chunk
storage keys.

### What changed
- **SELECT expansion** — `HandleGet`'s `object_head_cache` query now reads `is_chunked`.
- **`handleChunkedGet`** — branches before the normal `engine.Get`:
  1. `GetObjectChunks` → ordered chunk manifest (`chunk_index` ASC)
  2. per chunk: `LookupChunk` → `_chunks/{sha256}` storage key
  3. sequential `engine.Get` per chunk, concatenated into a buffer
  4. serves with the full GET header set + range support
  5. emits `object.downloaded`

  The full object is buffered **before** any response byte is written, so a
  pre-write failure falls through to the normal path safely (which surfaces
  `NoSuchKey`, since no whole-object blob exists at the key). Concatenation in
  `chunk_index` order is byte-identical to the upload, so the stored plaintext
  ETag matches.
- **HEAD** — no code change needed; `object_head_cache` already holds plaintext
  size/ETag/content-type. Verified by test.
- **No SSE handling** — chunking is mutually exclusive with encryption by
  construction in `HandlePut`, so chunked objects are never encrypted.

### Tests (`s3_chunking_test.go`)
- `TestHandleGet_ChunkedObject` — round-trip body/Content-Length/ETag/Content-Type
- `TestHandleGet_ChunkedObject_RangeRequest` — `bytes=0-99` → 206 + correct slice
- `TestHandleGet_ChunkedDedup_SharedContent` — same content under two keys → identical GETs
- `TestHandleGet_SmallObject_NotChunked` — small-object regression (normal path)
- `TestHandleHead_ChunkedObject` — 200 + Content-Length/ETag, no body
- `TestChunkedRoundTrip_PutDeletePut` — PUT → DELETE → PUT (same content) → GET intact

Range requests reassemble the full object then slice it (acceptable — chunked
objects are already buffered in memory on PUT). Sequential chunk fetch; parallel
prefetch is a future optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)