### PR TITLE
fix(ci): eliminate two flaky tests at the root

### DIFF
--- a/internal/devops/pipeline_test.go
+++ b/internal/devops/pipeline_test.go
@@ -87,16 +87,17 @@ func TestPipeline_Run(t *testing.T) {
 	})
 
 	t.Run("executes pipeline", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		run, err := pipeline.Run(ctx, &RunOptions{})
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, run.ID())
-		// Run() starts a goroutine, so status may already be "running"
-		// by the time we check. Both are valid initial states.
-		status := run.Status()
-		assert.True(t, status == RunStatusPending || status == RunStatusRunning,
-			"expected pending or running, got %s", status)
+		// Run() executes asynchronously. Wait for it to finish, then assert the
+		// terminal status. Asserting a transient pending/running status here was
+		// racy — the run can complete before the check (the CI flake).
+		require.NoError(t, run.Wait(ctx))
+		assert.Equal(t, RunStatusSuccess, run.Status())
 	})
 }
 

--- a/internal/drivers/queue.go
+++ b/internal/drivers/queue.go
@@ -81,6 +81,14 @@ func (q *RequestQueue) Submit(ctx context.Context, priority int, fn func() error
 	// Priority is ignored in this simple implementation
 	// Could be added with a heap-based priority queue
 
+	// Reject an already-cancelled context deterministically. Without this, the
+	// enqueue select below races the `q.jobs <- job` case against `<-ctx.Done()`
+	// when both are ready, so a pre-cancelled context would sometimes enqueue the
+	// job and return nil instead of the cancellation error (the CI flake).
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	job := &job{
 		fn:     fn,
 		result: make(chan error, 1),


### PR DESCRIPTION
## Two CI flakes producing false reds — fixed at the root

Both surfaced this week on PRs that don't touch the failing packages
(`TestRequestQueue` false-red'd #305, `TestPipeline_Run` false-red'd #309). Routine
false reds train reflexive re-runs, which is how a *real* failure eventually hides in
the noise. Root-caused and fixed deterministically — not re-run-and-hope.

### 1. `RequestQueue.Submit` — a real (minor) code race
The enqueue `select` had `q.jobs <- job`, `<-ctx.Done()`, and `default` all potentially
ready at once. When the context was **already cancelled** and the queue had space, Go
picks a ready case at random — so ~half the time it enqueued the job and returned `nil`
instead of `context.Canceled`. Fix: reject an already-cancelled context up front. A
pre-cancelled context must never enqueue work — deterministic *and* more correct.

### 2. `TestPipeline_Run/executes_pipeline` — a racy test
It asserted a **transient** `pending`/`running` status of an asynchronous run; if the
goroutine finished before the check, the status was terminal and the assert failed. Fix:
`PipelineRun.Wait()` for completion, then assert `RunStatusSuccess` (no-executor jobs use
a default no-op executor, so success is deterministic). This also tests *more* — that the
pipeline actually runs to completion — than the flaky transient check.

### Verification
- Each test run **500× under `-race`** → clean (the queue race was ~50%/run pre-fix).
- Full `internal/drivers` + `internal/devops` packages green under `-race`; lint clean.

This should remove two of the recurring false-red sources. (The perpetually-red **gosec**
is separate and tracked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)