### PR TITLE
feat(engine): stream chunked GET with per-chunk integrity verification [Phase 8.6]

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -7,7 +7,7 @@ S3-compatible API layer. Translates S3 protocol to engine operations, handles au
 - **server.go** — Server struct, router setup, middleware chain
 - **s3.go** — Request parsing, auth, routing to operation handlers
 - **s3_errors.go** — Error codes, messages, and response writing
-- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects, `handleChunkedGet` reassembles chunked objects on GET (buffers full object, supports range; falls through to normal path on failure). Chunks live in the shared `_global` container (const `chunkContainer`) so cross-bucket/cross-tenant dedup is retrievable
+- **s3_engine_adapter.go** — GET/PUT/DELETE/LIST handlers bridging S3 to engine; `handleChunkedPut` for content-defined chunking + dedup on large objects, `handleChunkedGet` streams chunked objects on GET one chunk at a time (`fetchAndVerifyChunk`: bounded ~16 MB buffer + SHA-256 integrity check per chunk; range via `chunk_offset`; corrupt first chunk → 500, never serves bad bytes). Chunks live in the shared `_global` container (const `chunkContainer`) so cross-bucket/cross-tenant dedup is retrievable
 - **s3_chunking_test.go** — Integration tests for chunked upload, dedup, delete, and GCI operations
 - **s3_buckets.go** — CreateBucket (with region), DeleteBucket, ListBuckets, GetBucketLocation, HeadBucket
 - **s3_versioning.go** — Bucket versioning enable/suspend

--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -312,6 +312,68 @@ func TestHandleGet_ChunkedDedup_CrossTenant(t *testing.T) {
 	assert.Equal(t, content, gw.Body.Bytes())
 }
 
