### PR TITLE
feat(dashboard): GCI dedup stats dashboard [Phase 8.6]

### DIFF
--- a/internal/dashboard/CLAUDE.md
+++ b/internal/dashboard/CLAUDE.md
@@ -98,6 +98,7 @@ Each session row in `dashboard_sessions` also tracks `ip_address`, `user_agent`,
 | `/admin/waitlist/export` | GET | session + admin | Download all waitlist signups as CSV |
 | `/admin/revenue` | GET | session + admin | Revenue dashboard: MRR, tier breakdown, churn, top customers |
 | `/admin/costs` | GET | session + admin | Cost dashboard: backend spend, per-tenant margin, negative-margin alerts |
+| `/admin/dedup` | GET | session + admin | GCI dedup dashboard: global ratio, savings, per-tenant breakdown |
 | `/admin/support` | GET | session + admin | Customer support search (email, tenant ID, access key, Stripe ID) |
 | `/admin/support/{id}` | GET | session + admin | Customer detail: info, timeline, S3 errors, notes, quick actions |
 | `/admin/support/{id}/notes` | POST | session + admin | Add internal admin note on a customer |

--- a/internal/dashboard/handlers/CLAUDE.md
+++ b/internal/dashboard/handlers/CLAUDE.md
@@ -198,6 +198,26 @@ Hidden when `object_locations` is empty. Complements the estimated ByBackend tab
 Template: `templates/admin/costs.html`. Nil-DB and empty-state both render 200
 with $0.00 zero-state.
 
