### PR TITLE
fix(engine): store dedup chunks in global container so cross-tenant GET works

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -7,7 +7,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **server.go** — Server struct, router setup, middleware chain
 - **s3.go** — Request parsing, auth, routing to operation handlers
 - **s3_errors.go** — Error codes, messages, and response writing
-- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects, `handleChunkedGet` reassembles chunked objects on GET (buffers full object, supports range; falls through to normal path on failure)
+- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects, `handleChunkedGet` reassembles chunked objects on GET (buffers full object, supports range; falls through to normal path on failure). Chunks live in the shared `_global` container (const `chunkContainer`) so cross-bucket/cross-tenant dedup is retrievable
 - **s3_chunking_test.go** — Integration tests for chunked upload, dedup, delete, and GCI operations
 - **s3_buckets.go** — CreateBucket (with region), DeleteBucket, ListBuckets, GetBucketLocation, HeadBucket
 - **s3_versioning.go** — Bucket versioning enable/suspend

--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -189,6 +189,129 @@ func TestChunkedRoundTrip_PutDeletePut(t *testing.T) {
 	assert.Equal(t, content, body, "data must survive PUT → DELETE → PUT round-trip")
 }
 
+// putChunkedAs uploads content for an explicit tenant (not just f.tenant), used
+// by the cross-tenant dedup test.
+func putChunkedAs(t *testing.T, f *adapterTestFixture, tn *tenant.Tenant, bucket, key string, content []byte) {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/"+bucket+"/"+key, bytes.NewReader(content))
+	req.ContentLength = int64(len(content))
+	req = req.WithContext(tenant.WithTenant(req.Context(), tn))
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, bucket, key)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func getChunkedAs(t *testing.T, f *adapterTestFixture, tn *tenant.Tenant, bucket, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/"+bucket+"/"+key, nil)
+	req = req.WithContext(tenant.WithTenant(req.Context(), tn))
+	w := httptest.NewRecorder()
+	f.adapter.HandleGet(w, req, bucket, key)
+	return w
+}
+
+// TestHandleGet_ChunkedObject_MultiChunk forces an object large enough to split
+// into multiple chunks (>16 MB max chunk size) and verifies that reassembly is
+// byte-identical and in chunk_index order — the core of handleChunkedGet that
+// the 8 KB tests (single chunk) never exercise.
+func TestHandleGet_ChunkedObject_MultiChunk(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := generateTestData(20 * 1024 * 1024) // 20 MB → multiple chunks (16 MB max)
+	putETag := putChunkedObject(t, f, "multi.bin", content, "application/octet-stream")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+	var chunkCount int
+	require.NoError(t, f.db.QueryRow(`
+		SELECT COUNT(*) FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", "multi.bin").Scan(&chunkCount))
+	require.GreaterOrEqual(t, chunkCount, 2, "20 MB object must split into multiple chunks for this test to be meaningful")
+
+	gw := getChunkedAs(t, f, f.tenant, "test-bucket", "multi.bin")
+	require.Equal(t, http.StatusOK, gw.Code)
+	require.Equal(t, content, gw.Body.Bytes(), "multi-chunk reassembly must be byte-identical and in order")
+	assert.Equal(t, putETag, gw.Header().Get("ETag"))
+
+	// Range straddling a chunk boundary (~1 MB).
+	rangeReq := httptest.NewRequest("GET", "/test-bucket/multi.bin", nil)
+	rangeReq.Header.Set("Range", "bytes=1048570-1048580")
+	rangeReq = rangeReq.WithContext(tenant.WithTenant(rangeReq.Context(), f.tenant))
+	rw := httptest.NewRecorder()
+	f.adapter.HandleGet(rw, rangeReq, "test-bucket", "multi.bin")
+	require.Equal(t, http.StatusPartialContent, rw.Code)
+	assert.Equal(t, content[1048570:1048581], rw.Body.Bytes())
+}
+
+// TestHandleGet_ChunkedDedup_CrossBucket verifies that an object which dedups
+// against a chunk first stored under a *different bucket* (same tenant) is still
+// retrievable. Chunks must live in a shared store, not the per-bucket namespace.
+func TestHandleGet_ChunkedDedup_CrossBucket(t *testing.T) {
+	f := setupChunkingFixture(t)
+	content := generateTestData(8 * 1024)
+
+	bucket2 := "second-bucket"
+	require.NoError(t, os.MkdirAll(filepath.Join(f.tempDir, f.tenant.NamespaceContainer(bucket2)), 0755))
+	t.Cleanup(func() {
+		_, _ = f.db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1 AND bucket = $2", f.tenantID, bucket2)
+		tenantUUID, _ := uuid.Parse(f.tenantID)
+		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1 AND bucket_name = $2", tenantUUID, bucket2)
+		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1 AND bucket_name = $2", tenantUUID, bucket2)
+	})
+
+	putChunkedObject(t, f, "obj1", content, "application/octet-stream") // test-bucket
+	putChunkedAs(t, f, f.tenant, bucket2, "obj2", content)              // second-bucket, dedup hit
+
+	gw := getChunkedAs(t, f, f.tenant, bucket2, "obj2")
+	require.Equal(t, http.StatusOK, gw.Code, "cross-bucket dedup GET must return the object")
+	assert.Equal(t, content, gw.Body.Bytes())
+}
+
+// TestHandleGet_ChunkedDedup_CrossTenant verifies the GCI's headline capability:
+// global dedup across tenants. Tenant B's object dedups against a chunk first
+// uploaded by tenant A, and B can still GET it.
+func TestHandleGet_ChunkedDedup_CrossTenant(t *testing.T) {
+	f := setupChunkingFixture(t)
+	content := generateTestData(8 * 1024)
+
+	// Tenant A (the fixture tenant) uploads first.
+	putChunkedObject(t, f, "objA", content, "application/octet-stream")
+
+	// Tenant B shares the same db + engine + data dir.
+	bUUID := uuid.New()
+	_, err := f.db.Exec(`
+		INSERT INTO tenants (id, name, email, access_key, secret_key)
+		VALUES ($1, $2, $3, $4, $5) ON CONFLICT (id) DO NOTHING`,
+		bUUID.String(), "Chunk Tenant B", "chunk-b@test.local", "AK-"+bUUID.String()[:8], "SK-"+bUUID.String()[:8])
+	require.NoError(t, err)
+	tB := &tenant.Tenant{ID: bUUID.String(), Namespace: "tenant/" + bUUID.String() + "/"}
+	require.NoError(t, os.MkdirAll(filepath.Join(f.tempDir, tB.NamespaceContainer("test-bucket")), 0755))
+	t.Cleanup(func() {
+		_, _ = f.db.Exec("DELETE FROM tenant_chunk_refs WHERE tenant_id = $1", bUUID)
+		_, _ = f.db.Exec("DELETE FROM object_metadata WHERE tenant_id = $1", bUUID)
+		_, _ = f.db.Exec("DELETE FROM object_head_cache WHERE tenant_id = $1", bUUID.String())
+		_, _ = f.db.Exec("DELETE FROM tenants WHERE id = $1", bUUID.String())
+	})
+
+	// Tenant B uploads identical content — must dedup against A's chunk.
+	putChunkedAs(t, f, tB, "test-bucket", "objB", content)
+
+	// Confirm a real dedup happened (ref_count == 2 across A + B).
+	var maxRef int
+	require.NoError(t, f.db.QueryRow(`
+		SELECT MAX(gci.ref_count) FROM global_content_index gci
+		INNER JOIN tenant_chunk_refs tcr ON tcr.plaintext_hash = gci.plaintext_hash
+		WHERE tcr.tenant_id = $1 AND tcr.bucket_name = $2 AND tcr.object_key = $3`,
+		bUUID, "test-bucket", "objB").Scan(&maxRef))
+	require.Equal(t, 2, maxRef, "tenant B's chunk must be deduplicated against tenant A's (ref_count=2)")
+
+	// Tenant B GETs — must reassemble from the globally-stored chunk.
+	gw := getChunkedAs(t, f, tB, "test-bucket", "objB")
+	require.Equal(t, http.StatusOK, gw.Code, "cross-tenant dedup GET must return the object")
+	assert.Equal(t, content, gw.Body.Bytes())
+}
+
 func setupChunkingFixture(t *testing.T) *adapterTestFixture {
 	t.Helper()
 

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -23,6 +23,19 @@ import (
 	"go.uber.org/zap"
 )
 
+// chunkContainer is the shared, tenant-independent container that stores
+// deduplicated content-defined chunks. Dedup is global — identical content is
+// stored once across all tenants — so chunks must live outside any tenant's
+// namespace, otherwise an object that dedups against a chunk first written by a
+// different tenant or bucket would have no reachable copy.
+//
+// Isolation is preserved at the manifest layer: a tenant can only reach a chunk
+// through its own tenant_chunk_refs rows (queried by tenant_id in
+// GetObjectChunks). The container itself is not addressable via the S3 API,
+// since every S3 request is routed through the tenant namespace
+// ("tenant/{id}/{bucket}"), never the bare "_global" prefix.
+const chunkContainer = "_global"
+
 // S3ToEngine adapts S3 requests to engine operations.
 type S3ToEngine struct {
 	engine            engine.Engine
@@ -620,7 +633,7 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 	}
 	if a.gci != nil && metadataSize > chunkThreshold && encryptionAlgorithm == "" {
 		if tenantUUID, parseErr := uuid.Parse(t.ID); parseErr == nil {
-			chunkErr := a.handleChunkedPut(r, w, t, tenantUUID, bucket, artifact, container, metadataSize, hashingBody, hasher)
+			chunkErr := a.handleChunkedPut(r, w, t, tenantUUID, bucket, artifact, metadataSize, hashingBody, hasher)
 			if chunkErr == nil {
 				return
 			}
@@ -786,7 +799,7 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 func (a *S3ToEngine) handleChunkedPut(
 	r *http.Request, w http.ResponseWriter,
 	t *tenant.Tenant, tenantUUID uuid.UUID,
-	bucket, artifact, container string,
+	bucket, artifact string,
 	metadataSize int64,
 	hashingBody io.Reader,
 	hasher hash.Hash,
@@ -827,7 +840,7 @@ func (a *S3ToEngine) handleChunkedPut(
 
 		if result.IsNewChunk {
 			chunkOpts := []engine.PutOption{engine.WithContentLength(int64(chunk.Size))}
-			bn, putErr := a.engine.Put(ctx, container, storageKey, bytes.NewReader(chunk.Data), chunkOpts...)
+			bn, putErr := a.engine.Put(ctx, chunkContainer, storageKey, bytes.NewReader(chunk.Data), chunkOpts...)
 			if putErr != nil {
 				return fmt.Errorf("store chunk %s: %w", chunk.Hash[:16], putErr)
 			}
@@ -1024,7 +1037,17 @@ func (a *S3ToEngine) handleChunkedGet(
 			storageKey = lookup.Entry.StorageKey
 		}
 
-		chunkReader, getErr := a.engine.Get(ctx, container, storageKey)
+		// Chunks live in the shared global container (dedup spans tenants), not
+		// this tenant's namespace. Hint the backend that actually holds the
+		// chunk so retrieval is deterministic after a restart (when the engine's
+		// in-memory routing map is cold).
+		if lookup != nil && lookup.Entry != nil && lookup.Entry.BackendID != "" {
+			if ce, ok := a.engine.(*engine.CoreEngine); ok {
+				ce.HintBackend(chunkContainer, storageKey, lookup.Entry.BackendID)
+			}
+		}
+
+		chunkReader, getErr := a.engine.Get(ctx, chunkContainer, storageKey)
 		if getErr != nil {
 			return fmt.Errorf("fetch chunk %s: %w", ref.PlaintextHash[:16], getErr)
 		}

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -34,9 +34,11 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 - `postquantum.go` — cloudflare/circl (pipeline encryption, existing)
 - `sse_s3.go` — Go stdlib crypto/mlkem (SSE-S3, new)
 
-## Chunking + Dedup Architecture (Phase 8.3-8.4)
+## Chunking + Dedup Architecture (Phase 8.3-8.5)
 
 **FastCDC chunking** splits large objects (>64 MB, unencrypted) into content-defined chunks. The **Global Content Index** (GCI) deduplicates chunks across all tenants — identical content is stored once.
+
+**Global chunk store** (Phase 8.5.1): chunks are stored in a shared, tenant-independent container `_global` (const `chunkContainer` in s3_engine_adapter.go), NOT the per-tenant/bucket namespace. Because dedup spans tenants, a chunk first written by tenant A / bucket X must be reachable when tenant B / bucket Y dedups against it — storing in the writer's namespace made cross-bucket/cross-tenant GETs 404. Isolation is preserved at the manifest layer: a tenant reaches a chunk only through its own `tenant_chunk_refs` (queried by `tenant_id`), and `_global` is not addressable via the S3 API (all S3 paths route through `tenant/{id}/{bucket}`).
 
 - **chunker.go** — FastCDC chunker (1 MB min / 4 MB avg / 16 MB max) using `restic/chunker`. `ChunkBytes()` for sync, `Chunk()` for streaming. SHA-256 per chunk.
 - **gci.go** — `GlobalContentIndex`: DB-backed dedup index with 100K-entry in-memory cache. Batch lookups (`LookupChunks`), ref counting (`IncrementRef`/`DecrementRef`), tenant chunk manifests (`AddTenantChunkRef`), object metadata (`SaveObjectMetadata`), transactional delete (`DeleteObjectChunks`).
@@ -45,18 +47,18 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 1. Gate: `gci != nil && size > threshold && no encryption`
 2. Parse tenant UUID (skip chunking if non-UUID tenant)
 3. `ReadAll` through MD5 hasher → `ChunkBytes` → batch `LookupChunks`
-4. For each chunk: if new → `engine.Put("_chunks/{sha256}")` + `InsertChunk`; if existing → `IncrementRef`
+4. For each chunk: if new → `engine.Put(_global, "_chunks/{sha256}")` + `InsertChunk`; if existing → `IncrementRef`
 5. `AddTenantChunkRef` per chunk, `SaveObjectMetadata`, `object_head_cache` with `is_chunked=TRUE`
 
 **DELETE flow** (s3_engine_adapter.go `HandleDelete`):
 1. Query `is_chunked` from `object_head_cache`
 2. If chunked → `gci.DeleteObjectChunks` (transactional: deletes refs, decrements counts, deletes object_metadata)
-3. Chunk data stays until GC (Phase 8.7) — `marked_for_deletion=TRUE` when `ref_count=0`
+3. Chunk data stays until GC (Phase 8.7) — `marked_for_deletion=TRUE` when `ref_count=0`. GC must delete from the `_global` container (using each GCI entry's `storage_key`/`backend_id`), not a tenant namespace.
 
 **GET flow** (s3_engine_adapter.go `handleChunkedGet`, Phase 8.5):
 1. `HandleGet` reads `is_chunked` from `object_head_cache`; if set and `gci != nil`, branches before the normal `engine.Get`
-2. `GetObjectChunks` → ordered manifest; per chunk `LookupChunk` → `_chunks/{sha256}` storage key
-3. Sequential `engine.Get` per chunk, concatenated into a buffer in `chunk_index` order (byte-identical to upload → plaintext ETag matches)
+2. `GetObjectChunks` → ordered manifest; per chunk `LookupChunk` → storage key + `BackendID` (used to `HintBackend` so retrieval is deterministic after a cold restart)
+3. Sequential `engine.Get(_global, "_chunks/{sha256}")` per chunk, concatenated into a buffer in `chunk_index` order (byte-identical to upload → plaintext ETag matches). Cross-bucket and cross-tenant dedup retrieval both work because chunks live in the shared `_global` container.
 4. Serves with full headers + range support (range = slice of the buffered object). On any pre-write failure, falls through to the normal path (→ NoSuchKey). HEAD needs no chunk-aware logic — `object_head_cache` already holds plaintext size/ETag.
 
 **Constraints**: chunking is mutually exclusive with SSE-S3/SSE-C in this phase. Convergent encryption (Phase 10) will enable per-chunk encryption + dedup.


### PR DESCRIPTION
## Cross-tenant / cross-bucket dedup retrieval was broken (404)

Follow-up to Phase 8.5 (#301). While reviewing the chunking foundation I
**empirically confirmed** a retrieval bug that's been latent since 8.3–8.4.

### The bug
Chunks were stored under the **writer's per-(tenant, bucket) namespace**
(`tenant/{id}/{bucket}/_chunks/{hash}`), but the GCI dedup index is **global**.
So when bucket B (or tenant B) deduplicated against a chunk first written by
bucket A (or tenant A), it `IncrementRef`'d but stored no reachable copy — and
GET looked in the requester's own namespace → miss → fallthrough → **404**.

This silently broke:
- **cross-tenant dedup** — the GCI's headline capability and the basis of the
  VAULT_SERIES overselling economics
- **cross-bucket dedup within a single tenant**

No chunking test caught it: every test (8.3–8.5) used one tenant + one bucket,
so the container always happened to match.

### The fix
Store chunks in a shared, tenant-independent container `_global`
(const `chunkContainer`). On GET, `HintBackend(entry.BackendID)` then fetch from
`_global`, so retrieval is deterministic even after a cold restart.

**Isolation preserved** at the manifest layer: a tenant reaches a chunk only via
its own `tenant_chunk_refs` (queried by `tenant_id`), and `_global` is not
addressable through the S3 API (all S3 paths route through `tenant/{id}/{bucket}`).

Chunking isn't in production traffic yet (behind the 64 MB threshold, feature is
days old), so there's no stored chunk data to migrate.

### Tests (TDD — the two dedup tests were RED before the fix)
- `TestHandleGet_ChunkedDedup_CrossBucket` — 404 → 200
- `TestHandleGet_ChunkedDedup_CrossTenant` — 404 → 200; asserts `ref_count=2` so it's a genuine dedup hit
- `TestHandleGet_ChunkedObject_MultiChunk` — 20 MB → ≥2 chunks; verifies multi-chunk reassembly **order** + a chunk-boundary-straddling range (a path the 8 KB single-chunk tests never exercised)

### Known follow-ups (not in this PR)
- Whole-object memory buffering on chunked PUT/GET (violates the "always stream" rule) — needs a streaming reassembly design before large-object production traffic
- Encryption silently skipped for >256 MB objects in SSE-enabled buckets (SSE cap vs chunk threshold gap)
- No read-time chunk integrity (hash) verification
- Chunk GC (Phase 8.7) must delete from `_global`

🤖 Generated with [Claude Code](https://claude.com/claude-code)