+// TestHandleGet_ChunkedObject_MultiChunkRanges exercises range requests that
+// span chunk boundaries on a multi-chunk (20 MB) object — the streaming range
+// path that selects only overlapping chunks via chunk_offset.
+func TestHandleGet_ChunkedObject_MultiChunkRanges(t *testing.T) {
+	f := setupChunkingFixture(t)
+	content := generateTestData(20 * 1024 * 1024)
+	putChunkedObject(t, f, "ranges.bin", content, "application/octet-stream")
+	total := len(content)
+
+	cases := []struct {
+		name   string
+		hdr    string
+		lo, hi int // [lo, hi)
+	}{
+		{"spans-multiple-chunks", "bytes=500000-15000000", 500000, 15000001},
+		{"suffix", "bytes=-1048576", total - 1048576, total},
+		{"open-ended", "bytes=18000000-", 18000000, total},
+		{"single-byte", "bytes=10000000-10000000", 10000000, 10000001},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test-bucket/ranges.bin", nil)
+			req.Header.Set("Range", tc.hdr)
+			req = req.WithContext(tenant.WithTenant(req.Context(), f.tenant))
+			w := httptest.NewRecorder()
+			f.adapter.HandleGet(w, req, "test-bucket", "ranges.bin")
+
+			require.Equal(t, http.StatusPartialContent, w.Code)
+			assert.Equal(t, content[tc.lo:tc.hi], w.Body.Bytes(), "range slice must be exact")
+			assert.Equal(t, strconv.Itoa(tc.hi-tc.lo), w.Header().Get("Content-Length"))
+			assert.Equal(t, fmt.Sprintf("bytes %d-%d/%d", tc.lo, tc.hi-1, total), w.Header().Get("Content-Range"))
+		})
+	}
+}
+
+// TestHandleGet_ChunkedObject_CorruptChunk verifies read-time integrity: if a
+// stored chunk's bytes no longer hash to its plaintext_hash, the corrupt data
+// must NOT be served (200), and the failure is surfaced as 500 (the object
+// exists but is corrupt) rather than falling through to 404.
+func TestHandleGet_ChunkedObject_CorruptChunk(t *testing.T) {
+	f := setupChunkingFixture(t)
+	content := generateTestData(8 * 1024) // single chunk
+	putChunkedObject(t, f, "corrupt.bin", content, "application/octet-stream")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+	var hashHex string
+	require.NoError(t, f.db.QueryRow(`
+		SELECT plaintext_hash FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3
+		ORDER BY chunk_index LIMIT 1`,
+		tenantUUID, "test-bucket", "corrupt.bin").Scan(&hashHex))
+
+	// Overwrite the chunk's bytes in the shared global container on disk.
+	chunkPath := filepath.Join(f.tempDir, "_global", "_chunks", hashHex)
+	require.NoError(t, os.WriteFile(chunkPath, []byte("corrupted chunk payload — wrong bytes"), 0600))
+
+	gw := getChunkedAs(t, f, f.tenant, "test-bucket", "corrupt.bin")
+	require.Equal(t, http.StatusInternalServerError, gw.Code, "corrupt chunk must not be served as 200")
+	assert.NotEqual(t, content, gw.Body.Bytes(), "original/correct bytes must not be served")
+}
+
 func setupChunkingFixture(t *testing.T) *adapterTestFixture {
 	t.Helper()
 

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/md5" // #nosec G501 — S3 spec requires MD5 for ETags
+	"crypto/md5"    // #nosec G501 — S3 spec requires MD5 for ETags
+	"crypto/sha256" // chunk integrity verification on read
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -979,17 +981,68 @@ func (a *S3ToEngine) handleChunkedPut(
 	return nil
 }
 
-// handleChunkedGet reassembles a chunked object from its individual chunk
-// storage keys and serves it. The object was stored by handleChunkedPut as an
-// ordered sequence of content-defined chunks under "_chunks/{sha256}" keys,
-// deduplicated through the GCI. Chunks are concatenated in chunk_index order so
-// the result is byte-identical to the original upload (its plaintext ETag).
+// errChunkIntegrity signals that a fetched chunk's bytes did not hash to its
+// expected plaintext hash. The object exists but is corrupt — this is distinct
+// from a missing/unresolvable manifest (which falls through to NoSuchKey).
+var errChunkIntegrity = errors.New("chunk integrity verification failed")
+
+// chunkDesc is a resolved chunk location + its byte position within the object.
+type chunkDesc struct {
+	storageKey    string
+	backendID     string
+	plaintextHash string
+	offset        int64 // byte offset of this chunk within the object
+	size          int64 // chunk size in bytes
+}
+
+// fetchAndVerifyChunk reads one chunk from the global container into a bounded
+// buffer (≤ max chunk size, ~16 MB) and verifies its SHA-256 matches the
+// expected plaintext hash before returning it. Verifying before the bytes are
+// written guarantees corrupt data is never served, and the per-chunk read keeps
+// peak memory at one chunk regardless of object size.
+func (a *S3ToEngine) fetchAndVerifyChunk(ctx context.Context, d chunkDesc) ([]byte, error) {
+	// Hint the backend that holds this chunk so retrieval is deterministic after
+	// a restart (when the engine's in-memory routing map is cold).
+	if d.backendID != "" {
+		if ce, ok := a.engine.(*engine.CoreEngine); ok {
+			ce.HintBackend(chunkContainer, d.storageKey, d.backendID)
+		}
+	}
+
+	rdr, err := a.engine.Get(ctx, chunkContainer, d.storageKey)
+	if err != nil {
+		return nil, fmt.Errorf("fetch chunk %s: %w", d.plaintextHash[:16], err)
+	}
+	defer func() { _ = rdr.Close() }()
+
+	data, err := io.ReadAll(rdr)
+	if err != nil {
+		return nil, fmt.Errorf("read chunk %s: %w", d.plaintextHash[:16], err)
+	}
+
+	sum := sha256.Sum256(data)
+	if hex.EncodeToString(sum[:]) != d.plaintextHash {
+		return nil, fmt.Errorf("%w: chunk %s (%d bytes)", errChunkIntegrity, d.plaintextHash[:16], len(data))
+	}
+	return data, nil
+}
+
+// handleChunkedGet serves a chunked object by streaming its content-defined
+// chunks one at a time, in chunk_index order, directly to the response writer.
+// Each chunk is read into a bounded buffer (~16 MB max) and integrity-verified
+// before its bytes are written, so peak memory is one chunk — not the whole
+// object — and corrupt data is never served. Range requests touch only the
+// chunks that overlap the requested byte range (located via chunk_offset).
 //
-// The full object is buffered in memory before any response bytes are written:
-// every error path returns before the first header is set, so the caller can
-// safely fall through to the normal GET path. SSE-C/SSE-S3 decryption is not
-// handled — chunking is mutually exclusive with encryption by construction in
-// HandlePut, so chunked objects are never encrypted.
+// Fallthrough contract: the manifest is fully resolved (all chunk index entries
+// present) BEFORE any byte is written, so a resolution failure returns an error
+// and the caller falls through to the normal GET path. Once the first chunk is
+// committed the status is fixed; a later integrity/fetch failure aborts the body
+// (a short read the client detects) rather than serving bad bytes. A corrupt
+// FIRST chunk yields a clean 500 (handled here — never a fallthrough to 404).
+//
+// SSE-C/SSE-S3 decryption is not handled — chunking is mutually exclusive with
+// encryption by construction in HandlePut, so chunked objects are never encrypted.
 func (a *S3ToEngine) handleChunkedGet(
 	w http.ResponseWriter, r *http.Request,
 	t *tenant.Tenant,
@@ -1020,45 +1073,30 @@ func (a *S3ToEngine) handleChunkedGet(
 		return fmt.Errorf("no chunk references for %s/%s", bucket, artifact)
 	}
 
-	// Reassemble in chunk_index order (GetObjectChunks sorts ASC). Sequential
-	// fetch is fine for launch — typical chunked objects have 4-16 chunks.
-	// Parallel prefetch is a future optimization.
-	var buf bytes.Buffer
-	if cachedSize > 0 {
-		buf.Grow(int(cachedSize))
-	}
-	for _, ref := range refs {
+	// Preflight: resolve every chunk's location from the index without reading
+	// data. A missing index entry means the manifest is unresolvable — return an
+	// error so HandleGet falls through (→ NoSuchKey) before any byte is written.
+	descs := make([]chunkDesc, len(refs))
+	for i, ref := range refs {
 		lookup, lookupErr := a.gci.LookupChunk(ctx, ref.PlaintextHash)
 		if lookupErr != nil {
 			return fmt.Errorf("lookup chunk %s: %w", ref.PlaintextHash[:16], lookupErr)
 		}
-		storageKey := "_chunks/" + ref.PlaintextHash
-		if lookup != nil && lookup.Entry != nil && lookup.Entry.StorageKey != "" {
-			storageKey = lookup.Entry.StorageKey
+		if lookup == nil || lookup.Entry == nil {
+			return fmt.Errorf("chunk %s missing from index", ref.PlaintextHash[:16])
 		}
-
-		// Chunks live in the shared global container (dedup spans tenants), not
-		// this tenant's namespace. Hint the backend that actually holds the
-		// chunk so retrieval is deterministic after a restart (when the engine's
-		// in-memory routing map is cold).
-		if lookup != nil && lookup.Entry != nil && lookup.Entry.BackendID != "" {
-			if ce, ok := a.engine.(*engine.CoreEngine); ok {
-				ce.HintBackend(chunkContainer, storageKey, lookup.Entry.BackendID)
-			}
+		storageKey := lookup.Entry.StorageKey
+		if storageKey == "" {
+			storageKey = "_chunks/" + ref.PlaintextHash
 		}
-
-		chunkReader, getErr := a.engine.Get(ctx, chunkContainer, storageKey)
-		if getErr != nil {
-			return fmt.Errorf("fetch chunk %s: %w", ref.PlaintextHash[:16], getErr)
-		}
-		_, copyErr := io.Copy(&buf, chunkReader)
-		_ = chunkReader.Close()
-		if copyErr != nil {
-			return fmt.Errorf("read chunk %s: %w", ref.PlaintextHash[:16], copyErr)
+		descs[i] = chunkDesc{
+			storageKey:    storageKey,
+			backendID:     lookup.Entry.BackendID,
+			plaintextHash: ref.PlaintextHash,
+			offset:        ref.ChunkOffset,
+			size:          lookup.Entry.SizeBytes,
 		}
 	}
-
-	data := buf.Bytes()
 
 	contentType := cachedContentType
 	if contentType == "" {
@@ -1066,9 +1104,8 @@ func (a *S3ToEngine) handleChunkedGet(
 	}
 
 	// Content-Disposition: ?response-content-disposition overrides the stored
-	// value (part of the signed request). Set before the range branch so both
-	// 200 and 206 responses carry it. From here on every path writes a response,
-	// so no caller fallthrough occurs.
+	// value (part of the signed request). Header mutations before the first
+	// WriteHeader are buffered, so this is safe to set up front.
 	disposition := r.URL.Query().Get("response-content-disposition")
 	if disposition == "" {
 		disposition = cachedContentDisposition
@@ -1077,63 +1114,154 @@ func (a *S3ToEngine) handleChunkedGet(
 		w.Header().Set("Content-Disposition", disposition)
 	}
 
-	// Range requests: serve a slice of the already-materialized object.
-	rangeHeader := r.Header.Get("Range")
-	if rangeHeader != "" && cachedSize > 0 {
-		rng, parseErr := parseRangeHeader(rangeHeader, cachedSize)
+	// Build the byte plan: which chunks to read and the (skip, take) slice within
+	// each. Full GET takes every chunk whole; a range takes only overlapping
+	// chunks, trimmed to the requested bounds.
+	type chunkSlice struct {
+		desc chunkDesc
+		skip int64
+		take int64
+	}
+	var (
+		plan    []chunkSlice
+		rng     *httpRange
+		isRange bool
+	)
+	if rh := r.Header.Get("Range"); rh != "" && cachedSize > 0 {
+		parsed, parseErr := parseRangeHeader(rh, cachedSize)
 		if parseErr != nil {
 			writeRangeNotSatisfiable(w, cachedSize)
 			return nil
 		}
+		rng = parsed
+		isRange = true
+		for _, d := range descs {
+			chunkStart := d.offset
+			chunkEnd := d.offset + d.size - 1
+			if chunkEnd < rng.start {
+				continue
+			}
+			if chunkStart > rng.end {
+				break
+			}
+			skip := int64(0)
+			if rng.start > chunkStart {
+				skip = rng.start - chunkStart
+			}
+			takeEnd := chunkEnd
+			if rng.end < takeEnd {
+				takeEnd = rng.end
+			}
+			plan = append(plan, chunkSlice{desc: d, skip: skip, take: takeEnd - (chunkStart + skip) + 1})
+		}
+	} else {
+		for _, d := range descs {
+			plan = append(plan, chunkSlice{desc: d, skip: 0, take: d.size})
+		}
+	}
+
+	write200Headers := func() {
+		w.Header().Set("Content-Type", contentType)
 		w.Header().Set("x-amz-request-id", generateRequestID())
 		if w.Header().Get("x-amz-version-id") == "" {
 			w.Header().Set("x-amz-version-id", "null")
 		}
-		if serveErr := serveRange(w, bytes.NewReader(data), rng, cachedSize, contentType); serveErr != nil {
-			a.logger.Error("chunked range serve failed",
-				zap.Error(serveErr),
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Cache-Control", "private, no-cache")
+		w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(cachedBackendName))
+		if cachedSize > 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
+		}
+		if cachedETag != "" {
+			w.Header().Set("ETag", fmt.Sprintf(`"%s"`, cachedETag))
+		}
+		if !cachedUpdatedAt.IsZero() {
+			w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
+		}
+		setS3MetadataHeaders(w, cachedMetadata)
+		if n := tagCount(cachedTags); n > 0 {
+			w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
+		}
+	}
+	write206Headers := func() {
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, cachedSize))
+		w.Header().Set("Content-Length", strconv.FormatInt(rng.length, 10))
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("x-amz-request-id", generateRequestID())
+		if w.Header().Get("x-amz-version-id") == "" {
+			w.Header().Set("x-amz-version-id", "null")
+		}
+		w.WriteHeader(http.StatusPartialContent)
+	}
+
+	// Stream the plan. The first chunk is fetched + verified BEFORE headers are
+	// committed, so a corrupt first chunk produces a clean 500. After that the
+	// status is fixed; a failure aborts the body without serving bad bytes.
+	headersWritten := false
+	var written int64
+	for _, p := range plan {
+		data, ferr := a.fetchAndVerifyChunk(ctx, p.desc)
+		if ferr != nil {
+			if !headersWritten {
+				if errors.Is(ferr, errChunkIntegrity) {
+					a.logger.Error("chunk integrity verification failed",
+						zap.Error(ferr),
+						zap.String("bucket", bucket),
+						zap.String("artifact", artifact),
+						zap.String("chunk", p.desc.plaintextHash))
+					WriteS3Error(w, ErrInternalError, r.URL.Path, generateRequestID())
+					return nil
+				}
+				// Unresolved/unavailable before any byte is written — fall through.
+				return ferr
+			}
+			a.logger.Error("chunk failure mid-stream; aborting response",
+				zap.Error(ferr),
+				zap.String("bucket", bucket),
+				zap.String("artifact", artifact))
+			return nil
+		}
+
+		if !headersWritten {
+			if isRange {
+				write206Headers()
+			} else {
+				write200Headers()
+			}
+			headersWritten = true
+		}
+
+		slice := data
+		if p.skip != 0 || p.take != int64(len(data)) {
+			end := p.skip + p.take
+			if end > int64(len(data)) {
+				end = int64(len(data))
+			}
+			slice = data[p.skip:end]
+		}
+		n, werr := w.Write(slice)
+		written += int64(n)
+		if werr != nil {
+			a.logger.Error("failed to stream chunk to client",
+				zap.Error(werr),
 				zap.String("container", container),
 				zap.String("artifact", artifact))
+			return nil
 		}
-		return nil
 	}
 
-	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("x-amz-request-id", generateRequestID())
-	if w.Header().Get("x-amz-version-id") == "" {
-		w.Header().Set("x-amz-version-id", "null")
-	}
-	w.Header().Set("Accept-Ranges", "bytes")
-	w.Header().Set("Cache-Control", "private, no-cache")
-	w.Header().Set("x-amz-storage-class", engine.BackendToStorageClass(cachedBackendName))
-	if cachedSize > 0 {
-		w.Header().Set("Content-Length", strconv.FormatInt(cachedSize, 10))
-	}
-	if cachedETag != "" {
-		w.Header().Set("ETag", fmt.Sprintf(`"%s"`, cachedETag))
-	}
-	if !cachedUpdatedAt.IsZero() {
-		w.Header().Set("Last-Modified", cachedUpdatedAt.UTC().Format(http.TimeFormat))
-	}
-	setS3MetadataHeaders(w, cachedMetadata)
-	if n := tagCount(cachedTags); n > 0 {
-		w.Header().Set("x-amz-tagging-count", strconv.Itoa(n))
-	}
-
-	written, err := io.Copy(w, bytes.NewReader(data))
-	if err != nil {
-		a.logger.Error("failed to stream chunked artifact",
-			zap.Error(err),
-			zap.String("container", container),
-			zap.String("artifact", artifact))
-		return nil
+	// Defensive: a zero-length object/plan still gets a valid response.
+	if !headersWritten {
+		write200Headers()
+		w.WriteHeader(http.StatusOK)
 	}
 
 	a.logger.Info("chunked artifact retrieved",
 		zap.String("s3.bucket", bucket),
 		zap.String("s3.object", artifact),
 		zap.String("engine.container", container),
-		zap.Int("chunks", len(refs)),
+		zap.Int("chunks", len(plan)),
 		zap.Int64("bytes", written))
 
 	emitEvent(ctx, a.db, a.logger, "object.downloaded", t.ID, map[string]interface{}{

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -55,11 +55,12 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 2. If chunked → `gci.DeleteObjectChunks` (transactional: deletes refs, decrements counts, deletes object_metadata)
 3. Chunk data stays until GC (Phase 8.7) — `marked_for_deletion=TRUE` when `ref_count=0`. GC must delete from the `_global` container (using each GCI entry's `storage_key`/`backend_id`), not a tenant namespace.
 
-**GET flow** (s3_engine_adapter.go `handleChunkedGet`, Phase 8.5):
+**GET flow** (s3_engine_adapter.go `handleChunkedGet`, Phase 8.5 → streaming in 8.6):
 1. `HandleGet` reads `is_chunked` from `object_head_cache`; if set and `gci != nil`, branches before the normal `engine.Get`
-2. `GetObjectChunks` → ordered manifest; per chunk `LookupChunk` → storage key + `BackendID` (used to `HintBackend` so retrieval is deterministic after a cold restart)
-3. Sequential `engine.Get(_global, "_chunks/{sha256}")` per chunk, concatenated into a buffer in `chunk_index` order (byte-identical to upload → plaintext ETag matches). Cross-bucket and cross-tenant dedup retrieval both work because chunks live in the shared `_global` container.
-4. Serves with full headers + range support (range = slice of the buffered object). On any pre-write failure, falls through to the normal path (→ NoSuchKey). HEAD needs no chunk-aware logic — `object_head_cache` already holds plaintext size/ETag.
+2. Preflight: `GetObjectChunks` → ordered manifest; per chunk `LookupChunk` resolves storage key + `BackendID` + `SizeBytes` WITHOUT reading data. A missing index entry → return error → caller falls through (→ NoSuchKey). Done before any byte is written.
+3. **Bounded streaming** (8.6): each chunk is read into a bounded buffer (≤ max chunk size, ~16 MB) via `fetchAndVerifyChunk` (`HintBackend` → `engine.Get(_global, "_chunks/{sha256}")`), its SHA-256 verified against the expected plaintext hash, then written to the response. Peak memory is ONE chunk, not the whole object (was a full `bytes.Buffer` in 8.5 — violated "always stream"). Order is `chunk_index` ASC → byte-identical to upload → plaintext ETag matches. Cross-bucket/cross-tenant retrieval works because chunks live in shared `_global`.
+4. Range requests touch only chunks overlapping `[start,end]`, located via `tenant_chunk_refs.chunk_offset` + per-chunk `SizeBytes`; the first/last overlapping chunks are trimmed (`skip`/`take`). No whole-object materialization.
+5. **Integrity** (8.6): corrupt chunk (sha256 mismatch) → never served. First-chunk corruption → clean 500 (`errChunkIntegrity`, handled here, NOT a fallthrough to 404 — corrupt ≠ missing). Mid-stream failure → body aborted (short read the client detects), status already committed. HEAD needs no chunk-aware logic — `object_head_cache` already holds plaintext size/ETag.
 
 **Constraints**: chunking is mutually exclusive with SSE-S3/SSE-C in this phase. Convergent encryption (Phase 10) will enable per-chunk encryption + dedup.
 


### PR DESCRIPTION
## Phase 8.6: Bounded-streaming chunked GET + read-time integrity

Two of the risks flagged after Phase 8.5, fixed together in one read-path rewrite
(they touch the same function). The third (>256 MB SSE encryption gap) is a
product/availability decision and is **left tracked, not auto-fixed** — see below.

### Problem
`handleChunkedGet` reassembled the **entire object** into a `bytes.Buffer` before
serving. Peak memory scaled with object size (a 5 GB GET = 5 GB RAM), violating
CLAUDE.md non-negotiable #4 ("always stream, never buffer"). It also trusted
chunk bytes blindly — one corrupted chunk would be served as a clean 200.

### Fix — bounded streaming + integrity (one chunk at a time)
- Read each chunk into a buffer capped at the **max chunk size (~16 MB)**, verify
  its SHA-256 against the expected `plaintext_hash`, then write it. **Peak memory
  is one chunk regardless of object size.**
- **Manifest preflight**: all chunk index entries are resolved *before* any byte
  is written, so a resolution failure still falls through to the normal path
  (→ NoSuchKey). Fallthrough safety is preserved up to the first committed byte.
- **Range**: touch only chunks overlapping `[start,end]`, located via
  `tenant_chunk_refs.chunk_offset` + per-chunk `size_bytes`; trim the first/last.
  No whole-object materialization.
- **Integrity**: corrupt first chunk → clean **500** (`errChunkIntegrity`, handled
  here — corrupt ≠ missing, so *not* a 404 fallthrough). Mid-stream failure aborts
  the body (a short read the client detects) rather than serving bad bytes.

### Tests
- `TestHandleGet_ChunkedObject_MultiChunkRanges` — 20 MB object, range matrix:
  spans-multiple-chunks / suffix (`bytes=-N`) / open-ended (`bytes=N-`) / single-byte
- `TestHandleGet_ChunkedObject_CorruptChunk` (was RED) — overwrites the stored chunk
  in `_global`, asserts **500** and that the original bytes are not served
- All prior chunking tests (incl. cross-bucket/cross-tenant dedup, multi-chunk
  full GET) still green; full `internal/api -race` suite green; lint clean

### Deliberately NOT in this PR
- **>256 MB SSE encryption gap** — the only interim fix (reject >256 MB uploads to
  `sse_enabled` buckets) breaks the backups/archives use case since `sse_enabled`
  defaults TRUE. That's a product call; real fix is streaming/chunk-level encryption
  (Phase 10). Tracked.
- **Chunked PUT still `io.ReadAll`s the whole object** — write-side streaming
  (via the existing FastCDC `Chunk()` streaming API) is a separate follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)