### PR TITLE
fix(engine): reject oversize uploads when SSE is required, never store plaintext

### DIFF
--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -205,6 +205,8 @@ Transparent server-side encryption at rest using ML-KEM-768 (post-quantum key en
 4. EncryptBytes → ciphertext (plaintext + 1117B overhead)
 5. engine.Put with ciphertext; object_head_cache stores plaintext size + encryption_algorithm
 
+**Oversize guard**: when encryption is required (header `x-amz-server-side-encryption: AES256` OR bucket `sse_enabled`) but the object exceeds `crypto.MaxEncryptableSize` (256 MiB), SSE is skipped (whole-object GCM can't buffer it) — the request is **rejected with `EntityTooLarge` (413)** rather than silently stored as plaintext, which would violate the bucket's encryption guarantee. (SSE-C rejects oversize in its own branch.) The real fix is streaming/chunk-level encryption (future phase).
+
 **GET flow** (s3_engine_adapter.go HandleGet):
 1. Query encryption_algorithm from object_head_cache
 2. engine.Get → encrypted blob

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -625,6 +625,22 @@ func (a *S3ToEngine) HandlePut(w http.ResponseWriter, r *http.Request, bucket, o
 		}
 	}
 
+	// Encryption-required guard: SSE-S3 encrypts the whole object in memory and
+	// is capped at crypto.MaxEncryptableSize. When encryption is required (an
+	// explicit x-amz-server-side-encryption header, or a bucket that defaults to
+	// SSE) but the object exceeds that cap, SSE was skipped above
+	// (encryptionAlgorithm == ""). Silently storing such an object as plaintext
+	// would violate the bucket's encryption guarantee, so reject it instead.
+	// (SSE-C already rejects oversize objects in its own branch above.)
+	// The real fix — streaming/chunk-level encryption — is a future phase.
+	if a.sseService != nil && encryptionAlgorithm == "" && metadataSize > crypto.MaxEncryptableSize &&
+		(r.Header.Get("x-amz-server-side-encryption") == "AES256" ||
+			isBucketSSEEnabled(r.Context(), a.db, t.ID, bucket)) {
+		WriteS3ErrorWithContext(w, ErrEntityTooLarge, r.URL.Path, generateRequestID(),
+			WithSuggestion("Objects larger than 256 MiB cannot yet be server-side encrypted. Upload without encryption, or split the object."))
+		return
+	}
+
 	// Chunked upload path: objects above the threshold that are NOT encrypted
 	// are split into content-defined chunks and deduplicated via the GCI.
 	// Chunked objects skip the normal engine.Put — each chunk is stored

--- a/internal/api/s3_sse_oversize_test.go
+++ b/internal/api/s3_sse_oversize_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FairForge/vaultaire/internal/crypto"
+	"github.com/FairForge/vaultaire/internal/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 64 hex chars = 32-byte SSE-S3 master key.
+const testSSEMasterKey = "abababababababababababababababababababababababababababababababab"
+
+// oversizePut issues a PUT whose declared Content-Length exceeds the SSE size
+// cap while sending only a tiny body. The reject-guard runs before the body is
+// read, so this exercises the size gate without allocating 256+ MiB.
+func oversizePut(t *testing.T, f *adapterTestFixture, key string, mutate func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/test-bucket/"+key, bytes.NewReader([]byte("tiny")))
+	req.ContentLength = crypto.MaxEncryptableSize + 1 // just over the cap
+	if mutate != nil {
+		mutate(req)
+	}
+	req = req.WithContext(tenant.WithTenant(req.Context(), f.tenant))
+	w := httptest.NewRecorder()
+	f.adapter.HandlePut(w, req, "test-bucket", key)
+	return w
+}
+
+// TestHandlePut_SSEHeaderOversize_Rejected: an explicit SSE-S3 request for an
+// object larger than the encryptable cap must be rejected, never stored plaintext.
+func TestHandlePut_SSEHeaderOversize_Rejected(t *testing.T) {
+	f := setupChunkingFixture(t)
+	svc, err := crypto.NewSSEService(f.db, testSSEMasterKey)
+	require.NoError(t, err)
+	f.adapter.sseService = svc
+
+	w := oversizePut(t, f, "sse-header-big.bin", func(r *http.Request) {
+		r.Header.Set("x-amz-server-side-encryption", "AES256")
+	})
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "oversize SSE-S3 object must be rejected (EntityTooLarge)")
+
+	// And it must NOT have been stored.
+	var count int
+	require.NoError(t, f.db.QueryRow(`SELECT COUNT(*) FROM object_head_cache
+		WHERE tenant_id=$1 AND bucket=$2 AND object_key=$3`,
+		f.tenantID, "test-bucket", "sse-header-big.bin").Scan(&count))
+	assert.Equal(t, 0, count, "rejected object must not be persisted")
+}
+
+// TestHandlePut_SSEBucketOversize_Rejected: a bucket that defaults to SSE must
+// reject oversize objects rather than silently storing them unencrypted.
+func TestHandlePut_SSEBucketOversize_Rejected(t *testing.T) {
+	f := setupChunkingFixture(t)
+	svc, err := crypto.NewSSEService(f.db, testSSEMasterKey)
+	require.NoError(t, err)
+	f.adapter.sseService = svc
+
+	// Mark the bucket SSE-enabled.
+	_, err = f.db.Exec(`INSERT INTO buckets (tenant_id, name, sse_enabled)
+		VALUES ($1,$2,TRUE)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET sse_enabled = TRUE`,
+		f.tenantID, "test-bucket")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = f.db.Exec(`DELETE FROM buckets WHERE tenant_id=$1 AND name=$2`, f.tenantID, "test-bucket")
+	})
+
+	w := oversizePut(t, f, "sse-bucket-big.bin", nil)
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "oversize object in SSE bucket must be rejected")
+}
+
+// TestHandlePut_NoSSEOversize_NotRejected: large objects WITHOUT encryption must
+// still be accepted (the guard only fires when encryption is required).
+func TestHandlePut_NoSSEOversize_NotRejected(t *testing.T) {
+	f := setupChunkingFixture(t)
+	svc, err := crypto.NewSSEService(f.db, testSSEMasterKey)
+	require.NoError(t, err)
+	f.adapter.sseService = svc // service present, but no SSE requested for this bucket/object
+
+	w := oversizePut(t, f, "plain-big.bin", nil)
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, w.Code,
+		"large non-encrypted object must not be rejected by the SSE guard")
+}


