### PR TITLE
fix(engine): atomically replace chunk manifest on overwrite [Phase 8.6.1]

### DIFF
--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -374,6 +374,72 @@ func TestHandleGet_ChunkedObject_CorruptChunk(t *testing.T) {
 	assert.NotEqual(t, content, gw.Body.Bytes(), "original/correct bytes must not be served")
 }
 
+// TestChunkedOverwrite_FewerChunks_ReplacesManifest verifies that overwriting a
+// chunked object with a smaller one fully replaces the manifest — stale
+// higher-index chunk refs from the previous version must not linger and corrupt
+// the GET.
+func TestChunkedOverwrite_FewerChunks_ReplacesManifest(t *testing.T) {
+	f := setupChunkingFixture(t)
+	key := "overwrite.bin"
+
+	big := generateTestData(20 * 1024 * 1024) // many chunks
+	putChunkedObject(t, f, key, big, "application/octet-stream")
+
+	small := generateTestData(8 * 1024) // single chunk, still > 1KB threshold
+	putChunkedObject(t, f, key, small, "application/octet-stream")
+
+	gw := getChunkedAs(t, f, f.tenant, "test-bucket", key)
+	require.Equal(t, http.StatusOK, gw.Code)
+	require.Equal(t, small, gw.Body.Bytes(),
+		"overwrite must replace the manifest, not append stale chunks from the previous version")
+
+	// The new manifest must contain exactly the new object's chunk count.
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+	var refCount int
+	require.NoError(t, f.db.QueryRow(`
+		SELECT COUNT(*) FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3`,
+		tenantUUID, "test-bucket", key).Scan(&refCount))
+	assert.Equal(t, 1, refCount, "8 KB object should leave exactly one chunk ref")
+}
+
+// TestChunkedOverwrite_ReleasesOldChunkRefs verifies that overwriting a chunked
+// object decrements the previous version's chunk references (no ref-count leak).
+func TestChunkedOverwrite_ReleasesOldChunkRefs(t *testing.T) {
+	f := setupChunkingFixture(t)
+	key := "release.bin"
+
+	contentA := generateTestData(8 * 1024)
+	putChunkedObject(t, f, key, contentA, "application/octet-stream")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+	var oldHash string
+	require.NoError(t, f.db.QueryRow(`
+		SELECT plaintext_hash FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3 ORDER BY chunk_index LIMIT 1`,
+		tenantUUID, "test-bucket", key).Scan(&oldHash))
+
+	// Overwrite with different content (different chunk hash).
+	contentB := generateTestData(8 * 1024)
+	putChunkedObject(t, f, key, contentB, "application/octet-stream")
+
+	// The old version's chunk should have been released (ref_count 0 → marked).
+	var refCount int
+	var marked bool
+	require.NoError(t, f.db.QueryRow(`
+		SELECT ref_count, marked_for_deletion FROM global_content_index WHERE plaintext_hash = $1`,
+		oldHash).Scan(&refCount, &marked))
+	assert.Equal(t, 0, refCount, "overwritten object's old chunk must be released, not leaked")
+	assert.True(t, marked, "released chunk (ref_count 0) should be marked_for_deletion")
+
+	// New content still round-trips.
+	gw := getChunkedAs(t, f, f.tenant, "test-bucket", key)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, contentB, gw.Body.Bytes())
+}
+
 func setupChunkingFixture(t *testing.T) *adapterTestFixture {
 	t.Helper()
 

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -852,6 +852,11 @@ func (a *S3ToEngine) handleChunkedPut(
 	var physicalSize int64
 	backendName := "chunked"
 
+	// Store/dedup each chunk's data and global index entry, and collect the new
+	// manifest. New chunks are ref-counted up front (InsertChunk/IncrementRef);
+	// the manifest itself is swapped in atomically below so an overwrite never
+	// leaves stale refs or leaks the previous version's chunk references.
+	newRefs := make([]crypto.TenantChunkRef, 0, len(chunks))
 	for _, chunk := range chunks {
 		result := lookups[chunk.Hash]
 		storageKey := "_chunks/" + chunk.Hash
@@ -882,7 +887,7 @@ func (a *S3ToEngine) handleChunkedPut(
 			}
 		}
 
-		if refErr := a.gci.AddTenantChunkRef(ctx, &crypto.TenantChunkRef{
+		newRefs = append(newRefs, crypto.TenantChunkRef{
 			TenantID:             tenantUUID,
 			BucketName:           bucket,
 			ObjectKey:            artifact,
@@ -890,9 +895,7 @@ func (a *S3ToEngine) handleChunkedPut(
 			ChunkOffset:          chunk.Offset,
 			PlaintextHash:        chunk.Hash,
 			EncryptionKeyVersion: 1,
-		}); refErr != nil {
-			return fmt.Errorf("add tenant chunk ref: %w", refErr)
-		}
+		})
 	}
 
 	if physicalSize == 0 {
@@ -908,7 +911,9 @@ func (a *S3ToEngine) handleChunkedPut(
 		contentType = "application/octet-stream"
 	}
 
-	if metaErr := a.gci.SaveObjectMetadata(ctx, &crypto.ObjectMeta{
+	// Atomically install the new manifest and release any previous version's
+	// chunk references (single transaction — no stale refs, no ref leak).
+	if metaErr := a.gci.ReplaceObjectManifest(ctx, tenantUUID, bucket, artifact, newRefs, &crypto.ObjectMeta{
 		TenantID:     tenantUUID,
 		BucketName:   bucket,
 		ObjectKey:    artifact,
@@ -919,7 +924,7 @@ func (a *S3ToEngine) handleChunkedPut(
 		PhysicalSize: &physicalSize,
 		DedupRatio:   &dedupRatio,
 	}); metaErr != nil {
-		return fmt.Errorf("save object metadata: %w", metaErr)
+		return fmt.Errorf("replace object manifest: %w", metaErr)
 	}
 
 	etag := fmt.Sprintf("%x", hasher.Sum(nil))

--- a/internal/crypto/CLAUDE.md
+++ b/internal/crypto/CLAUDE.md
@@ -41,14 +41,14 @@ Encryption, key management, and post-quantum cryptography for Vaultaire.
 **Global chunk store** (Phase 8.5.1): chunks are stored in a shared, tenant-independent container `_global` (const `chunkContainer` in s3_engine_adapter.go), NOT the per-tenant/bucket namespace. Because dedup spans tenants, a chunk first written by tenant A / bucket X must be reachable when tenant B / bucket Y dedups against it — storing in the writer's namespace made cross-bucket/cross-tenant GETs 404. Isolation is preserved at the manifest layer: a tenant reaches a chunk only through its own `tenant_chunk_refs` (queried by `tenant_id`), and `_global` is not addressable via the S3 API (all S3 paths route through `tenant/{id}/{bucket}`).
 
 - **chunker.go** — FastCDC chunker (1 MB min / 4 MB avg / 16 MB max) using `restic/chunker`. `ChunkBytes()` for sync, `Chunk()` for streaming. SHA-256 per chunk.
-- **gci.go** — `GlobalContentIndex`: DB-backed dedup index with 100K-entry in-memory cache. Batch lookups (`LookupChunks`), ref counting (`IncrementRef`/`DecrementRef`), tenant chunk manifests (`AddTenantChunkRef`), object metadata (`SaveObjectMetadata`), transactional delete (`DeleteObjectChunks`).
+- **gci.go** — `GlobalContentIndex`: DB-backed dedup index with 100K-entry in-memory cache. Batch lookups (`LookupChunks`), ref counting (`IncrementRef`/`DecrementRef`), tenant chunk manifests (`AddTenantChunkRef`), object metadata (`SaveObjectMetadata`), transactional delete (`DeleteObjectChunks`), atomic manifest swap on overwrite (`ReplaceObjectManifest` — releases old refs + installs new manifest + metadata in one tx).
 
 **PUT flow** (s3_engine_adapter.go `handleChunkedPut`):
 1. Gate: `gci != nil && size > threshold && no encryption`
 2. Parse tenant UUID (skip chunking if non-UUID tenant)
 3. `ReadAll` through MD5 hasher → `ChunkBytes` → batch `LookupChunks`
-4. For each chunk: if new → `engine.Put(_global, "_chunks/{sha256}")` + `InsertChunk`; if existing → `IncrementRef`
-5. `AddTenantChunkRef` per chunk, `SaveObjectMetadata`, `object_head_cache` with `is_chunked=TRUE`
+4. For each chunk: if new → `engine.Put(_global, "_chunks/{sha256}")` + `InsertChunk`; if existing → `IncrementRef`. Collect the new manifest refs.
+5. `ReplaceObjectManifest` (single tx): release the previous version's chunk refs (decrement counts) + install the new manifest + upsert `object_metadata` — **atomic**, so overwriting a key never leaves stale higher-index refs (GET corruption) or leaks old chunk refs. New chunks are IncrementRef'd in step 4 *before* this, so a chunk shared between old and new versions never transiently hits ref_count 0. Then `object_head_cache` with `is_chunked=TRUE`.
 
 **DELETE flow** (s3_engine_adapter.go `HandleDelete`):
 1. Query `is_chunked` from `object_head_cache`

--- a/internal/crypto/gci.go
+++ b/internal/crypto/gci.go
@@ -407,6 +407,110 @@ func (g *GlobalContentIndex) DeleteObjectChunks(ctx context.Context, tenantID uu
 	return tx.Commit()
 }
 
+// ReplaceObjectManifest atomically swaps an object's chunk manifest. In a single
+// transaction it releases the previous version's chunk references (decrementing
+// their global ref counts), installs the new manifest, and upserts the object
+// metadata — so a reader never observes a mixed or partial manifest and an
+// overwritten object's old chunks do not leak their references.
+//
+// The NEW chunks' data and global_content_index entries (InsertChunk/IncrementRef)
+// must already be persisted before calling this. Callers should IncrementRef new
+// chunks BEFORE this call so that a chunk shared between the old and new versions
+// never transiently drops to ref_count 0 (which would mark it for deletion).
+func (g *GlobalContentIndex) ReplaceObjectManifest(ctx context.Context, tenantID uuid.UUID, bucket, key string, newRefs []TenantChunkRef, meta *ObjectMeta) error {
+	tx, err := g.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin manifest swap: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Capture the previous version's chunk hashes so we can release them.
+	rows, err := tx.QueryContext(ctx, `
+		SELECT plaintext_hash FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3
+	`, tenantID, bucket, key)
+	if err != nil {
+		return fmt.Errorf("read previous manifest: %w", err)
+	}
+	var oldHashes []string
+	for rows.Next() {
+		var h string
+		if scanErr := rows.Scan(&h); scanErr != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan previous hash: %w", scanErr)
+		}
+		oldHashes = append(oldHashes, h)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate previous manifest: %w", err)
+	}
+
+	// Remove the old manifest and release its chunk references.
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM tenant_chunk_refs
+		WHERE tenant_id = $1 AND bucket_name = $2 AND object_key = $3
+	`, tenantID, bucket, key); err != nil {
+		return fmt.Errorf("delete previous manifest: %w", err)
+	}
+	for _, h := range oldHashes {
+		if _, err := tx.ExecContext(ctx, `SELECT decrement_chunk_ref($1)`, h); err != nil {
+			return fmt.Errorf("release chunk %s: %w", h, err)
+		}
+	}
+
+	// Install the new manifest.
+	for i := range newRefs {
+		ref := &newRefs[i]
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO tenant_chunk_refs
+			(tenant_id, bucket_name, object_key, chunk_index, chunk_offset,
+			 plaintext_hash, encryption_key_version, ciphertext_hash)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (tenant_id, bucket_name, object_key, chunk_index) DO UPDATE SET
+				chunk_offset = EXCLUDED.chunk_offset,
+				plaintext_hash = EXCLUDED.plaintext_hash,
+				encryption_key_version = EXCLUDED.encryption_key_version,
+				ciphertext_hash = EXCLUDED.ciphertext_hash
+		`, ref.TenantID, ref.BucketName, ref.ObjectKey, ref.ChunkIndex,
+			ref.ChunkOffset, ref.PlaintextHash, ref.EncryptionKeyVersion, ref.CiphertextHash); err != nil {
+			return fmt.Errorf("insert chunk ref %d: %w", ref.ChunkIndex, err)
+		}
+	}
+
+	// Upsert object metadata.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO object_metadata
+		(tenant_id, bucket_name, object_key, total_size, chunk_count, content_hash,
+		 content_type, logical_size, physical_size, dedup_ratio, pipeline_config)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		ON CONFLICT (tenant_id, bucket_name, object_key) DO UPDATE SET
+			total_size = EXCLUDED.total_size,
+			chunk_count = EXCLUDED.chunk_count,
+			content_hash = EXCLUDED.content_hash,
+			content_type = EXCLUDED.content_type,
+			logical_size = EXCLUDED.logical_size,
+			physical_size = EXCLUDED.physical_size,
+			dedup_ratio = EXCLUDED.dedup_ratio,
+			pipeline_config = EXCLUDED.pipeline_config,
+			updated_at = NOW()
+	`, meta.TenantID, meta.BucketName, meta.ObjectKey, meta.TotalSize,
+		meta.ChunkCount, meta.ContentHash, meta.ContentType, meta.LogicalSize,
+		meta.PhysicalSize, meta.DedupRatio, meta.PipelineConfig); err != nil {
+		return fmt.Errorf("save object metadata: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit manifest swap: %w", err)
+	}
+
+	// Released chunks' ref counts changed — drop their cache entries.
+	for _, h := range oldHashes {
+		g.cache.delete(h)
+	}
+	return nil
+}
+
 // SaveObjectMetadata saves or updates object metadata
 func (g *GlobalContentIndex) SaveObjectMetadata(ctx context.Context, meta *ObjectMeta) error {
 	_, err := g.db.ExecContext(ctx, `


### PR DESCRIPTION
## Chunked overwrite corrupted data + leaked chunk refs (live in main)

`handleChunkedPut` never released a chunked object's previous manifest. Because
`tenant_chunk_refs` is upserted by `chunk_index`:
- **Fewer-chunk overwrite → data corruption.** Stale higher-index refs from the
  old version lingered, so GET reassembled old+new chunks. Verified: a
  20 MB → 8 KB overwrite returned **~19 MB** (mixed old+new) instead of 8 KB.
- **Any overwrite → ref-count leak.** The old version's chunks were never
  decremented, so they never become GC-eligible and dedup stats drift.

(As with the other chunking bugs, chunking isn't in production traffic yet, so no
customer data is harmed — but it was in `main`.)

### Fix — atomic manifest swap
New `GlobalContentIndex.ReplaceObjectManifest` does, in **one transaction**:
release the previous version's chunk refs (decrement counts) → install the new
manifest → upsert `object_metadata`. A reader never observes a mixed/partial
manifest. `handleChunkedPut` collects the new refs in its chunk loop and calls
this instead of per-chunk `AddTenantChunkRef` + `SaveObjectMetadata`. New chunks
are `IncrementRef`'d **before** the swap, so a chunk shared between the old and
new versions never transiently drops to `ref_count` 0 (which would mark it for
deletion).

### Tests (TDD — both were RED)
- `TestChunkedOverwrite_FewerChunks_ReplacesManifest` — 20 MB → 8 KB overwrite →
  GET == 8 KB, exactly one chunk ref remains
- `TestChunkedOverwrite_ReleasesOldChunkRefs` — overwrite with different content →
  old chunk released (`ref_count` 0, `marked_for_deletion`), new content round-trips

All prior chunking + GCI tests pass; `internal/api` and `internal/crypto` race
suites green; lint clean.

### Note
`object_head_cache` (size/ETag) is still updated just after the swap (one statement,
same as the non-chunked PUT path), so a concurrent reader during an overwrite could
briefly see new manifest + old size/ETag — a minor, non-corrupting window that also
exists for normal overwrites. Folding it into the swap tx is a possible later refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)