+## Admin Dedup Dashboard (`admin_dedup.go`)
+
+`HandleAdminDedup(tmpl, db, logger)` — GET `/admin/dedup`: GCI deduplication stats.
+
+Global cards: dedup ratio, storage saved, logical vs physical bytes, chunk count.
+Per-tenant table: queries tenants with `object_metadata` rows, calls
+`crypto.GetTenantDedupStats` per tenant for logical/physical/saved/ratio.
+
+No migration — reads existing `global_content_index`, `object_metadata`, and the
+`get_tenant_dedup_ratio` SQL function from migration 051.
+
+DB errors or nil-DB degrade to zero-state (1.0x ratio, 0 B saved), never 500.
+
+Template: `templates/admin/dedup.html`. Types: `tenantDedupRow`.
+
+**Customer-facing dedup savings** (Phase 8.6): `populateDedupSavings` in `usage.go`
+adds a `DedupSavings` string to the usage page template data (e.g. "You've saved
+4.2 GB (32%) via deduplication") when the tenant has positive `BytesSaved`. Hidden
+when there's no chunked data or the tenant ID isn't a UUID.
+
 ## Admin Customer Support (`admin_support.go`)
 
 Three handlers for the admin customer support view (Phase 3.7):

--- a/internal/dashboard/handlers/admin_dedup.go
+++ b/internal/dashboard/handlers/admin_dedup.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/FairForge/vaultaire/internal/crypto"
+	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type tenantDedupRow struct {
+	Email       string
+	TenantID    string
+	LogicalFmt  string
+	PhysicalFmt string
+	SavedFmt    string
+	SavedPct    string
+	DedupRatio  string
+}
+
+func HandleAdminDedup(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sd := dashauth.GetSession(r.Context())
+		if sd == nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		data := sessionData(sd, "admin-dedup")
+		withCSRF(r.Context(), data)
+
+		data["DedupRatio"] = "1.0x"
+		data["StorageSaved"] = "0 B"
+		data["LogicalBytes"] = "0 B"
+		data["PhysicalBytes"] = "0 B"
+		data["ChunksProcessed"] = int64(0)
+		data["TenantTable"] = []tenantDedupRow{}
+
+		if db != nil {
+			populateDedupStats(r.Context(), db, data, logger)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.ExecuteTemplate(w, "admin", data); err != nil {
+			logger.Error("render admin dedup", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}
+
+func populateDedupStats(ctx context.Context, db *sql.DB, data map[string]any, logger *zap.Logger) {
+	gci := crypto.NewGlobalContentIndex(db)
+
+	stats, err := gci.GetGlobalDedupStats(ctx)
+	if err != nil {
+		logger.Debug("dedup: global stats", zap.Error(err))
+		return
+	}
+
+	data["DedupRatio"] = fmt.Sprintf("%.1fx", stats.DedupRatio)
+	data["StorageSaved"] = formatBytes(stats.BytesSaved)
+	data["LogicalBytes"] = formatBytes(stats.BytesLogical)
+	data["PhysicalBytes"] = formatBytes(stats.BytesPhysical)
+	data["ChunksProcessed"] = stats.ChunksProcessed
+
+	populateTenantDedup(ctx, db, gci, data, logger)
+}
+
+func populateTenantDedup(ctx context.Context, db *sql.DB, gci *crypto.GlobalContentIndex, data map[string]any, logger *zap.Logger) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT t.id, t.email
+		FROM tenants t
+		INNER JOIN object_metadata om ON om.tenant_id = t.id
+		ORDER BY t.email`)
+	if err != nil {
+		logger.Debug("dedup: query tenants with chunks", zap.Error(err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var table []tenantDedupRow
+	for rows.Next() {
+		var tidStr, email string
+		if err := rows.Scan(&tidStr, &email); err != nil {
+			logger.Debug("dedup: scan tenant", zap.Error(err))
+			continue
+		}
+		tid, err := uuid.Parse(tidStr)
+		if err != nil {
+			continue
+		}
+		ts, err := gci.GetTenantDedupStats(ctx, tid)
+		if err != nil {
+			logger.Debug("dedup: tenant stats", zap.String("tenant", tidStr), zap.Error(err))
+			continue
+		}
+		savedPct := "0%"
+		if ts.BytesLogical > 0 {
+			savedPct = fmt.Sprintf("%.0f%%", float64(ts.BytesSaved)/float64(ts.BytesLogical)*100)
+		}
+		table = append(table, tenantDedupRow{
+			Email:       email,
+			TenantID:    tidStr,
+			LogicalFmt:  formatBytes(ts.BytesLogical),
+			PhysicalFmt: formatBytes(ts.BytesPhysical),
+			SavedFmt:    formatBytes(ts.BytesSaved),
+			SavedPct:    savedPct,
+			DedupRatio:  fmt.Sprintf("%.1fx", ts.DedupRatio),
+		})
+	}
+
+	if len(table) > 0 {
+		data["TenantTable"] = table
+	}
+}

--- a/internal/dashboard/handlers/admin_dedup_test.go
+++ b/internal/dashboard/handlers/admin_dedup_test.go
@@ -1,0 +1,175 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testDedupTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.Must(template.New("admin").Parse(
+		`{{define "admin"}}{{block "content" .}}{{end}}{{end}}`))
+	template.Must(tmpl.Parse(
+		`{{define "title"}}Dedup{{end}}` +
+			`{{define "content"}}` +
+			`<span class="ratio">{{.DedupRatio}}</span>` +
+			`<span class="saved">{{.StorageSaved}}</span>` +
+			`<span class="logical">{{.LogicalBytes}}</span>` +
+			`<span class="physical">{{.PhysicalBytes}}</span>` +
+			`<span class="chunks">{{.ChunksProcessed}}</span>` +
+			`{{range .TenantTable}}<span class="tenant">{{.Email}} {{.LogicalFmt}} {{.PhysicalFmt}} {{.SavedFmt}} {{.SavedPct}} {{.DedupRatio}}</span>{{end}}` +
+			`{{if not .TenantTable}}<p>No tenants</p>{{end}}` +
+			`{{end}}`))
+	return tmpl
+}
+
+func TestHandleAdminDedup_RendersGlobalStats(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Global stats query: COUNT(*), SUM(size_bytes), SUM(saved)
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
+		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
+			AddRow(int64(100), int64(1024*1024*1024), int64(512*1024*1024)))
+
+	// Per-tenant query: no tenants with chunks
+	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}))
+
+	handler := HandleAdminDedup(testDedupTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// Logical = 1 GB + 512 MB = 1.5 GB, Physical = 1 GB, Ratio = 1.5x
+	assert.Contains(t, body, `<span class="ratio">1.5x</span>`)
+	assert.Contains(t, body, `<span class="saved">512 MB</span>`)
+	assert.Contains(t, body, `<span class="chunks">100</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminDedup_PerTenantTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Global stats
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
+		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
+			AddRow(int64(200), int64(2*1024*1024*1024), int64(1024*1024*1024)))
+
+	// Tenants with chunked objects
+	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}).
+			AddRow("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "alice@example.com").
+			AddRow("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22", "bob@example.com"))
+
+	// Tenant dedup stats for alice (get_tenant_dedup_ratio)
+	mock.ExpectQuery(`SELECT \* FROM get_tenant_dedup_ratio`).
+		WillReturnRows(sqlmock.NewRows([]string{"logical", "physical", "ratio"}).
+			AddRow(int64(1024*1024*1024), int64(768*1024*1024), float64(1.33)))
+
+	// Tenant dedup stats for bob
+	mock.ExpectQuery(`SELECT \* FROM get_tenant_dedup_ratio`).
+		WillReturnRows(sqlmock.NewRows([]string{"logical", "physical", "ratio"}).
+			AddRow(int64(2*1024*1024*1024), int64(1024*1024*1024), float64(2.0)))
+
+	handler := HandleAdminDedup(testDedupTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "alice@example.com")
+	assert.Contains(t, body, "bob@example.com")
+	assert.Contains(t, body, "1.3x") // alice's ratio
+	assert.Contains(t, body, "2.0x") // bob's ratio
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminDedup_EmptyNoChunks(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Global stats: no chunks
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
+		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
+			AddRow(int64(0), int64(0), int64(0)))
+
+	// No tenants
+	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}))
+
+	handler := HandleAdminDedup(testDedupTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="ratio">1.0x</span>`)
+	assert.Contains(t, body, `<span class="saved">0 B</span>`)
+	assert.Contains(t, body, `<span class="chunks">0</span>`)
+	assert.Contains(t, body, "No tenants")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAdminDedup_NilDB(t *testing.T) {
+	handler := HandleAdminDedup(testDedupTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="ratio">1.0x</span>`)
+	assert.Contains(t, body, `<span class="saved">0 B</span>`)
+	assert.Contains(t, body, `<span class="chunks">0</span>`)
+}
+
+func TestHandleAdminDedup_NoSession(t *testing.T) {
+	handler := HandleAdminDedup(testDedupTemplate(t), nil, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Equal(t, "/login", w.Header().Get("Location"))
+}
+
+func TestHandleAdminDedup_DBErrorDegrades(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Global stats query fails
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
+		WillReturnError(assert.AnError)
+
+	handler := HandleAdminDedup(testDedupTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `<span class="ratio">1.0x</span>`)
+	assert.Contains(t, body, `<span class="saved">0 B</span>`)
+}

--- a/internal/dashboard/handlers/usage.go
+++ b/internal/dashboard/handlers/usage.go
@@ -3,11 +3,14 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"html/template"
 	"net/http"
 	"time"
 
+	"github.com/FairForge/vaultaire/internal/crypto"
 	dashauth "github.com/FairForge/vaultaire/internal/dashboard/auth"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -39,6 +42,7 @@ func HandleUsage(tmpl *template.Template, db *sql.DB, logger *zap.Logger) http.H
 			populateUsageBandwidth(ctx, db, sd.TenantID, data)
 			populateUsageChart(ctx, db, sd.TenantID, data)
 			populateUsageHistory(ctx, db, sd.TenantID, data)
+			populateDedupSavings(ctx, db, sd.TenantID, data, logger)
 		} else {
 			setUsageDefaults(data)
 		}
