### PR TITLE
feat(engine): lossless zstd compression on chunked PUT/GET [Phase 9]

### DIFF
--- a/internal/api/s3_chunking_test.go
+++ b/internal/api/s3_chunking_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/FairForge/vaultaire/internal/crypto"
@@ -971,3 +972,139 @@ func (d *failingPutDriver) Delete(_ context.Context, _, _ string) error         
 func (d *failingPutDriver) List(_ context.Context, _, _ string) ([]string, error) { return nil, nil }
 func (d *failingPutDriver) Exists(_ context.Context, _, _ string) (bool, error)   { return false, nil }
 func (d *failingPutDriver) HealthCheck(_ context.Context) error                   { return nil }
+
+// --- Phase 9: Compression tests ---
+
+func TestHandlePut_CompressesTextChunks(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	// Highly compressible text data above chunking threshold
+	content := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 200))
+	putChunkedObject(t, f, "compressible.txt", content, "text/plain")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+
+	rows, err := f.db.Query(`
+		SELECT g.compressed_size, g.compression_algo, g.size_bytes
+		FROM tenant_chunk_refs r
+		JOIN global_content_index g ON g.plaintext_hash = r.plaintext_hash
+		WHERE r.tenant_id = $1 AND r.bucket_name = $2 AND r.object_key = $3`,
+		tenantUUID, "test-bucket", "compressible.txt")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var found int
+	for rows.Next() {
+		var compressedSize *int64
+		var algo *string
+		var sizeBytes int64
+		require.NoError(t, rows.Scan(&compressedSize, &algo, &sizeBytes))
+		found++
+		require.NotNil(t, compressedSize, "compressed_size should be set for compressible text")
+		require.NotNil(t, algo, "compression_algo should be set")
+		assert.Equal(t, "zstd", *algo)
+		assert.Less(t, *compressedSize, sizeBytes, "compressed size should be smaller than plaintext")
+	}
+	require.NoError(t, rows.Err())
+	assert.Greater(t, found, 0, "should have at least one chunk")
+}
+
+func TestHandlePut_SkipsCompressionForImages(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	// JPEG magic bytes + random data (incompressible)
+	content := make([]byte, 4*1024)
+	content[0] = 0xFF
+	content[1] = 0xD8
+	content[2] = 0xFF
+	content[3] = 0xE0
+	_, _ = rand.Read(content[4:])
+	putChunkedObject(t, f, "photo.jpg", content, "image/jpeg")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+
+	rows, err := f.db.Query(`
+		SELECT g.compressed_size, g.compression_algo
+		FROM tenant_chunk_refs r
+		JOIN global_content_index g ON g.plaintext_hash = r.plaintext_hash
+		WHERE r.tenant_id = $1 AND r.bucket_name = $2 AND r.object_key = $3`,
+		tenantUUID, "test-bucket", "photo.jpg")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var compressedSize *int64
+		var algo *string
+		require.NoError(t, rows.Scan(&compressedSize, &algo))
+		assert.Nil(t, compressedSize, "compressed_size should be NULL for image content")
+		assert.Nil(t, algo, "compression_algo should be NULL for image content")
+	}
+	require.NoError(t, rows.Err())
+}
+
+func TestHandleGet_DecompressesCompressedChunks(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := []byte(strings.Repeat("Compression test payload for decompression verification. ", 200))
+	putChunkedObject(t, f, "compressed-get.txt", content, "text/plain")
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/compressed-get.txt", nil)
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "compressed-get.txt")
+
+	require.Equal(t, http.StatusOK, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content, body, "decompressed body must match original plaintext")
+}
+
+func TestHandleGet_RangeOnCompressedChunks(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	content := []byte(strings.Repeat("Range request on compressed data works correctly. ", 200))
+	putChunkedObject(t, f, "compressed-range.txt", content, "text/plain")
+
+	getReq := httptest.NewRequest("GET", "/test-bucket/compressed-range.txt", nil)
+	getReq.Header.Set("Range", "bytes=50-149")
+	getReq = getReq.WithContext(tenant.WithTenant(getReq.Context(), f.tenant))
+	gw := httptest.NewRecorder()
+	f.adapter.HandleGet(gw, getReq, "test-bucket", "compressed-range.txt")
+
+	require.Equal(t, http.StatusPartialContent, gw.Code)
+	body, _ := io.ReadAll(gw.Body)
+	assert.Equal(t, content[50:150], body, "range slice must match original plaintext range")
+	assert.Equal(t, "100", gw.Header().Get("Content-Length"))
+}
+
+func TestHandlePut_CompressionExpansionSkipped(t *testing.T) {
+	f := setupChunkingFixture(t)
+
+	// Purely random data — compression would expand it
+	content := generateTestData(4 * 1024)
+	putChunkedObject(t, f, "random.bin", content, "application/octet-stream")
+
+	tenantUUID, err := uuid.Parse(f.tenantID)
+	require.NoError(t, err)
+
+	rows, err := f.db.Query(`
+		SELECT g.compressed_size, g.compression_algo, g.size_bytes
+		FROM tenant_chunk_refs r
+		JOIN global_content_index g ON g.plaintext_hash = r.plaintext_hash
+		WHERE r.tenant_id = $1 AND r.bucket_name = $2 AND r.object_key = $3`,
+		tenantUUID, "test-bucket", "random.bin")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var compressedSize *int64
+		var algo *string
+		var sizeBytes int64
+		require.NoError(t, rows.Scan(&compressedSize, &algo, &sizeBytes))
+		// Random data should NOT be compressed (expansion skipped)
+		assert.Nil(t, compressedSize, "compressed_size should be NULL for incompressible data")
+		assert.Nil(t, algo, "compression_algo should be NULL for incompressible data")
+	}
+	require.NoError(t, rows.Err())
+}