### PR DESCRIPTION
## Live encryption breach: >256 MiB objects stored plaintext in SSE buckets

SSE-S3 encrypts the whole object in memory, capped at `MaxEncryptableSize` (256 MiB).
For an object **larger than the cap** in an SSE context — explicit
`x-amz-server-side-encryption: AES256` header OR a bucket with `sse_enabled` —
`shouldEncrypt` was false, so encryption was skipped and the object was stored
**unencrypted** (plaintext chunks if over the chunk threshold, else a plaintext
normal PUT).

A customer who believes the bucket is encrypted-at-rest had large objects silently
stored in the clear. This is **not** gated behind chunking (it hits the normal PUT
path too), so with SSE enabled in production it affects live uploads today.

### Fix
Add a guard after the encryption decision in `HandlePut`: if encryption is required
and the object exceeds the cap, **reject with `EntityTooLarge` (413)** rather than
silently storing plaintext. This mirrors SSE-C, which already rejects oversize
objects. The real fix — streaming/chunk-level encryption — is a planned follow-on
(Option C / Phase 10); this stops the silent-plaintext breach now.

### Tests (TDD — the two reject cases were RED)
- oversize + `x-amz-server-side-encryption: AES256` → 413, and not persisted
- oversize + `sse_enabled` bucket → 413
- oversize **without** SSE → still accepted (guard fires only when encryption is required)

Tests use a large declared `Content-Length` with a tiny body, so the guard is
exercised without allocating 256+ MiB (it runs before the body is read).

### Follow-ups (tracked, not here)
- Real fix: streaming SSE so large objects can actually be encrypted (Option C, or convergent/Phase 10)
- `SSE-requested-but-service-nil` and unknown-`Content-Length` SSE uploads are separate pre-existing gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)