@@ -155,6 +159,24 @@ func populateUsageHistory(ctx context.Context, db *sql.DB, tenantID string, data
 		})
 	}
 	data["UsageHistory"] = history
+}
+
+func populateDedupSavings(ctx context.Context, db *sql.DB, tenantID string, data map[string]any, logger *zap.Logger) {
+	tid, err := uuid.Parse(tenantID)
+	if err != nil {
+		return
+	}
+	gci := crypto.NewGlobalContentIndex(db)
+	stats, err := gci.GetTenantDedupStats(ctx, tid)
+	if err != nil {
+		logger.Debug("usage: dedup savings", zap.Error(err))
+		return
+	}
+	if stats.BytesSaved <= 0 {
+		return
+	}
+	pct := float64(stats.BytesSaved) / float64(stats.BytesLogical) * 100
+	data["DedupSavings"] = fmt.Sprintf("You've saved %s (%.0f%%) via deduplication", formatBytes(stats.BytesSaved), pct)
 }
 
 func setUsageDefaults(data map[string]any) {

--- a/internal/dashboard/router.go
+++ b/internal/dashboard/router.go
@@ -273,6 +273,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		"templates/layouts/admin.html",
 		"templates/admin/costs.html",
 	))
+	dedupTmpl := template.Must(template.ParseFS(Templates,
+		"templates/layouts/admin.html",
+		"templates/admin/dedup.html",
+	))
 	supportTmpl := template.Must(template.ParseFS(Templates,
 		"templates/layouts/admin.html",
 		"templates/admin/support.html",
@@ -318,6 +322,7 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 		ar.Get("/waitlist/export", handlers.HandleAdminWaitlistExport(deps.DB, deps.Logger))
 		ar.Get("/revenue", handlers.HandleAdminRevenue(revenueTmpl, deps.DB, deps.Logger))
 		ar.Get("/costs", handlers.HandleAdminCosts(costsTmpl, deps.DB, deps.Logger))
+		ar.Get("/dedup", handlers.HandleAdminDedup(dedupTmpl, deps.DB, deps.Logger))
 		ar.Get("/notifications", handlers.HandleAdminNotifications(notificationsTmpl, deps.DB, deps.Logger))
 		ar.Post("/notifications/read-all", handlers.HandleMarkAllRead(deps.DB, deps.Logger))
 		ar.Post("/notifications/{id}/read", handlers.HandleMarkRead(deps.DB, deps.Logger))

--- a/internal/dashboard/templates/admin/dedup.html
+++ b/internal/dashboard/templates/admin/dedup.html
@@ -1,0 +1,68 @@
+{{define "title"}}Dedup — stored.ge admin{{end}}
+{{define "content"}}
+<div class="dashboard-header">
+    <h1>Deduplication</h1>
+</div>
+
+<p class="text-muted" style="margin-bottom:1.5rem">Global Content Index deduplication statistics across all chunked objects.</p>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Dedup Ratio</div>
+        <div class="card-value">{{.DedupRatio}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Storage Saved</div>
+        <div class="card-value">{{.StorageSaved}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Logical Size</div>
+        <div class="card-value">{{.LogicalBytes}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Physical Size</div>
+        <div class="card-value">{{.PhysicalBytes}}</div>
+    </div>
+</div>
+
+<div class="card-grid" style="grid-template-columns:1fr">
+    <div class="card">
+        <div class="card-title">Chunks in Index</div>
+        <div class="card-value">{{.ChunksProcessed}}</div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title" style="margin-bottom:0.75rem">Per-Tenant Deduplication</div>
+    {{if .TenantTable}}
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Tenant</th>
+                    <th style="text-align:right">Logical</th>
+                    <th style="text-align:right">Physical</th>
+                    <th style="text-align:right">Saved</th>
+                    <th style="text-align:right">Saved %</th>
+                    <th style="text-align:right">Ratio</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .TenantTable}}
+                <tr>
+                    <td>{{.Email}}</td>
+                    <td style="text-align:right">{{.LogicalFmt}}</td>
+                    <td style="text-align:right">{{.PhysicalFmt}}</td>
+                    <td style="text-align:right">{{.SavedFmt}}</td>
+                    <td style="text-align:right">{{.SavedPct}}</td>
+                    <td style="text-align:right">{{.DedupRatio}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{else}}
+    <p class="text-muted">No tenants with chunked objects.</p>
+    {{end}}
+</div>
+{{end}}

--- a/internal/dashboard/templates/customer/usage.html
+++ b/internal/dashboard/templates/customer/usage.html
@@ -33,6 +33,13 @@
     </div>
 </div>
 
+{{if .DedupSavings}}
+<div class="card" style="margin-bottom:1.5rem">
+    <div class="card-title">Deduplication</div>
+    <div class="card-detail">{{.DedupSavings}}</div>
+</div>
+{{end}}
+
 {{if .HasChartData}}
 <div class="card" hx-get="/dashboard/usage" hx-trigger="every 30s" hx-select=".chart-wrap" hx-swap="innerHTML" hx-target=".chart-wrap">
     <div class="card-title">Bandwidth — Last 30 Days</div>

--- a/internal/dashboard/templates/layouts/admin.html
+++ b/internal/dashboard/templates/layouts/admin.html
@@ -26,6 +26,7 @@
                 <a href="/admin/waitlist" class="sidebar-link{{if eq .Page "admin-waitlist"}} sidebar-link--active{{end}}">Waitlist</a>
                 <a href="/admin/revenue" class="sidebar-link{{if eq .Page "admin-revenue"}} sidebar-link--active{{end}}">Revenue</a>
                 <a href="/admin/costs" class="sidebar-link{{if eq .Page "admin-costs"}} sidebar-link--active{{end}}">Costs</a>
+                <a href="/admin/dedup" class="sidebar-link{{if eq .Page "admin-dedup"}} sidebar-link--active{{end}}">Dedup</a>
                 <a href="/admin/notifications" class="sidebar-link{{if eq .Page "admin-notifications"}} sidebar-link--active{{end}}">Notifications <span hx-get="/admin/notifications/count" hx-trigger="load" hx-swap="innerHTML"></span></a>
                 <a href="/admin/abuse" class="sidebar-link{{if eq .Page "admin-abuse"}} sidebar-link--active{{end}}">Abuse Queue</a>
             </nav>


### PR DESCRIPTION
## Summary
- Admin dedup dashboard at `/admin/dedup` — global ratio, storage saved, logical vs physical bytes, chunk count, and per-tenant breakdown table (queries `global_content_index` + `object_metadata` + `get_tenant_dedup_ratio`)
- Customer-facing dedup savings stat on the usage page — "You've saved X (Y%) via deduplication" when `BytesSaved > 0`, hidden otherwise
- Nav link added to admin sidebar between Costs and Notifications

## Test plan
- [x] 6 new handler tests: global stats render, per-tenant table, empty/zero state, nil DB degradation, no session redirect, DB error degradation
- [x] All existing dashboard tests pass (no regressions)
- [x] `make lint` clean (0 issues)
- [x] `make test` all green
- [ ] CI `build-and-test` passes