--- a/internal/api/s3_engine_adapter.go
+++ b/internal/api/s3_engine_adapter.go
@@ -847,6 +847,11 @@ func (a *S3ToEngine) handleChunkedPut(
 	var chunkCount int
 	backendName := "chunked"
 
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
 	newRefs := make([]crypto.TenantChunkRef, 0, 16)
 	for result := range chunkCh {
 		if result.Err != nil {
@@ -865,8 +870,24 @@ func (a *S3ToEngine) handleChunkedPut(
 		storageKey := "_chunks/" + chunk.Hash
 
 		if lookup.IsNewChunk {
-			chunkOpts := []engine.PutOption{engine.WithContentLength(int64(chunk.Size))}
-			bn, putErr := a.engine.Put(ctx, chunkContainer, storageKey, bytes.NewReader(chunk.Data), chunkOpts...)
+			storeData := chunk.Data
+			var compressedSize *int64
+			var compressionAlgo *string
+
+			if crypto.ShouldCompress(chunk.Data, contentType) {
+				compressed, compErr := crypto.CompressBuffer(chunk.Data)
+				if compErr == nil && len(compressed) < chunk.Size {
+					storeData = compressed
+					cs := int64(len(compressed))
+					compressedSize = &cs
+					algo := "zstd"
+					compressionAlgo = &algo
+				}
+			}
+
+			storedBytes := int64(len(storeData))
+			chunkOpts := []engine.PutOption{engine.WithContentLength(storedBytes)}
+			bn, putErr := a.engine.Put(ctx, chunkContainer, storageKey, bytes.NewReader(storeData), chunkOpts...)
 			if putErr != nil {
 				return fmt.Errorf("store chunk %s: %w", chunk.Hash[:16], putErr)
 			}
@@ -875,15 +896,17 @@ func (a *S3ToEngine) handleChunkedPut(
 			}
 
 			if insertErr := a.gci.InsertChunk(ctx, &crypto.GCIEntry{
-				PlaintextHash: chunk.Hash,
-				BackendID:     bn,
-				StorageKey:    storageKey,
-				SizeBytes:     int64(chunk.Size),
-				RefCount:      1,
+				PlaintextHash:   chunk.Hash,
+				BackendID:       bn,
+				StorageKey:      storageKey,
+				SizeBytes:       int64(chunk.Size),
+				CompressedSize:  compressedSize,
+				CompressionAlgo: compressionAlgo,
+				RefCount:        1,
 			}); insertErr != nil {
 				return fmt.Errorf("insert chunk index %s: %w", chunk.Hash[:16], insertErr)
 			}
-			physicalSize += int64(chunk.Size)
+			physicalSize += storedBytes
 		} else {
 			if incErr := a.gci.IncrementRef(ctx, chunk.Hash); incErr != nil {
 				return fmt.Errorf("increment ref %s: %w", chunk.Hash[:16], incErr)
@@ -907,11 +930,6 @@ func (a *S3ToEngine) handleChunkedPut(
 	dedupRatio := float32(1.0)
 	if physicalSize > 0 {
 		dedupRatio = float32(measuredSize) / float32(physicalSize)
-	}
-
-	contentType := r.Header.Get("Content-Type")
-	if contentType == "" {
-		contentType = "application/octet-stream"
 	}
 
 	// Atomically install the new manifest and release any previous version's
@@ -1016,7 +1034,8 @@ type chunkDesc struct {
 	backendID     string
 	plaintextHash string
 	offset        int64 // byte offset of this chunk within the object
-	size          int64 // chunk size in bytes
+	size          int64 // chunk size in bytes (plaintext)
+	compressed    bool  // true if chunk is stored compressed (needs decompression on read)
 }
 
 // fetchAndVerifyChunk reads one chunk from the global container into a bounded
@@ -1042,6 +1061,13 @@ func (a *S3ToEngine) fetchAndVerifyChunk(ctx context.Context, d chunkDesc) ([]by
 	data, err := io.ReadAll(rdr)
 	if err != nil {
 		return nil, fmt.Errorf("read chunk %s: %w", d.plaintextHash[:16], err)
+	}
+
+	if d.compressed {
+		data, err = crypto.DecompressBuffer(data)
+		if err != nil {
+			return nil, fmt.Errorf("decompress chunk %s: %w", d.plaintextHash[:16], err)
+		}
 	}
 
 	sum := sha256.Sum256(data)
@@ -1119,6 +1145,7 @@ func (a *S3ToEngine) handleChunkedGet(
 			plaintextHash: ref.PlaintextHash,
 			offset:        ref.ChunkOffset,
 			size:          lookup.Entry.SizeBytes,
+			compressed:    lookup.Entry.CompressionAlgo != nil,
 		}
 	}
 

--- a/internal/crypto/gci.go
+++ b/internal/crypto/gci.go
@@ -629,6 +629,50 @@ func (g *GlobalContentIndex) GetGlobalDedupStats(ctx context.Context) (*DedupSta
 	return &stats, nil
 }
 
+// CompressionStatsResult holds global compression statistics from the GCI.
+type CompressionStatsResult struct {
+	ChunksCompressed   int64   `json:"chunks_compressed"`
+	ChunksUncompressed int64   `json:"chunks_uncompressed"`
+	TotalPlaintext     int64   `json:"total_plaintext"`
+	TotalStored        int64   `json:"total_stored"`
+	BytesSaved         int64   `json:"bytes_saved"`
+	CompressionRatio   float64 `json:"compression_ratio"`
+}
+
+// GetGlobalCompressionStats retrieves compression statistics across all chunks.
+func (g *GlobalContentIndex) GetGlobalCompressionStats(ctx context.Context) (*CompressionStatsResult, error) {
+	var stats CompressionStatsResult
+
+	err := g.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE compression_algo IS NOT NULL) as chunks_compressed,
+			COUNT(*) FILTER (WHERE compression_algo IS NULL) as chunks_uncompressed,
+			COALESCE(SUM(size_bytes), 0) as total_plaintext,
+			COALESCE(SUM(CASE WHEN compressed_size IS NOT NULL
+				THEN compressed_size ELSE size_bytes END), 0) as total_stored,
+			COALESCE(SUM(size_bytes) - SUM(CASE WHEN compressed_size IS NOT NULL
+				THEN compressed_size ELSE size_bytes END), 0) as bytes_saved
+		FROM global_content_index
+	`).Scan(
+		&stats.ChunksCompressed,
+		&stats.ChunksUncompressed,
+		&stats.TotalPlaintext,
+		&stats.TotalStored,
+		&stats.BytesSaved,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get compression stats: %w", err)
+	}
+
+	if stats.TotalStored > 0 {
+		stats.CompressionRatio = float64(stats.TotalPlaintext) / float64(stats.TotalStored)
+	} else {
+		stats.CompressionRatio = 1.0
+	}
+
+	return &stats, nil
+}
+
 // Cache methods
 
 func (c *gciCache) get(hash string) *GCIEntry {

--- a/internal/dashboard/handlers/admin_dedup.go
+++ b/internal/dashboard/handlers/admin_dedup.go
@@ -40,6 +40,10 @@ func HandleAdminDedup(tmpl *template.Template, db *sql.DB, logger *zap.Logger) h
 		data["PhysicalBytes"] = "0 B"
 		data["ChunksProcessed"] = int64(0)
 		data["TenantTable"] = []tenantDedupRow{}
+		data["CompressionRatio"] = "1.0x"
+		data["CompressionSaved"] = "0 B"
+		data["ChunksCompressed"] = int64(0)
+		data["ChunksUncompressed"] = int64(0)
 
 		if db != nil {
 			populateDedupStats(r.Context(), db, data, logger)
@@ -67,6 +71,16 @@ func populateDedupStats(ctx context.Context, db *sql.DB, data map[string]any, lo
 	data["LogicalBytes"] = formatBytes(stats.BytesLogical)
 	data["PhysicalBytes"] = formatBytes(stats.BytesPhysical)
 	data["ChunksProcessed"] = stats.ChunksProcessed
+
+	cstats, cerr := gci.GetGlobalCompressionStats(ctx)
+	if cerr != nil {
+		logger.Debug("dedup: compression stats", zap.Error(cerr))
+	} else {
+		data["CompressionRatio"] = fmt.Sprintf("%.1fx", cstats.CompressionRatio)
+		data["CompressionSaved"] = formatBytes(cstats.BytesSaved)
+		data["ChunksCompressed"] = cstats.ChunksCompressed
+		data["ChunksUncompressed"] = cstats.ChunksUncompressed
+	}
 
 	populateTenantDedup(ctx, db, gci, data, logger)
 }

--- a/internal/dashboard/handlers/admin_dedup_test.go
+++ b/internal/dashboard/handlers/admin_dedup_test.go
@@ -24,6 +24,10 @@ func testDedupTemplate(t *testing.T) *template.Template {
 			`<span class="logical">{{.LogicalBytes}}</span>` +
 			`<span class="physical">{{.PhysicalBytes}}</span>` +
 			`<span class="chunks">{{.ChunksProcessed}}</span>` +
+			`<span class="comp-ratio">{{.CompressionRatio}}</span>` +
+			`<span class="comp-saved">{{.CompressionSaved}}</span>` +
+			`<span class="comp-chunks">{{.ChunksCompressed}}</span>` +
+			`<span class="comp-skipped">{{.ChunksUncompressed}}</span>` +
 			`{{range .TenantTable}}<span class="tenant">{{.Email}} {{.LogicalFmt}} {{.PhysicalFmt}} {{.SavedFmt}} {{.SavedPct}} {{.DedupRatio}}</span>{{end}}` +
 			`{{if not .TenantTable}}<p>No tenants</p>{{end}}` +
 			`{{end}}`))
@@ -39,6 +43,11 @@ func TestHandleAdminDedup_RendersGlobalStats(t *testing.T) {
 	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
 		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
 			AddRow(int64(100), int64(1024*1024*1024), int64(512*1024*1024)))
+
+	// Compression stats query
+	mock.ExpectQuery(`COUNT\(\*\) FILTER \(WHERE compression_algo IS NOT NULL\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"chunks_compressed", "chunks_uncompressed", "total_plaintext", "total_stored", "bytes_saved"}).
+			AddRow(int64(60), int64(40), int64(1024*1024*1024), int64(800*1024*1024), int64(224*1024*1024)))
 
 	// Per-tenant query: no tenants with chunks
 	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
@@ -68,6 +77,11 @@ func TestHandleAdminDedup_PerTenantTable(t *testing.T) {
 	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
 		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
 			AddRow(int64(200), int64(2*1024*1024*1024), int64(1024*1024*1024)))
+
+	// Compression stats query
+	mock.ExpectQuery(`COUNT\(\*\) FILTER \(WHERE compression_algo IS NOT NULL\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"chunks_compressed", "chunks_uncompressed", "total_plaintext", "total_stored", "bytes_saved"}).
+			AddRow(int64(0), int64(200), int64(2*1024*1024*1024), int64(2*1024*1024*1024), int64(0)))
 
 	// Tenants with chunked objects
 	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
@@ -109,6 +123,11 @@ func TestHandleAdminDedup_EmptyNoChunks(t *testing.T) {
 	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
 		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
 			AddRow(int64(0), int64(0), int64(0)))
+
+	// Compression stats: empty
+	mock.ExpectQuery(`COUNT\(\*\) FILTER \(WHERE compression_algo IS NOT NULL\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"chunks_compressed", "chunks_uncompressed", "total_plaintext", "total_stored", "bytes_saved"}).
+			AddRow(int64(0), int64(0), int64(0), int64(0), int64(0)))
 
 	// No tenants
 	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
@@ -172,4 +191,39 @@ func TestHandleAdminDedup_DBErrorDegrades(t *testing.T) {
 	body := w.Body.String()
 	assert.Contains(t, body, `<span class="ratio">1.0x</span>`)
 	assert.Contains(t, body, `<span class="saved">0 B</span>`)
+}
+
+func TestHandleAdminDedup_CompressionStats(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Global dedup stats
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) as total_chunks`).
+		WillReturnRows(sqlmock.NewRows([]string{"total_chunks", "total_bytes", "bytes_saved"}).
+			AddRow(int64(50), int64(500*1024*1024), int64(0)))
+
+	// Compression stats: 30 compressed, 20 uncompressed, good ratio
+	mock.ExpectQuery(`COUNT\(\*\) FILTER \(WHERE compression_algo IS NOT NULL\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"chunks_compressed", "chunks_uncompressed", "total_plaintext", "total_stored", "bytes_saved"}).
+			AddRow(int64(30), int64(20), int64(500*1024*1024), int64(300*1024*1024), int64(200*1024*1024)))
+
+	// No tenants
+	mock.ExpectQuery(`SELECT DISTINCT t.id, t.email`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}))
+
+	handler := HandleAdminDedup(testDedupTemplate(t), db, zap.NewNop())
+	req := httptest.NewRequest("GET", "/admin/dedup", nil)
+	req = req.WithContext(adminCtx(t))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 500 MB / 300 MB = 1.67x
+	assert.Contains(t, body, `<span class="comp-ratio">1.7x</span>`)
+	assert.Contains(t, body, `<span class="comp-saved">200 MB</span>`)
+	assert.Contains(t, body, `<span class="comp-chunks">30</span>`)
+	assert.Contains(t, body, `<span class="comp-skipped">20</span>`)
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/dashboard/templates/admin/dedup.html
+++ b/internal/dashboard/templates/admin/dedup.html
@@ -32,6 +32,30 @@
     </div>
 </div>
 
+<div class="dashboard-header" style="margin-top:2rem">
+    <h2>Compression</h2>
+</div>
+<p class="text-muted" style="margin-bottom:1.5rem">Zstd lossless compression applied to compressible chunks before storage.</p>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="card-title">Compression Ratio</div>
+        <div class="card-value">{{.CompressionRatio}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Bytes Saved</div>
+        <div class="card-value">{{.CompressionSaved}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Chunks Compressed</div>
+        <div class="card-value">{{.ChunksCompressed}}</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Chunks Skipped</div>
+        <div class="card-value">{{.ChunksUncompressed}}</div>
+    </div>
+</div>
+
 <div class="card">
     <div class="card-title" style="margin-bottom:0.75rem">Per-Tenant Deduplication</div>
     {{if .TenantTable}}


### PR DESCRIPTION
## Summary

- Wire existing zstd compression into the live chunked PUT/GET S3 path — compressible chunks are stored smaller, decompressed transparently on read
- PUT path: `ShouldCompress` checks content type + magic bytes, `CompressBuffer` compresses, skips if expansion would occur; `SizeBytes` stays plaintext (range math depends on it), `CompressedSize`/`CompressionAlgo` track stored state
- GET path: `fetchAndVerifyChunk` decompresses before SHA-256 integrity verification against plaintext hash
- Dashboard: add Compression section to admin dedup page (ratio, bytes saved, chunks compressed/skipped)
- GCI: add `GetGlobalCompressionStats` query (uses existing `compressed_size`/`compression_algo` columns from migration 051)

No new migration needed. Existing uncompressed chunks continue working unchanged (`CompressionAlgo=NULL` → no decompression).

## Test plan

- [ ] `TestHandlePut_CompressesTextChunks` — text data gets compressed, GCI entries have `compressed_size < size_bytes`
- [ ] `TestHandlePut_SkipsCompressionForImages` — JPEG magic bytes → no compression applied
- [ ] `TestHandleGet_DecompressesCompressedChunks` — round-trip: upload text, GET back, verify content matches
- [ ] `TestHandleGet_RangeOnCompressedChunks` — range GET on compressed object returns correct byte slice
- [ ] `TestHandlePut_CompressionExpansionSkipped` — random data stored uncompressed (expansion guard)
- [ ] `TestHandleAdminDedup_CompressionStats` — mock DB, verify compression template data populated
- [ ] Existing dedup dashboard tests updated with compression query expectations
- [ ] `golangci-lint` clean, `go vet` clean, `go build` clean